### PR TITLE
fix: resolve corsa-oxlint wrapper node type lookup

### DIFF
--- a/scripts/bench_bindings.ts
+++ b/scripts/bench_bindings.ts
@@ -49,12 +49,7 @@ function main(): void {
 
   run("cargo", ["build", "-p", "corsa_ffi"], { cwd: workspaceRoot });
 
-  const targets = [
-    buildCTarget(),
-    buildCppTarget(),
-    buildGoTarget(),
-    buildSwiftTarget(),
-  ];
+  const targets = [buildCTarget(), buildCppTarget(), buildGoTarget(), buildSwiftTarget()];
 
   const rows: BenchRow[] = [];
   for (const target of targets) {
@@ -163,7 +158,10 @@ function buildSwiftTarget(): BuiltTarget {
   }).trim();
   return {
     language: "swift",
-    executable: join(binPath, process.platform === "win32" ? "CorsaUtilsBench.exe" : "CorsaUtilsBench"),
+    executable: join(
+      binPath,
+      process.platform === "win32" ? "CorsaUtilsBench.exe" : "CorsaUtilsBench",
+    ),
   };
 }
 

--- a/src/bindings/c/corsa_ffi/include/corsa_utils.h
+++ b/src/bindings/c/corsa_ffi/include/corsa_utils.h
@@ -129,6 +129,20 @@ CorsaString corsa_tsgo_api_client_get_string_type_json(
     CorsaStrRef snapshot,
     CorsaStrRef project
 );
+CorsaString corsa_tsgo_api_client_get_type_at_position_json(
+    const CorsaTsgoApiClient *value,
+    CorsaStrRef snapshot,
+    CorsaStrRef project,
+    CorsaStrRef file,
+    uint32_t position
+);
+CorsaString corsa_tsgo_api_client_get_symbol_at_position_json(
+    const CorsaTsgoApiClient *value,
+    CorsaStrRef snapshot,
+    CorsaStrRef project,
+    CorsaStrRef file,
+    uint32_t position
+);
 CorsaString corsa_tsgo_api_client_type_to_string(
     const CorsaTsgoApiClient *value,
     CorsaStrRef snapshot,

--- a/src/bindings/c/corsa_ffi/src/api_client.rs
+++ b/src/bindings/c/corsa_ffi/src/api_client.rs
@@ -339,6 +339,74 @@ pub unsafe extern "C" fn corsa_tsgo_api_client_get_string_type_json(
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn corsa_tsgo_api_client_get_type_at_position_json(
+    value: *const CorsaTsgoApiClient,
+    snapshot: CorsaStrRef,
+    project: CorsaStrRef,
+    file: CorsaStrRef,
+    position: u32,
+) -> CorsaString {
+    let Some(client) = (unsafe { client_ref(value) }) else {
+        return CorsaString::default();
+    };
+    let Some(snapshot) = read_required_text(snapshot, "snapshot") else {
+        return CorsaString::default();
+    };
+    let Some(project) = read_required_text(project, "project") else {
+        return CorsaString::default();
+    };
+    let Some(file) = read_required_text(file, "file") else {
+        return CorsaString::default();
+    };
+    match block_on(client.inner.get_type_at_position(
+        SnapshotHandle::from(snapshot.as_str()),
+        ProjectHandle::from(project.as_str()),
+        file,
+        position,
+    )) {
+        Ok(response) => take_json(&response),
+        Err(error) => {
+            set_last_error(error);
+            CorsaString::default()
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn corsa_tsgo_api_client_get_symbol_at_position_json(
+    value: *const CorsaTsgoApiClient,
+    snapshot: CorsaStrRef,
+    project: CorsaStrRef,
+    file: CorsaStrRef,
+    position: u32,
+) -> CorsaString {
+    let Some(client) = (unsafe { client_ref(value) }) else {
+        return CorsaString::default();
+    };
+    let Some(snapshot) = read_required_text(snapshot, "snapshot") else {
+        return CorsaString::default();
+    };
+    let Some(project) = read_required_text(project, "project") else {
+        return CorsaString::default();
+    };
+    let Some(file) = read_required_text(file, "file") else {
+        return CorsaString::default();
+    };
+    match block_on(client.inner.get_symbol_at_position(
+        SnapshotHandle::from(snapshot.as_str()),
+        ProjectHandle::from(project.as_str()),
+        file,
+        position,
+    )) {
+        Ok(response) => take_json(&response),
+        Err(error) => {
+            set_last_error(error);
+            CorsaString::default()
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn corsa_tsgo_api_client_type_to_string(
     value: *const CorsaTsgoApiClient,
     snapshot: CorsaStrRef,

--- a/src/bindings/c/corsa_ffi/src/tests.rs
+++ b/src/bindings/c/corsa_ffi/src/tests.rs
@@ -1,7 +1,14 @@
+use std::path::PathBuf;
+
 use crate::{
-    api_client::corsa_tsgo_api_client_spawn,
+    api_client::{
+        corsa_tsgo_api_client_close, corsa_tsgo_api_client_free,
+        corsa_tsgo_api_client_get_symbol_at_position_json,
+        corsa_tsgo_api_client_get_type_at_position_json, corsa_tsgo_api_client_spawn,
+        corsa_tsgo_api_client_update_snapshot_json,
+    },
     error::corsa_error_message_take,
-    types::{CorsaStrRef, corsa_utils_string_free, corsa_utils_string_list_free},
+    types::{CorsaStrRef, CorsaString, corsa_utils_string_free, corsa_utils_string_list_free},
     utils::{
         corsa_utils_classify_type_text, corsa_utils_has_unsafe_any_flow,
         corsa_utils_is_error_like_type_texts, corsa_utils_split_type_text,
@@ -19,20 +26,45 @@ fn text_ref(text: &str) -> CorsaStrRef {
     }
 }
 
-#[test]
-fn classifies_type_texts_over_ffi() {
-    let result = unsafe { corsa_utils_classify_type_text(text_ref("Promise<string> | null")) };
+fn take_string(value: CorsaString) -> String {
+    if value.ptr.is_null() {
+        return String::new();
+    }
     let text = unsafe {
         std::str::from_utf8(std::slice::from_raw_parts(
-            result.ptr.cast::<u8>(),
-            result.len,
+            value.ptr.cast::<u8>(),
+            value.len,
         ))
         .unwrap()
         .to_owned()
     };
     unsafe {
-        corsa_utils_string_free(result);
+        corsa_utils_string_free(value);
     }
+    text
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(4)
+        .unwrap()
+        .to_owned()
+}
+
+fn mock_tsgo_binary() -> Option<PathBuf> {
+    let binary = workspace_root().join(if cfg!(windows) {
+        "target/debug/mock_tsgo.exe"
+    } else {
+        "target/debug/mock_tsgo"
+    });
+    binary.exists().then_some(binary)
+}
+
+#[test]
+fn classifies_type_texts_over_ffi() {
+    let result = unsafe { corsa_utils_classify_type_text(text_ref("Promise<string> | null")) };
+    let text = take_string(result);
     assert_eq!(text, "nullish");
 }
 
@@ -152,4 +184,62 @@ fn reports_api_client_spawn_errors() {
         corsa_utils_string_free(error);
     }
     assert!(!message.is_empty());
+}
+
+#[test]
+fn resolves_checker_positions_over_ffi() {
+    let Some(binary) = mock_tsgo_binary() else {
+        return;
+    };
+    let options = serde_json::json!({
+        "executable": binary.display().to_string(),
+        "cwd": workspace_root().display().to_string(),
+        "mode": "jsonrpc",
+    })
+    .to_string();
+    let client = unsafe { corsa_tsgo_api_client_spawn(text_ref(&options)) };
+    assert!(!client.is_null());
+
+    let snapshot_json = take_string(unsafe {
+        corsa_tsgo_api_client_update_snapshot_json(
+            client,
+            text_ref(r#"{"openProject":"/workspace/tsconfig.json"}"#),
+        )
+    });
+    let snapshot: serde_json::Value = serde_json::from_str(&snapshot_json).unwrap();
+    let snapshot_id = snapshot["snapshot"].as_str().unwrap();
+    let project_id = snapshot["projects"][0]["id"].as_str().unwrap();
+
+    let type_json = take_string(unsafe {
+        corsa_tsgo_api_client_get_type_at_position_json(
+            client,
+            text_ref(snapshot_id),
+            text_ref(project_id),
+            text_ref("/workspace/src/index.ts"),
+            1,
+        )
+    });
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&type_json).unwrap()["id"],
+        "t0000000000000001"
+    );
+
+    let symbol_json = take_string(unsafe {
+        corsa_tsgo_api_client_get_symbol_at_position_json(
+            client,
+            text_ref(snapshot_id),
+            text_ref(project_id),
+            text_ref("/workspace/src/index.ts"),
+            1,
+        )
+    });
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&symbol_json).unwrap()["name"],
+        "value"
+    );
+
+    assert!(unsafe { corsa_tsgo_api_client_close(client) });
+    unsafe {
+        corsa_tsgo_api_client_free(client);
+    }
 }

--- a/src/bindings/cpp/corsa_tsgo_api.hpp
+++ b/src/bindings/cpp/corsa_tsgo_api.hpp
@@ -69,6 +69,32 @@ class tsgo_api_client {
         handle_, utils::to_ref(snapshot), utils::to_ref(project)));
   }
 
+  std::string get_type_at_position_json(
+      std::string_view snapshot,
+      std::string_view project,
+      std::string_view file,
+      std::uint32_t position) const {
+    return utils::take_string(corsa_tsgo_api_client_get_type_at_position_json(
+        handle_,
+        utils::to_ref(snapshot),
+        utils::to_ref(project),
+        utils::to_ref(file),
+        position));
+  }
+
+  std::string get_symbol_at_position_json(
+      std::string_view snapshot,
+      std::string_view project,
+      std::string_view file,
+      std::uint32_t position) const {
+    return utils::take_string(corsa_tsgo_api_client_get_symbol_at_position_json(
+        handle_,
+        utils::to_ref(snapshot),
+        utils::to_ref(project),
+        utils::to_ref(file),
+        position));
+  }
+
   std::string type_to_string(
       std::string_view snapshot,
       std::string_view project,

--- a/src/bindings/go/corsa_utils/api_client.go
+++ b/src/bindings/go/corsa_utils/api_client.go
@@ -108,6 +108,38 @@ func (value *ApiClient) GetStringTypeJSON(snapshot string, project string) (stri
 	return takeCheckedString(C.corsa_tsgo_api_client_get_string_type_json(value.ptr, snapshotValue.ref, projectValue.ref))
 }
 
+func (value *ApiClient) GetTypeAtPositionJSON(snapshot string, project string, file string, position uint32) (string, error) {
+	snapshotValue := newBorrowedString(snapshot)
+	defer snapshotValue.free()
+	projectValue := newBorrowedString(project)
+	defer projectValue.free()
+	fileValue := newBorrowedString(file)
+	defer fileValue.free()
+	return takeCheckedString(C.corsa_tsgo_api_client_get_type_at_position_json(
+		value.ptr,
+		snapshotValue.ref,
+		projectValue.ref,
+		fileValue.ref,
+		C.uint32_t(position),
+	))
+}
+
+func (value *ApiClient) GetSymbolAtPositionJSON(snapshot string, project string, file string, position uint32) (string, error) {
+	snapshotValue := newBorrowedString(snapshot)
+	defer snapshotValue.free()
+	projectValue := newBorrowedString(project)
+	defer projectValue.free()
+	fileValue := newBorrowedString(file)
+	defer fileValue.free()
+	return takeCheckedString(C.corsa_tsgo_api_client_get_symbol_at_position_json(
+		value.ptr,
+		snapshotValue.ref,
+		projectValue.ref,
+		fileValue.ref,
+		C.uint32_t(position),
+	))
+}
+
 func (value *ApiClient) TypeToString(snapshot string, project string, typeHandle string, location *string, flags *int32) (string, error) {
 	snapshotValue := newBorrowedString(snapshot)
 	defer snapshotValue.free()

--- a/src/bindings/go/corsa_utils/corsa_utils_test.go
+++ b/src/bindings/go/corsa_utils/corsa_utils_test.go
@@ -1,6 +1,11 @@
 package corsautils
 
-import "testing"
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestUtilsBindings(t *testing.T) {
 	if got := ClassifyTypeText("Promise<string> | null"); got != "nullish" {
@@ -32,5 +37,68 @@ func TestVirtualDocumentBindings(t *testing.T) {
 	}
 	if got := document.Version(); got != 2 {
 		t.Fatalf("version = %d", got)
+	}
+}
+
+func TestApiClientCheckerPositionBindings(t *testing.T) {
+	root, err := filepath.Abs("../../../..")
+	if err != nil {
+		t.Fatalf("workspace root: %v", err)
+	}
+	binary := filepath.Join(root, "target", "debug", "mock_tsgo")
+	if _, err := os.Stat(binary); err != nil {
+		t.Skip("mock_tsgo binary is not built")
+	}
+	client, err := NewApiClient(ApiClientOptions{
+		Executable: binary,
+		Cwd:        root,
+		Mode:       ApiModeJSONRPC,
+	})
+	if err != nil {
+		t.Fatalf("new api client: %v", err)
+	}
+	defer client.Close()
+
+	snapshotJSON, err := client.UpdateSnapshotJSON(`{"openProject":"/workspace/tsconfig.json"}`)
+	if err != nil {
+		t.Fatalf("update snapshot: %v", err)
+	}
+	var snapshot struct {
+		Snapshot string `json:"snapshot"`
+		Projects []struct {
+			ID string `json:"id"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal([]byte(snapshotJSON), &snapshot); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	project := snapshot.Projects[0].ID
+
+	typeJSON, err := client.GetTypeAtPositionJSON(snapshot.Snapshot, project, "/workspace/src/index.ts", 1)
+	if err != nil {
+		t.Fatalf("get type at position: %v", err)
+	}
+	var typ struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(typeJSON), &typ); err != nil {
+		t.Fatalf("decode type: %v", err)
+	}
+	if typ.ID != "t0000000000000001" {
+		t.Fatalf("type id = %q", typ.ID)
+	}
+
+	symbolJSON, err := client.GetSymbolAtPositionJSON(snapshot.Snapshot, project, "/workspace/src/index.ts", 1)
+	if err != nil {
+		t.Fatalf("get symbol at position: %v", err)
+	}
+	var symbol struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(symbolJSON), &symbol); err != nil {
+		t.Fatalf("decode symbol: %v", err)
+	}
+	if symbol.Name != "value" {
+		t.Fatalf("symbol name = %q", symbol.Name)
 	}
 }

--- a/src/bindings/nodejs/corsa_node/index.d.ts
+++ b/src/bindings/nodejs/corsa_node/index.d.ts
@@ -40,6 +40,10 @@ export declare class TsgoApiClient {
   getSourceFile(snapshot: string, project: string, file: string): Buffer | null
   /** Resolves the intrinsic string type for a project. */
   getStringTypeJson(snapshot: string, project: string): string
+  /** Resolves the checker type visible at a file position. */
+  getTypeAtPositionJson(snapshot: string, project: string, file: string, position: number): string
+  /** Resolves the checker symbol visible at a file position. */
+  getSymbolAtPositionJson(snapshot: string, project: string, file: string, position: number): string
   /** Renders a type back to a string representation. */
   typeToString(snapshot: string, project: string, typeHandle: string, location?: string | undefined | null, flags?: number | undefined | null): string
   /** Sends an arbitrary JSON endpoint request. */

--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -108,6 +108,44 @@ impl TsgoApiClient {
         to_json(&response)
     }
 
+    /// Resolves the checker type visible at a file position.
+    #[napi]
+    pub fn get_type_at_position_json(
+        &self,
+        snapshot: String,
+        project: String,
+        file: String,
+        position: u32,
+    ) -> Result<String> {
+        let response = block_on(self.inner.get_type_at_position(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            file,
+            position,
+        ))
+        .map_err(into_napi_error)?;
+        to_json(&response)
+    }
+
+    /// Resolves the checker symbol visible at a file position.
+    #[napi]
+    pub fn get_symbol_at_position_json(
+        &self,
+        snapshot: String,
+        project: String,
+        file: String,
+        position: u32,
+    ) -> Result<String> {
+        let response = block_on(self.inner.get_symbol_at_position(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            file,
+            position,
+        ))
+        .map_err(into_napi_error)?;
+        to_json(&response)
+    }
+
     /// Renders a type back to a string representation.
     #[napi]
     pub fn type_to_string(

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -108,6 +108,13 @@ describe("CorsaApiClient", () => {
 
       const stringType = client.getStringType(snapshot.snapshot, project.id);
       expect(stringType.id).toBe("t0000000000000010");
+      expect(
+        client.getTypeAtPosition(snapshot.snapshot, project.id, "/workspace/src/index.ts", 1)?.id,
+      ).toBe("t0000000000000001");
+      expect(
+        client.getSymbolAtPosition(snapshot.snapshot, project.id, "/workspace/src/index.ts", 1)
+          ?.name,
+      ).toBe("value");
       expect(client.typeToString(snapshot.snapshot, project.id, stringType.id)).toBe("type:string");
 
       client.releaseHandle(snapshot.snapshot);

--- a/src/bindings/nodejs/corsa_node/ts/index.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.ts
@@ -4,6 +4,7 @@ import type {
   ApiClientOptions,
   ConfigResponse,
   InitializeResponse,
+  SymbolResponse,
   TypeTextKind,
   TypeResponse,
   UnsafeTypeFlowInput,
@@ -130,6 +131,32 @@ export class CorsaApiClient {
 
   getStringType(snapshot: string, project: string): TypeResponse {
     return fromJson(this.#inner.getStringTypeJson(snapshot, project));
+  }
+
+  getTypeAtPosition(
+    snapshot: string,
+    project: string,
+    file: string,
+    position: number,
+  ): TypeResponse | undefined {
+    return (
+      fromJson<TypeResponse | null>(
+        this.#inner.getTypeAtPositionJson(snapshot, project, file, position),
+      ) ?? undefined
+    );
+  }
+
+  getSymbolAtPosition(
+    snapshot: string,
+    project: string,
+    file: string,
+    position: number,
+  ): SymbolResponse | undefined {
+    return (
+      fromJson<SymbolResponse | null>(
+        this.#inner.getSymbolAtPositionJson(snapshot, project, file, position),
+      ) ?? undefined
+    );
   }
 
   typeToString(

--- a/src/bindings/nodejs/corsa_node/ts/types.ts
+++ b/src/bindings/nodejs/corsa_node/ts/types.ts
@@ -62,6 +62,15 @@ export interface TypeResponse {
   texts: string[];
 }
 
+export interface SymbolResponse {
+  id: string;
+  name: string;
+  flags: number;
+  checkFlags: number;
+  declarations: string[];
+  valueDeclaration?: string;
+}
+
 export interface OverlayUpdate {
   document: DocumentIdentifier;
   text: string;

--- a/src/bindings/nodejs/typescript_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/checker.ts
@@ -39,18 +39,20 @@ export function createProgram(
 export function createTypeChecker(context: ContextWithParserOptions): TsgoTypeCheckerShape {
   return {
     getTypeAtLocation(node) {
+      const lookupNode = nodeForTypeLookup(node);
       return sessionForContext(context).session.getTypeAtPosition(
-        filenameFor(context, node),
-        toPosition(node),
+        filenameFor(context, lookupNode),
+        toPosition(lookupNode),
       );
     },
     getContextualType(node) {
       return this.getTypeAtLocation(node);
     },
     getSymbolAtLocation(node) {
+      const lookupNode = nodeForTypeLookup(node);
       return sessionForContext(context).session.getSymbolAtPosition(
-        filenameFor(context, node),
-        toPosition(node),
+        filenameFor(context, lookupNode),
+        toPosition(lookupNode),
       );
     },
     getTypeOfSymbol(symbol) {
@@ -88,6 +90,33 @@ export function createTypeChecker(context: ContextWithParserOptions): TsgoTypeCh
       return sessionForContext(context).session.getTypeArguments(type);
     },
   };
+}
+
+function nodeForTypeLookup(node: Node | TsgoNode): Node | TsgoNode {
+  if ("pos" in node) {
+    return node;
+  }
+  switch ((node as { readonly type?: string }).type) {
+    case "ClassDeclaration":
+    case "ClassExpression":
+      return childNode(node, "id") ?? node;
+    case "TSPropertySignature":
+      return childNode(node, "key") ?? node;
+    default:
+      return node;
+  }
+}
+
+function childNode(node: Node, key: string): Node | undefined {
+  const value = (node as unknown as Record<string, unknown>)[key];
+  if (isNode(value)) {
+    return value;
+  }
+  return undefined;
+}
+
+function isNode(value: unknown): value is Node {
+  return typeof value === "object" && value !== null && "type" in value && "range" in value;
 }
 
 function filenameFor(

--- a/src/bindings/nodejs/typescript_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/session.ts
@@ -48,12 +48,9 @@ export class TsgoProjectSession {
     if (!state.typeByPosition.has(position)) {
       state.typeByPosition.set(
         position,
-        this.client().callJson("getTypeAtPosition", {
-          snapshot: this.#snapshot,
-          project: state.projectId,
-          file: fileName,
-          position,
-        }),
+        this.client().getTypeAtPosition(this.#snapshot!, state.projectId, fileName, position) as
+          | TsgoType
+          | undefined,
       );
     }
     return state.typeByPosition.get(position);
@@ -64,12 +61,9 @@ export class TsgoProjectSession {
     if (!state.symbolByPosition.has(position)) {
       state.symbolByPosition.set(
         position,
-        this.client().callJson("getSymbolAtPosition", {
-          snapshot: this.#snapshot,
-          project: state.projectId,
-          file: fileName,
-          position,
-        }),
+        this.client().getSymbolAtPosition(this.#snapshot!, state.projectId, fileName, position) as
+          | TsgoSymbol
+          | undefined,
       );
     }
     return state.symbolByPosition.get(position);

--- a/src/bindings/nodejs/typescript_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/type_location.test.ts
@@ -1,0 +1,85 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { defaultTsgoExecutable } from "./context";
+import { OxlintUtils } from "./oxlint_utils";
+import { RuleTester } from "./rule_tester";
+
+const workspaceRoot = resolve(import.meta.dirname, "../../../../..");
+const realTsgoBinary = defaultTsgoExecutable(workspaceRoot);
+const integrationCase = existsSync(realTsgoBinary) ? it : it.skip;
+
+describe("corsa-oxlint type locations", () => {
+  integrationCase("resolves types from declaration wrapper nodes", () => {
+    const seen: Record<string, string | undefined> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "wrapper-node-types",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise wrapper node type lookup",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          TSPropertySignature(node: any) {
+            if (node.key?.name !== "label") {
+              return;
+            }
+            const fromNode = checker.getTypeAtLocation(node);
+            const fromKey = checker.getTypeAtLocation(node.key);
+            seen.propertyFromNode = fromNode ? checker.typeToString(fromNode) : undefined;
+            seen.propertyFromKey = fromKey ? checker.typeToString(fromKey) : undefined;
+          },
+          ClassDeclaration(node: any) {
+            if (node.id?.name !== "ChildClass") {
+              return;
+            }
+            const fromNode = checker.getTypeAtLocation(node);
+            const fromId = checker.getTypeAtLocation(node.id);
+            seen.classFromNode = fromNode ? checker.typeToString(fromNode) : undefined;
+            seen.classFromId = fromId ? checker.typeToString(fromId) : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("wrapper-node-types", rule as any, {
+      valid: [
+        {
+          code: ["interface Demo {", "  readonly label: string;", "}", "class ChildClass {}"].join(
+            "\n",
+          ),
+          settings: {
+            typescriptOxlint: {
+              parserOptions: {
+                tsgo: {
+                  executable: realTsgoBinary,
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.propertyFromNode).toBe("string");
+    expect(seen.propertyFromNode).toBe(seen.propertyFromKey);
+    expect(seen.classFromNode).toBeDefined();
+    expect(seen.classFromNode).not.toBe("any");
+    expect(seen.classFromNode).toBe(seen.classFromId);
+  });
+});

--- a/src/bindings/swift/CorsaUtils/Sources/CorsaUtils/CorsaTsgoApiClient.swift
+++ b/src/bindings/swift/CorsaUtils/Sources/CorsaUtils/CorsaTsgoApiClient.swift
@@ -64,6 +64,24 @@ private func getStringTypeTsgoApiClientNative(
     _ project: CorsaStrRef
 ) -> CorsaString
 
+@_silgen_name("corsa_tsgo_api_client_get_type_at_position_json")
+private func getTypeAtPositionTsgoApiClientNative(
+    _ value: UnsafeMutableRawPointer?,
+    _ snapshot: CorsaStrRef,
+    _ project: CorsaStrRef,
+    _ file: CorsaStrRef,
+    _ position: UInt32
+) -> CorsaString
+
+@_silgen_name("corsa_tsgo_api_client_get_symbol_at_position_json")
+private func getSymbolAtPositionTsgoApiClientNative(
+    _ value: UnsafeMutableRawPointer?,
+    _ snapshot: CorsaStrRef,
+    _ project: CorsaStrRef,
+    _ file: CorsaStrRef,
+    _ position: UInt32
+) -> CorsaString
+
 @_silgen_name("corsa_tsgo_api_client_type_to_string")
 private func typeToStringTsgoApiClientNative(
     _ value: UnsafeMutableRawPointer?,
@@ -158,6 +176,20 @@ public final class CorsaTsgoApiClient {
         let refs = BorrowedRefs([snapshot, project])
         return try refs.refs.withUnsafeBufferPointer {
             try takeCheckedString(getStringTypeTsgoApiClientNative(handle, $0[0], $0[1]))
+        }
+    }
+
+    public func getTypeAtPositionJSON(snapshot: String, project: String, file: String, position: UInt32) throws -> String {
+        let refs = BorrowedRefs([snapshot, project, file])
+        return try refs.refs.withUnsafeBufferPointer {
+            try takeCheckedString(getTypeAtPositionTsgoApiClientNative(handle, $0[0], $0[1], $0[2], position))
+        }
+    }
+
+    public func getSymbolAtPositionJSON(snapshot: String, project: String, file: String, position: UInt32) throws -> String {
+        let refs = BorrowedRefs([snapshot, project, file])
+        return try refs.refs.withUnsafeBufferPointer {
+            try takeCheckedString(getSymbolAtPositionTsgoApiClientNative(handle, $0[0], $0[1], $0[2], position))
         }
     }
 

--- a/src/bindings/swift/CorsaUtils/Tests/CorsaUtilsTests/CorsaUtilsTests.swift
+++ b/src/bindings/swift/CorsaUtils/Tests/CorsaUtilsTests/CorsaUtilsTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import CorsaUtils
 
@@ -10,4 +11,44 @@ import Testing
     try document.splice(startLine: 0, startCharacter: 14, endLine: 0, endCharacter: 15, text: "2")
     #expect(document.text == "const value = 2;")
     #expect(document.version == 2)
+}
+
+@Test func apiClientCheckerPositionBindings() async throws {
+    let root = URL(fileURLWithPath: "../../../..", relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)).standardizedFileURL
+    let binary = root.appending(path: "target/debug/mock_tsgo").path
+    guard FileManager.default.fileExists(atPath: binary) else {
+        return
+    }
+    let client = try CorsaTsgoApiClient(options: CorsaTsgoApiClientOptions(
+        executable: binary,
+        cwd: root.path,
+        mode: .jsonrpc
+    ))
+    defer {
+        try? client.close()
+    }
+
+    let snapshotJSON = try client.updateSnapshotJSON(paramsJSON: #"{"openProject":"/workspace/tsconfig.json"}"#)
+    let snapshot = try JSONSerialization.jsonObject(with: Data(snapshotJSON.utf8)) as! [String: Any]
+    let snapshotID = snapshot["snapshot"] as! String
+    let projects = snapshot["projects"] as! [[String: Any]]
+    let projectID = projects[0]["id"] as! String
+
+    let typeJSON = try client.getTypeAtPositionJSON(
+        snapshot: snapshotID,
+        project: projectID,
+        file: "/workspace/src/index.ts",
+        position: 1
+    )
+    let type = try JSONSerialization.jsonObject(with: Data(typeJSON.utf8)) as! [String: Any]
+    #expect(type["id"] as? String == "t0000000000000001")
+
+    let symbolJSON = try client.getSymbolAtPositionJSON(
+        snapshot: snapshotID,
+        project: projectID,
+        file: "/workspace/src/index.ts",
+        position: 1
+    )
+    let symbol = try JSONSerialization.jsonObject(with: Data(symbolJSON.utf8)) as! [String: Any]
+    #expect(symbol["name"] as? String == "value")
 }

--- a/src/bindings/zig/corsa_tsgo_api.zig
+++ b/src/bindings/zig/corsa_tsgo_api.zig
@@ -118,6 +118,50 @@ pub const ApiClient = struct {
         return value;
     }
 
+    pub fn getTypeAtPositionJson(
+        self: ApiClient,
+        allocator: std.mem.Allocator,
+        snapshot: []const u8,
+        project: []const u8,
+        file: []const u8,
+        position: u32,
+    ) ![]u8 {
+        const value = try utils.takeString(
+            allocator,
+            c.corsa_tsgo_api_client_get_type_at_position_json(
+                self.handle,
+                utils.toRef(snapshot),
+                utils.toRef(project),
+                utils.toRef(file),
+                position,
+            ),
+        );
+        if (value.len == 0) return error.CorsaFfiError;
+        return value;
+    }
+
+    pub fn getSymbolAtPositionJson(
+        self: ApiClient,
+        allocator: std.mem.Allocator,
+        snapshot: []const u8,
+        project: []const u8,
+        file: []const u8,
+        position: u32,
+    ) ![]u8 {
+        const value = try utils.takeString(
+            allocator,
+            c.corsa_tsgo_api_client_get_symbol_at_position_json(
+                self.handle,
+                utils.toRef(snapshot),
+                utils.toRef(project),
+                utils.toRef(file),
+                position,
+            ),
+        );
+        if (value.len == 0) return error.CorsaFfiError;
+        return value;
+    }
+
     pub fn typeToString(
         self: ApiClient,
         allocator: std.mem.Allocator,


### PR DESCRIPTION
## Summary
- resolve wrapper node selection for class and property signature type/symbol lookups in `typescript_oxlint`
- add native tsgo position lookup methods for Node/NAPI and route the oxlint wrapper through them
- expose the same typed position lookup API across C, C++, Go, Swift, and Zig bindings
- add focused regression coverage for wrapper behavior plus C/Go/Node binding coverage with the mock tsgo server

## Validation
- `vp check`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/typescript_oxlint/ts/type_location.test.ts src/bindings/nodejs/corsa_node/ts/index.test.ts`
- `cargo test -p corsa_node api_client`
- `cargo test -p corsa_ffi resolves_checker_positions_over_ffi`
- `cargo build -p corsa_ffi`
- `GOCACHE=/tmp/corsa-go-cache go test ./...` from `src/bindings/go/corsa_utils`
- `cargo fmt --all --check`
- `zig fmt --check src/bindings/zig/corsa_tsgo_api.zig src/bindings/zig/corsa_utils.zig src/bindings/zig/corsa_virtual_document.zig`
- `cargo test -p corsa --no-default-features --test real_tsgo_regression --test real_tsgo_typecheck`

`swift test` was attempted from `src/bindings/swift/CorsaUtils`, but the local Swift toolchain failed while loading the package manifest with an undefined `PackageDescription.Package.__allocating_init(...)` symbol before project tests were compiled.
