### PR TITLE
fix: guard corsa-oxlint type arguments lookup

### DIFF
--- a/src/bindings/c/corsa_ffi/include/corsa_utils.h
+++ b/src/bindings/c/corsa_ffi/include/corsa_utils.h
@@ -143,6 +143,13 @@ CorsaString corsa_tsgo_api_client_get_symbol_at_position_json(
     CorsaStrRef file,
     uint32_t position
 );
+CorsaString corsa_tsgo_api_client_get_type_arguments_json(
+    const CorsaTsgoApiClient *value,
+    CorsaStrRef snapshot,
+    CorsaStrRef project,
+    CorsaStrRef type_handle,
+    uint32_t object_flags
+);
 CorsaString corsa_tsgo_api_client_type_to_string(
     const CorsaTsgoApiClient *value,
     CorsaStrRef snapshot,

--- a/src/bindings/c/corsa_ffi/src/api_client.rs
+++ b/src/bindings/c/corsa_ffi/src/api_client.rs
@@ -39,6 +39,8 @@ pub struct CorsaTsgoApiClient {
     snapshots: Mutex<HashMap<String, ManagedSnapshot>>,
 }
 
+const OBJECT_FLAGS_REFERENCE: u32 = 1 << 2;
+
 fn build_spawn_config(options: SpawnOptions) -> Result<ApiSpawnConfig, String> {
     let mut config = ApiSpawnConfig::new(options.executable);
     if let Some(cwd) = options.cwd {
@@ -397,6 +399,42 @@ pub unsafe extern "C" fn corsa_tsgo_api_client_get_symbol_at_position_json(
         ProjectHandle::from(project.as_str()),
         file,
         position,
+    )) {
+        Ok(response) => take_json(&response),
+        Err(error) => {
+            set_last_error(error);
+            CorsaString::default()
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn corsa_tsgo_api_client_get_type_arguments_json(
+    value: *const CorsaTsgoApiClient,
+    snapshot: CorsaStrRef,
+    project: CorsaStrRef,
+    type_handle: CorsaStrRef,
+    object_flags: u32,
+) -> CorsaString {
+    let Some(client) = (unsafe { client_ref(value) }) else {
+        return CorsaString::default();
+    };
+    let Some(snapshot) = read_required_text(snapshot, "snapshot") else {
+        return CorsaString::default();
+    };
+    let Some(project) = read_required_text(project, "project") else {
+        return CorsaString::default();
+    };
+    let Some(type_handle) = read_required_text(type_handle, "type_handle") else {
+        return CorsaString::default();
+    };
+    if object_flags & OBJECT_FLAGS_REFERENCE == 0 {
+        return take_json(&Vec::<corsa_client::TypeResponse>::new());
+    }
+    match block_on(client.inner.get_type_arguments(
+        SnapshotHandle::from(snapshot.as_str()),
+        ProjectHandle::from(project.as_str()),
+        TypeHandle::from(type_handle.as_str()),
     )) {
         Ok(response) => take_json(&response),
         Err(error) => {

--- a/src/bindings/c/corsa_ffi/src/tests.rs
+++ b/src/bindings/c/corsa_ffi/src/tests.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use crate::{
     api_client::{
         corsa_tsgo_api_client_close, corsa_tsgo_api_client_free,
+        corsa_tsgo_api_client_get_string_type_json,
         corsa_tsgo_api_client_get_symbol_at_position_json,
+        corsa_tsgo_api_client_get_type_arguments_json,
         corsa_tsgo_api_client_get_type_at_position_json, corsa_tsgo_api_client_spawn,
         corsa_tsgo_api_client_update_snapshot_json,
     },
@@ -237,6 +239,73 @@ fn resolves_checker_positions_over_ffi() {
         serde_json::from_str::<serde_json::Value>(&symbol_json).unwrap()["name"],
         "value"
     );
+
+    assert!(unsafe { corsa_tsgo_api_client_close(client) });
+    unsafe {
+        corsa_tsgo_api_client_free(client);
+    }
+}
+
+#[test]
+fn resolves_type_arguments_over_ffi() {
+    let Some(binary) = mock_tsgo_binary() else {
+        return;
+    };
+    let options = serde_json::json!({
+        "executable": binary.display().to_string(),
+        "cwd": workspace_root().display().to_string(),
+        "mode": "jsonrpc",
+    })
+    .to_string();
+    let client = unsafe { corsa_tsgo_api_client_spawn(text_ref(&options)) };
+    assert!(!client.is_null());
+
+    let snapshot_json = take_string(unsafe {
+        corsa_tsgo_api_client_update_snapshot_json(
+            client,
+            text_ref(r#"{"openProject":"/workspace/tsconfig.json"}"#),
+        )
+    });
+    let snapshot: serde_json::Value = serde_json::from_str(&snapshot_json).unwrap();
+    let snapshot_id = snapshot["snapshot"].as_str().unwrap();
+    let project_id = snapshot["projects"][0]["id"].as_str().unwrap();
+
+    let string_type_json = take_string(unsafe {
+        corsa_tsgo_api_client_get_string_type_json(
+            client,
+            text_ref(snapshot_id),
+            text_ref(project_id),
+        )
+    });
+    let string_type: serde_json::Value = serde_json::from_str(&string_type_json).unwrap();
+    let type_id = string_type["id"].as_str().unwrap().to_owned();
+    let object_flags = string_type["objectFlags"].as_u64().unwrap() as u32;
+
+    let non_reference_json = take_string(unsafe {
+        corsa_tsgo_api_client_get_type_arguments_json(
+            client,
+            text_ref(snapshot_id),
+            text_ref(project_id),
+            text_ref(type_id.as_str()),
+            object_flags,
+        )
+    });
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&non_reference_json).unwrap(),
+        serde_json::json!([])
+    );
+
+    let reference_json = take_string(unsafe {
+        corsa_tsgo_api_client_get_type_arguments_json(
+            client,
+            text_ref(snapshot_id),
+            text_ref(project_id),
+            text_ref(type_id.as_str()),
+            1 << 2,
+        )
+    });
+    let reference_arguments: serde_json::Value = serde_json::from_str(&reference_json).unwrap();
+    assert_eq!(reference_arguments[0]["id"], "t0000000000000001");
 
     assert!(unsafe { corsa_tsgo_api_client_close(client) });
     unsafe {

--- a/src/bindings/cpp/corsa_tsgo_api.hpp
+++ b/src/bindings/cpp/corsa_tsgo_api.hpp
@@ -95,6 +95,19 @@ class tsgo_api_client {
         position));
   }
 
+  std::string get_type_arguments_json(
+      std::string_view snapshot,
+      std::string_view project,
+      std::string_view type_handle,
+      std::uint32_t object_flags = 0) const {
+    return utils::take_string(corsa_tsgo_api_client_get_type_arguments_json(
+        handle_,
+        utils::to_ref(snapshot),
+        utils::to_ref(project),
+        utils::to_ref(type_handle),
+        object_flags));
+  }
+
   std::string type_to_string(
       std::string_view snapshot,
       std::string_view project,

--- a/src/bindings/go/corsa_utils/api_client.go
+++ b/src/bindings/go/corsa_utils/api_client.go
@@ -140,6 +140,22 @@ func (value *ApiClient) GetSymbolAtPositionJSON(snapshot string, project string,
 	))
 }
 
+func (value *ApiClient) GetTypeArgumentsJSON(snapshot string, project string, typeHandle string, objectFlags uint32) (string, error) {
+	snapshotValue := newBorrowedString(snapshot)
+	defer snapshotValue.free()
+	projectValue := newBorrowedString(project)
+	defer projectValue.free()
+	typeValue := newBorrowedString(typeHandle)
+	defer typeValue.free()
+	return takeCheckedString(C.corsa_tsgo_api_client_get_type_arguments_json(
+		value.ptr,
+		snapshotValue.ref,
+		projectValue.ref,
+		typeValue.ref,
+		C.uint32_t(objectFlags),
+	))
+}
+
 func (value *ApiClient) TypeToString(snapshot string, project string, typeHandle string, location *string, flags *int32) (string, error) {
 	snapshotValue := newBorrowedString(snapshot)
 	defer snapshotValue.free()

--- a/src/bindings/go/corsa_utils/corsa_utils_test.go
+++ b/src/bindings/go/corsa_utils/corsa_utils_test.go
@@ -102,3 +102,76 @@ func TestApiClientCheckerPositionBindings(t *testing.T) {
 		t.Fatalf("symbol name = %q", symbol.Name)
 	}
 }
+
+func TestApiClientTypeArgumentsBinding(t *testing.T) {
+	root, err := filepath.Abs("../../../..")
+	if err != nil {
+		t.Fatalf("workspace root: %v", err)
+	}
+	binary := filepath.Join(root, "target", "debug", "mock_tsgo")
+	if _, err := os.Stat(binary); err != nil {
+		t.Skip("mock_tsgo binary is not built")
+	}
+	client, err := NewApiClient(ApiClientOptions{
+		Executable: binary,
+		Cwd:        root,
+		Mode:       ApiModeJSONRPC,
+	})
+	if err != nil {
+		t.Fatalf("new api client: %v", err)
+	}
+	defer client.Close()
+
+	snapshotJSON, err := client.UpdateSnapshotJSON(`{"openProject":"/workspace/tsconfig.json"}`)
+	if err != nil {
+		t.Fatalf("update snapshot: %v", err)
+	}
+	var snapshot struct {
+		Snapshot string `json:"snapshot"`
+		Projects []struct {
+			ID string `json:"id"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal([]byte(snapshotJSON), &snapshot); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	project := snapshot.Projects[0].ID
+
+	stringTypeJSON, err := client.GetStringTypeJSON(snapshot.Snapshot, project)
+	if err != nil {
+		t.Fatalf("get string type: %v", err)
+	}
+	var stringType struct {
+		ID          string `json:"id"`
+		ObjectFlags uint32 `json:"objectFlags"`
+	}
+	if err := json.Unmarshal([]byte(stringTypeJSON), &stringType); err != nil {
+		t.Fatalf("decode string type: %v", err)
+	}
+
+	nonReferenceJSON, err := client.GetTypeArgumentsJSON(snapshot.Snapshot, project, stringType.ID, stringType.ObjectFlags)
+	if err != nil {
+		t.Fatalf("get non-reference type arguments: %v", err)
+	}
+	var nonReference []any
+	if err := json.Unmarshal([]byte(nonReferenceJSON), &nonReference); err != nil {
+		t.Fatalf("decode non-reference type arguments: %v", err)
+	}
+	if len(nonReference) != 0 {
+		t.Fatalf("non-reference type arguments = %#v", nonReference)
+	}
+
+	referenceJSON, err := client.GetTypeArgumentsJSON(snapshot.Snapshot, project, stringType.ID, 1<<2)
+	if err != nil {
+		t.Fatalf("get reference type arguments: %v", err)
+	}
+	var reference []struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(referenceJSON), &reference); err != nil {
+		t.Fatalf("decode reference type arguments: %v", err)
+	}
+	if len(reference) != 1 || reference[0].ID != "t0000000000000001" {
+		t.Fatalf("reference type arguments = %#v", reference)
+	}
+}

--- a/src/bindings/nodejs/corsa_node/index.d.ts
+++ b/src/bindings/nodejs/corsa_node/index.d.ts
@@ -44,6 +44,8 @@ export declare class TsgoApiClient {
   getTypeAtPositionJson(snapshot: string, project: string, file: string, position: number): string
   /** Resolves the checker symbol visible at a file position. */
   getSymbolAtPositionJson(snapshot: string, project: string, file: string, position: number): string
+  /** Resolves type arguments for type-reference objects and returns [] otherwise. */
+  getTypeArgumentsJson(snapshot: string, project: string, typeHandle: string, objectFlags?: number | undefined | null): string
   /** Renders a type back to a string representation. */
   typeToString(snapshot: string, project: string, typeHandle: string, location?: string | undefined | null, flags?: number | undefined | null): string
   /** Sends an arbitrary JSON endpoint request. */

--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -15,6 +15,8 @@ use crate::util::{
     SpawnOptions, build_spawn_config, into_napi_error, parse_json, parse_optional_json, to_json,
 };
 
+const OBJECT_FLAGS_REFERENCE: u32 = 1 << 2;
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SnapshotState<'a> {
@@ -141,6 +143,27 @@ impl TsgoApiClient {
             ProjectHandle::from(project.as_str()),
             file,
             position,
+        ))
+        .map_err(into_napi_error)?;
+        to_json(&response)
+    }
+
+    /// Resolves type arguments for type-reference objects and returns [] otherwise.
+    #[napi]
+    pub fn get_type_arguments_json(
+        &self,
+        snapshot: String,
+        project: String,
+        type_handle: String,
+        object_flags: Option<u32>,
+    ) -> Result<String> {
+        if object_flags.unwrap_or_default() & OBJECT_FLAGS_REFERENCE == 0 {
+            return to_json(&Vec::<corsa::api::TypeResponse>::new());
+        }
+        let response = block_on(self.inner.get_type_arguments(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            TypeHandle::from(type_handle.as_str()),
         ))
         .map_err(into_napi_error)?;
         to_json(&response)

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -115,6 +115,17 @@ describe("CorsaApiClient", () => {
         client.getSymbolAtPosition(snapshot.snapshot, project.id, "/workspace/src/index.ts", 1)
           ?.name,
       ).toBe("value");
+      expect(
+        client.getTypeArguments(
+          snapshot.snapshot,
+          project.id,
+          stringType.id,
+          stringType.objectFlags,
+        ),
+      ).toEqual([]);
+      expect(
+        client.getTypeArguments(snapshot.snapshot, project.id, stringType.id, 1 << 2),
+      ).toHaveLength(1);
       expect(client.typeToString(snapshot.snapshot, project.id, stringType.id)).toBe("type:string");
 
       client.releaseHandle(snapshot.snapshot);

--- a/src/bindings/nodejs/corsa_node/ts/index.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.ts
@@ -159,6 +159,15 @@ export class CorsaApiClient {
     );
   }
 
+  getTypeArguments(
+    snapshot: string,
+    project: string,
+    typeHandle: string,
+    objectFlags?: number,
+  ): TypeResponse[] {
+    return fromJson(this.#inner.getTypeArgumentsJson(snapshot, project, typeHandle, objectFlags));
+  }
+
   typeToString(
     snapshot: string,
     project: string,

--- a/src/bindings/nodejs/typescript_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/session.ts
@@ -143,13 +143,12 @@ export class TsgoProjectSession {
   }
 
   getTypeArguments(type: TsgoType): readonly TsgoType[] {
-    return (
-      this.client().callJson("getTypeArguments", {
-        snapshot: this.#snapshot,
-        project: this.projectId(),
-        type: type.id,
-      }) ?? []
-    );
+    return this.client().getTypeArguments(
+      this.#snapshot!,
+      this.projectId(),
+      type.id,
+      type.objectFlags,
+    ) as unknown as readonly TsgoType[];
   }
 
   private client(): TsgoApiClient {

--- a/src/bindings/nodejs/typescript_oxlint/ts/type_arguments.test.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/type_arguments.test.ts
@@ -1,0 +1,85 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { defaultTsgoExecutable } from "./context";
+import { OxlintUtils } from "./oxlint_utils";
+import { RuleTester } from "./rule_tester";
+
+const workspaceRoot = resolve(import.meta.dirname, "../../../../..");
+const realTsgoBinary = defaultTsgoExecutable(workspaceRoot);
+const integrationCase = existsSync(realTsgoBinary) ? it : it.skip;
+
+describe("corsa-oxlint type arguments", () => {
+  integrationCase("returns empty type arguments for non-generic types", () => {
+    const seen: Record<string, readonly string[]> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "safe-type-arguments",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise type argument lookups",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          TSPropertySignature(node: any) {
+            const keyName = node.key?.name;
+            if (!keyName) {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node.key);
+            seen[keyName] = type
+              ? checker.getTypeArguments(type).map((argument) => checker.typeToString(argument))
+              : [];
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("safe-type-arguments", rule as any, {
+      valid: [
+        {
+          code: [
+            "interface Demo {",
+            "  text: string;",
+            "  count: number;",
+            "  flag: boolean;",
+            "  mixed: string | number;",
+            "  object: { value: string };",
+            "  list: Array<string>;",
+            "}",
+          ].join("\n"),
+          settings: {
+            typescriptOxlint: {
+              parserOptions: {
+                tsgo: {
+                  executable: realTsgoBinary,
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.text).toEqual([]);
+    expect(seen.count).toEqual([]);
+    expect(seen.flag).toEqual([]);
+    expect(seen.mixed).toEqual([]);
+    expect(seen.object).toEqual([]);
+    expect(seen.list).toEqual(["string"]);
+  });
+});

--- a/src/bindings/swift/CorsaUtils/Sources/CorsaUtils/CorsaTsgoApiClient.swift
+++ b/src/bindings/swift/CorsaUtils/Sources/CorsaUtils/CorsaTsgoApiClient.swift
@@ -82,6 +82,15 @@ private func getSymbolAtPositionTsgoApiClientNative(
     _ position: UInt32
 ) -> CorsaString
 
+@_silgen_name("corsa_tsgo_api_client_get_type_arguments_json")
+private func getTypeArgumentsTsgoApiClientNative(
+    _ value: UnsafeMutableRawPointer?,
+    _ snapshot: CorsaStrRef,
+    _ project: CorsaStrRef,
+    _ typeHandle: CorsaStrRef,
+    _ objectFlags: UInt32
+) -> CorsaString
+
 @_silgen_name("corsa_tsgo_api_client_type_to_string")
 private func typeToStringTsgoApiClientNative(
     _ value: UnsafeMutableRawPointer?,
@@ -190,6 +199,18 @@ public final class CorsaTsgoApiClient {
         let refs = BorrowedRefs([snapshot, project, file])
         return try refs.refs.withUnsafeBufferPointer {
             try takeCheckedString(getSymbolAtPositionTsgoApiClientNative(handle, $0[0], $0[1], $0[2], position))
+        }
+    }
+
+    public func getTypeArgumentsJSON(
+        snapshot: String,
+        project: String,
+        typeHandle: String,
+        objectFlags: UInt32 = 0
+    ) throws -> String {
+        let refs = BorrowedRefs([snapshot, project, typeHandle])
+        return try refs.refs.withUnsafeBufferPointer {
+            try takeCheckedString(getTypeArgumentsTsgoApiClientNative(handle, $0[0], $0[1], $0[2], objectFlags))
         }
     }
 

--- a/src/bindings/swift/CorsaUtils/Tests/CorsaUtilsTests/CorsaUtilsTests.swift
+++ b/src/bindings/swift/CorsaUtils/Tests/CorsaUtilsTests/CorsaUtilsTests.swift
@@ -52,3 +52,48 @@ import Testing
     let symbol = try JSONSerialization.jsonObject(with: Data(symbolJSON.utf8)) as! [String: Any]
     #expect(symbol["name"] as? String == "value")
 }
+
+@Test func apiClientTypeArgumentsBinding() async throws {
+    let root = URL(fileURLWithPath: "../../../..", relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)).standardizedFileURL
+    let binary = root.appending(path: "target/debug/mock_tsgo").path
+    guard FileManager.default.fileExists(atPath: binary) else {
+        return
+    }
+    let client = try CorsaTsgoApiClient(options: CorsaTsgoApiClientOptions(
+        executable: binary,
+        cwd: root.path,
+        mode: .jsonrpc
+    ))
+    defer {
+        try? client.close()
+    }
+
+    let snapshotJSON = try client.updateSnapshotJSON(paramsJSON: #"{"openProject":"/workspace/tsconfig.json"}"#)
+    let snapshot = try JSONSerialization.jsonObject(with: Data(snapshotJSON.utf8)) as! [String: Any]
+    let snapshotID = snapshot["snapshot"] as! String
+    let projects = snapshot["projects"] as! [[String: Any]]
+    let projectID = projects[0]["id"] as! String
+
+    let stringTypeJSON = try client.getStringTypeJSON(snapshot: snapshotID, project: projectID)
+    let stringType = try JSONSerialization.jsonObject(with: Data(stringTypeJSON.utf8)) as! [String: Any]
+    let typeID = stringType["id"] as! String
+    let objectFlags = (stringType["objectFlags"] as! NSNumber).uint32Value
+
+    let nonReferenceJSON = try client.getTypeArgumentsJSON(
+        snapshot: snapshotID,
+        project: projectID,
+        typeHandle: typeID,
+        objectFlags: objectFlags
+    )
+    let nonReference = try JSONSerialization.jsonObject(with: Data(nonReferenceJSON.utf8)) as! [Any]
+    #expect(nonReference.isEmpty)
+
+    let referenceJSON = try client.getTypeArgumentsJSON(
+        snapshot: snapshotID,
+        project: projectID,
+        typeHandle: typeID,
+        objectFlags: 1 << 2
+    )
+    let reference = try JSONSerialization.jsonObject(with: Data(referenceJSON.utf8)) as! [[String: Any]]
+    #expect(reference[0]["id"] as? String == "t0000000000000001")
+}

--- a/src/bindings/zig/corsa_tsgo_api.zig
+++ b/src/bindings/zig/corsa_tsgo_api.zig
@@ -162,6 +162,28 @@ pub const ApiClient = struct {
         return value;
     }
 
+    pub fn getTypeArgumentsJson(
+        self: ApiClient,
+        allocator: std.mem.Allocator,
+        snapshot: []const u8,
+        project: []const u8,
+        type_handle: []const u8,
+        object_flags: u32,
+    ) ![]u8 {
+        const value = try utils.takeString(
+            allocator,
+            c.corsa_tsgo_api_client_get_type_arguments_json(
+                self.handle,
+                utils.toRef(snapshot),
+                utils.toRef(project),
+                utils.toRef(type_handle),
+                object_flags,
+            ),
+        );
+        if (value.len == 0) return error.CorsaFfiError;
+        return value;
+    }
+
     pub fn typeToString(
         self: ApiClient,
         allocator: std.mem.Allocator,


### PR DESCRIPTION
## Summary
- guard corsa-oxlint type argument lookup so non-reference object types return an empty list instead of calling upstream with invalid assumptions
- move the guard into the native Node/NAPI client method used by the oxlint wrapper
- expose the guarded `getTypeArguments` API across C, C++, Go, Swift, and Zig bindings
- add regression coverage for the oxlint wrapper plus C/Go/Node binding tests against the mock tsgo server

## Validation
- `vp run -w build_node_debug`
- `vp check`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/typescript_oxlint/ts/type_arguments.test.ts src/bindings/nodejs/corsa_node/ts/index.test.ts`
- `cargo test -p corsa_node api_client`
- `cargo test -p corsa_ffi resolves_type_arguments_over_ffi`
- `cargo build -p corsa_ffi`
- `GOCACHE=/tmp/corsa-go-cache go test ./...` from `src/bindings/go/corsa_utils`
- `cargo fmt --all --check`
- `zig fmt --check src/bindings/zig/corsa_tsgo_api.zig src/bindings/zig/corsa_utils.zig src/bindings/zig/corsa_virtual_document.zig`
- `cargo test -p corsa --no-default-features --test real_tsgo_regression --test real_tsgo_typecheck`

`swift test` was attempted from `src/bindings/swift/CorsaUtils`, but the local Swift toolchain failed while loading the package manifest with an undefined `PackageDescription.Package.__allocating_init(...)` symbol before project tests were compiled.
