### PR TITLE
feat: add corsa-oxlint implemented types API

### DIFF
--- a/src/bindings/c/corsa_ffi/include/corsa_utils.h
+++ b/src/bindings/c/corsa_ffi/include/corsa_utils.h
@@ -150,6 +150,18 @@ CorsaString corsa_tsgo_api_client_get_type_arguments_json(
     CorsaStrRef type_handle,
     uint32_t object_flags
 );
+CorsaString corsa_tsgo_api_client_get_type_of_symbol_json(
+    const CorsaTsgoApiClient *value,
+    CorsaStrRef snapshot,
+    CorsaStrRef project,
+    CorsaStrRef symbol
+);
+CorsaString corsa_tsgo_api_client_get_declared_type_of_symbol_json(
+    const CorsaTsgoApiClient *value,
+    CorsaStrRef snapshot,
+    CorsaStrRef project,
+    CorsaStrRef symbol
+);
 CorsaString corsa_tsgo_api_client_type_to_string(
     const CorsaTsgoApiClient *value,
     CorsaStrRef snapshot,

--- a/src/bindings/c/corsa_ffi/src/api_client.rs
+++ b/src/bindings/c/corsa_ffi/src/api_client.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Mutex, time::Duration};
 
 use corsa_client::{
     ApiClient, ApiMode, ApiSpawnConfig, ManagedSnapshot, NodeHandle, ProjectHandle, SnapshotHandle,
-    TypeHandle, UpdateSnapshotParams,
+    SymbolHandle, TypeHandle, UpdateSnapshotParams,
 };
 use corsa_runtime::block_on;
 use serde::{Serialize, de::DeserializeOwned};
@@ -435,6 +435,70 @@ pub unsafe extern "C" fn corsa_tsgo_api_client_get_type_arguments_json(
         SnapshotHandle::from(snapshot.as_str()),
         ProjectHandle::from(project.as_str()),
         TypeHandle::from(type_handle.as_str()),
+    )) {
+        Ok(response) => take_json(&response),
+        Err(error) => {
+            set_last_error(error);
+            CorsaString::default()
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn corsa_tsgo_api_client_get_type_of_symbol_json(
+    value: *const CorsaTsgoApiClient,
+    snapshot: CorsaStrRef,
+    project: CorsaStrRef,
+    symbol: CorsaStrRef,
+) -> CorsaString {
+    let Some(client) = (unsafe { client_ref(value) }) else {
+        return CorsaString::default();
+    };
+    let Some(snapshot) = read_required_text(snapshot, "snapshot") else {
+        return CorsaString::default();
+    };
+    let Some(project) = read_required_text(project, "project") else {
+        return CorsaString::default();
+    };
+    let Some(symbol) = read_required_text(symbol, "symbol") else {
+        return CorsaString::default();
+    };
+    match block_on(client.inner.get_type_of_symbol(
+        SnapshotHandle::from(snapshot.as_str()),
+        ProjectHandle::from(project.as_str()),
+        SymbolHandle::from(symbol.as_str()),
+    )) {
+        Ok(response) => take_json(&response),
+        Err(error) => {
+            set_last_error(error);
+            CorsaString::default()
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn corsa_tsgo_api_client_get_declared_type_of_symbol_json(
+    value: *const CorsaTsgoApiClient,
+    snapshot: CorsaStrRef,
+    project: CorsaStrRef,
+    symbol: CorsaStrRef,
+) -> CorsaString {
+    let Some(client) = (unsafe { client_ref(value) }) else {
+        return CorsaString::default();
+    };
+    let Some(snapshot) = read_required_text(snapshot, "snapshot") else {
+        return CorsaString::default();
+    };
+    let Some(project) = read_required_text(project, "project") else {
+        return CorsaString::default();
+    };
+    let Some(symbol) = read_required_text(symbol, "symbol") else {
+        return CorsaString::default();
+    };
+    match block_on(client.inner.get_declared_type_of_symbol(
+        SnapshotHandle::from(snapshot.as_str()),
+        ProjectHandle::from(project.as_str()),
+        SymbolHandle::from(symbol.as_str()),
     )) {
         Ok(response) => take_json(&response),
         Err(error) => {

--- a/src/bindings/c/corsa_ffi/src/tests.rs
+++ b/src/bindings/c/corsa_ffi/src/tests.rs
@@ -3,10 +3,12 @@ use std::path::PathBuf;
 use crate::{
     api_client::{
         corsa_tsgo_api_client_close, corsa_tsgo_api_client_free,
+        corsa_tsgo_api_client_get_declared_type_of_symbol_json,
         corsa_tsgo_api_client_get_string_type_json,
         corsa_tsgo_api_client_get_symbol_at_position_json,
         corsa_tsgo_api_client_get_type_arguments_json,
-        corsa_tsgo_api_client_get_type_at_position_json, corsa_tsgo_api_client_spawn,
+        corsa_tsgo_api_client_get_type_at_position_json,
+        corsa_tsgo_api_client_get_type_of_symbol_json, corsa_tsgo_api_client_spawn,
         corsa_tsgo_api_client_update_snapshot_json,
     },
     error::corsa_error_message_take,
@@ -306,6 +308,75 @@ fn resolves_type_arguments_over_ffi() {
     });
     let reference_arguments: serde_json::Value = serde_json::from_str(&reference_json).unwrap();
     assert_eq!(reference_arguments[0]["id"], "t0000000000000001");
+
+    assert!(unsafe { corsa_tsgo_api_client_close(client) });
+    unsafe {
+        corsa_tsgo_api_client_free(client);
+    }
+}
+
+#[test]
+fn resolves_symbol_type_methods_over_ffi() {
+    let Some(binary) = mock_tsgo_binary() else {
+        return;
+    };
+    let options = serde_json::json!({
+        "executable": binary.display().to_string(),
+        "cwd": workspace_root().display().to_string(),
+        "mode": "jsonrpc",
+    })
+    .to_string();
+    let client = unsafe { corsa_tsgo_api_client_spawn(text_ref(&options)) };
+    assert!(!client.is_null());
+
+    let snapshot_json = take_string(unsafe {
+        corsa_tsgo_api_client_update_snapshot_json(
+            client,
+            text_ref(r#"{"openProject":"/workspace/tsconfig.json"}"#),
+        )
+    });
+    let snapshot: serde_json::Value = serde_json::from_str(&snapshot_json).unwrap();
+    let snapshot_id = snapshot["snapshot"].as_str().unwrap();
+    let project_id = snapshot["projects"][0]["id"].as_str().unwrap();
+
+    let symbol_json = take_string(unsafe {
+        corsa_tsgo_api_client_get_symbol_at_position_json(
+            client,
+            text_ref(snapshot_id),
+            text_ref(project_id),
+            text_ref("/workspace/src/index.ts"),
+            1,
+        )
+    });
+    let symbol: serde_json::Value = serde_json::from_str(&symbol_json).unwrap();
+    assert_eq!(symbol["name"], "value");
+    let symbol_id = symbol["id"].as_str().unwrap().to_owned();
+
+    let symbol_type_json = take_string(unsafe {
+        corsa_tsgo_api_client_get_type_of_symbol_json(
+            client,
+            text_ref(snapshot_id),
+            text_ref(project_id),
+            text_ref(symbol_id.as_str()),
+        )
+    });
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&symbol_type_json).unwrap()["id"],
+        "t0000000000000001"
+    );
+
+    let declared_type_json = take_string(unsafe {
+        corsa_tsgo_api_client_get_declared_type_of_symbol_json(
+            client,
+            text_ref(snapshot_id),
+            text_ref(project_id),
+            text_ref(symbol_id.as_str()),
+        )
+    });
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&declared_type_json).unwrap()["id"],
+        "t0000000000000001"
+    );
 
     assert!(unsafe { corsa_tsgo_api_client_close(client) });
     unsafe {

--- a/src/bindings/cpp/corsa_tsgo_api.hpp
+++ b/src/bindings/cpp/corsa_tsgo_api.hpp
@@ -108,6 +108,28 @@ class tsgo_api_client {
         object_flags));
   }
 
+  std::string get_type_of_symbol_json(
+      std::string_view snapshot,
+      std::string_view project,
+      std::string_view symbol) const {
+    return utils::take_string(corsa_tsgo_api_client_get_type_of_symbol_json(
+        handle_,
+        utils::to_ref(snapshot),
+        utils::to_ref(project),
+        utils::to_ref(symbol)));
+  }
+
+  std::string get_declared_type_of_symbol_json(
+      std::string_view snapshot,
+      std::string_view project,
+      std::string_view symbol) const {
+    return utils::take_string(corsa_tsgo_api_client_get_declared_type_of_symbol_json(
+        handle_,
+        utils::to_ref(snapshot),
+        utils::to_ref(project),
+        utils::to_ref(symbol)));
+  }
+
   std::string type_to_string(
       std::string_view snapshot,
       std::string_view project,

--- a/src/bindings/go/corsa_utils/api_client.go
+++ b/src/bindings/go/corsa_utils/api_client.go
@@ -156,6 +156,36 @@ func (value *ApiClient) GetTypeArgumentsJSON(snapshot string, project string, ty
 	))
 }
 
+func (value *ApiClient) GetTypeOfSymbolJSON(snapshot string, project string, symbol string) (string, error) {
+	snapshotValue := newBorrowedString(snapshot)
+	defer snapshotValue.free()
+	projectValue := newBorrowedString(project)
+	defer projectValue.free()
+	symbolValue := newBorrowedString(symbol)
+	defer symbolValue.free()
+	return takeCheckedString(C.corsa_tsgo_api_client_get_type_of_symbol_json(
+		value.ptr,
+		snapshotValue.ref,
+		projectValue.ref,
+		symbolValue.ref,
+	))
+}
+
+func (value *ApiClient) GetDeclaredTypeOfSymbolJSON(snapshot string, project string, symbol string) (string, error) {
+	snapshotValue := newBorrowedString(snapshot)
+	defer snapshotValue.free()
+	projectValue := newBorrowedString(project)
+	defer projectValue.free()
+	symbolValue := newBorrowedString(symbol)
+	defer symbolValue.free()
+	return takeCheckedString(C.corsa_tsgo_api_client_get_declared_type_of_symbol_json(
+		value.ptr,
+		snapshotValue.ref,
+		projectValue.ref,
+		symbolValue.ref,
+	))
+}
+
 func (value *ApiClient) TypeToString(snapshot string, project string, typeHandle string, location *string, flags *int32) (string, error) {
 	snapshotValue := newBorrowedString(snapshot)
 	defer snapshotValue.free()

--- a/src/bindings/go/corsa_utils/corsa_utils_test.go
+++ b/src/bindings/go/corsa_utils/corsa_utils_test.go
@@ -175,3 +175,81 @@ func TestApiClientTypeArgumentsBinding(t *testing.T) {
 		t.Fatalf("reference type arguments = %#v", reference)
 	}
 }
+
+func TestApiClientSymbolTypeBindings(t *testing.T) {
+	root, err := filepath.Abs("../../../..")
+	if err != nil {
+		t.Fatalf("workspace root: %v", err)
+	}
+	binary := filepath.Join(root, "target", "debug", "mock_tsgo")
+	if _, err := os.Stat(binary); err != nil {
+		t.Skip("mock_tsgo binary is not built")
+	}
+	client, err := NewApiClient(ApiClientOptions{
+		Executable: binary,
+		Cwd:        root,
+		Mode:       ApiModeJSONRPC,
+	})
+	if err != nil {
+		t.Fatalf("new api client: %v", err)
+	}
+	defer client.Close()
+
+	snapshotJSON, err := client.UpdateSnapshotJSON(`{"openProject":"/workspace/tsconfig.json"}`)
+	if err != nil {
+		t.Fatalf("update snapshot: %v", err)
+	}
+	var snapshot struct {
+		Snapshot string `json:"snapshot"`
+		Projects []struct {
+			ID string `json:"id"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal([]byte(snapshotJSON), &snapshot); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	project := snapshot.Projects[0].ID
+
+	symbolJSON, err := client.GetSymbolAtPositionJSON(snapshot.Snapshot, project, "/workspace/src/index.ts", 1)
+	if err != nil {
+		t.Fatalf("get symbol at position: %v", err)
+	}
+	var symbol struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(symbolJSON), &symbol); err != nil {
+		t.Fatalf("decode symbol: %v", err)
+	}
+	if symbol.Name != "value" {
+		t.Fatalf("symbol name = %q", symbol.Name)
+	}
+
+	symbolTypeJSON, err := client.GetTypeOfSymbolJSON(snapshot.Snapshot, project, symbol.ID)
+	if err != nil {
+		t.Fatalf("get type of symbol: %v", err)
+	}
+	var symbolType struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(symbolTypeJSON), &symbolType); err != nil {
+		t.Fatalf("decode symbol type: %v", err)
+	}
+	if symbolType.ID != "t0000000000000001" {
+		t.Fatalf("symbol type id = %q", symbolType.ID)
+	}
+
+	declaredTypeJSON, err := client.GetDeclaredTypeOfSymbolJSON(snapshot.Snapshot, project, symbol.ID)
+	if err != nil {
+		t.Fatalf("get declared type of symbol: %v", err)
+	}
+	var declaredType struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(declaredTypeJSON), &declaredType); err != nil {
+		t.Fatalf("decode declared type: %v", err)
+	}
+	if declaredType.ID != "t0000000000000001" {
+		t.Fatalf("declared type id = %q", declaredType.ID)
+	}
+}

--- a/src/bindings/nodejs/corsa_node/index.d.ts
+++ b/src/bindings/nodejs/corsa_node/index.d.ts
@@ -46,6 +46,10 @@ export declare class TsgoApiClient {
   getSymbolAtPositionJson(snapshot: string, project: string, file: string, position: number): string
   /** Resolves type arguments for type-reference objects and returns [] otherwise. */
   getTypeArgumentsJson(snapshot: string, project: string, typeHandle: string, objectFlags?: number | undefined | null): string
+  /** Resolves the apparent checker type of a symbol. */
+  getTypeOfSymbolJson(snapshot: string, project: string, symbol: string): string
+  /** Resolves the declared checker type of a symbol. */
+  getDeclaredTypeOfSymbolJson(snapshot: string, project: string, symbol: string): string
   /** Renders a type back to a string representation. */
   typeToString(snapshot: string, project: string, typeHandle: string, location?: string | undefined | null, flags?: number | undefined | null): string
   /** Sends an arbitrary JSON endpoint request. */

--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -2,7 +2,8 @@ use std::sync::Mutex;
 
 use corsa::{
     api::{
-        ApiClient, ManagedSnapshot, ProjectHandle, SnapshotHandle, TypeHandle, UpdateSnapshotParams,
+        ApiClient, ManagedSnapshot, ProjectHandle, SnapshotHandle, SymbolHandle, TypeHandle,
+        UpdateSnapshotParams,
     },
     fast::{CompactString, FastMap},
     runtime::block_on,
@@ -164,6 +165,40 @@ impl TsgoApiClient {
             SnapshotHandle::from(snapshot.as_str()),
             ProjectHandle::from(project.as_str()),
             TypeHandle::from(type_handle.as_str()),
+        ))
+        .map_err(into_napi_error)?;
+        to_json(&response)
+    }
+
+    /// Resolves the apparent checker type of a symbol.
+    #[napi]
+    pub fn get_type_of_symbol_json(
+        &self,
+        snapshot: String,
+        project: String,
+        symbol: String,
+    ) -> Result<String> {
+        let response = block_on(self.inner.get_type_of_symbol(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            SymbolHandle::from(symbol.as_str()),
+        ))
+        .map_err(into_napi_error)?;
+        to_json(&response)
+    }
+
+    /// Resolves the declared checker type of a symbol.
+    #[napi]
+    pub fn get_declared_type_of_symbol_json(
+        &self,
+        snapshot: String,
+        project: String,
+        symbol: String,
+    ) -> Result<String> {
+        let response = block_on(self.inner.get_declared_type_of_symbol(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            SymbolHandle::from(symbol.as_str()),
         ))
         .map_err(into_napi_error)?;
         to_json(&response)

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -127,6 +127,26 @@ describe("CorsaApiClient", () => {
         client.getTypeArguments(snapshot.snapshot, project.id, stringType.id, 1 << 2),
       ).toHaveLength(1);
       expect(client.typeToString(snapshot.snapshot, project.id, stringType.id)).toBe("type:string");
+      const nodeType = client.getTypeAtPosition(
+        snapshot.snapshot,
+        project.id,
+        "/workspace/src/index.ts",
+        1,
+      );
+      expect(nodeType?.id).toBe("t0000000000000001");
+      const symbol = client.getSymbolAtPosition(
+        snapshot.snapshot,
+        project.id,
+        "/workspace/src/index.ts",
+        1,
+      );
+      expect(symbol?.name).toBe("value");
+      expect(client.getTypeOfSymbol(snapshot.snapshot, project.id, symbol!.id)?.id).toBe(
+        "t0000000000000001",
+      );
+      expect(client.getDeclaredTypeOfSymbol(snapshot.snapshot, project.id, symbol!.id)?.id).toBe(
+        "t0000000000000001",
+      );
 
       client.releaseHandle(snapshot.snapshot);
     } finally {

--- a/src/bindings/nodejs/corsa_node/ts/index.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.ts
@@ -168,6 +168,25 @@ export class CorsaApiClient {
     return fromJson(this.#inner.getTypeArgumentsJson(snapshot, project, typeHandle, objectFlags));
   }
 
+  getTypeOfSymbol(snapshot: string, project: string, symbol: string): TypeResponse | undefined {
+    return (
+      fromJson<TypeResponse | null>(this.#inner.getTypeOfSymbolJson(snapshot, project, symbol)) ??
+      undefined
+    );
+  }
+
+  getDeclaredTypeOfSymbol(
+    snapshot: string,
+    project: string,
+    symbol: string,
+  ): TypeResponse | undefined {
+    return (
+      fromJson<TypeResponse | null>(
+        this.#inner.getDeclaredTypeOfSymbolJson(snapshot, project, symbol),
+      ) ?? undefined
+    );
+  }
+
   typeToString(
     snapshot: string,
     project: string,

--- a/src/bindings/nodejs/typescript_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/checker.ts
@@ -86,6 +86,17 @@ export function createTypeChecker(context: ContextWithParserOptions): TsgoTypeCh
     getBaseTypes(type) {
       return sessionForContext(context).session.getBaseTypes(type);
     },
+    getImplementedTypes(node) {
+      return implementedClauseNodes(node)
+        .map((clause) => {
+          const expression = implementedClauseChildNode(clause, "expression") ?? clause;
+          const symbol = this.getSymbolAtLocation(expression) ?? this.getSymbolAtLocation(clause);
+          return symbol
+            ? (this.getDeclaredTypeOfSymbol(symbol) ?? this.getTypeOfSymbol(symbol))
+            : (this.getTypeAtLocation(expression) ?? this.getTypeAtLocation(clause));
+        })
+        .filter((type): type is TsgoType => type !== undefined);
+    },
     getTypeArguments(type) {
       return sessionForContext(context).session.getTypeArguments(type);
     },
@@ -108,6 +119,25 @@ function nodeForTypeLookup(node: Node | TsgoNode): Node | TsgoNode {
 }
 
 function childNode(node: Node, key: string): Node | undefined {
+  const value = (node as unknown as Record<string, unknown>)[key];
+  if (isNode(value)) {
+    return value;
+  }
+  return undefined;
+}
+
+function implementedClauseNodes(node: Node | TsgoNode): readonly Node[] {
+  if ("pos" in node) {
+    return [];
+  }
+  const clauses = (node as unknown as { readonly implements?: unknown }).implements;
+  if (!Array.isArray(clauses)) {
+    return [];
+  }
+  return clauses.filter(isNode);
+}
+
+function implementedClauseChildNode(node: Node, key: string): Node | undefined {
   const value = (node as unknown as Record<string, unknown>)[key];
   if (isNode(value)) {
     return value;

--- a/src/bindings/nodejs/typescript_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/implemented_types.test.ts
@@ -1,0 +1,79 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { defaultTsgoExecutable } from "./context";
+import { OxlintUtils } from "./oxlint_utils";
+import { RuleTester } from "./rule_tester";
+
+const workspaceRoot = resolve(import.meta.dirname, "../../../../..");
+const realTsgoBinary = defaultTsgoExecutable(workspaceRoot);
+const integrationCase = existsSync(realTsgoBinary) ? it : it.skip;
+
+describe("corsa-oxlint implemented types", () => {
+  integrationCase("exposes class implements clause types", () => {
+    const seen: Record<string, readonly string[] | undefined> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "implemented-types",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise class implements type lookup",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          ClassDeclaration(node: any) {
+            const className = node.id?.name;
+            if (!className) {
+              return;
+            }
+            seen[className] = checker
+              .getImplementedTypes(node)
+              .map((type) => checker.typeToString(type));
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("implemented-types", rule as any, {
+      valid: [
+        {
+          code: [
+            "interface SuperClass { value: string }",
+            "interface Other { item: number }",
+            "class ChildClass implements SuperClass, Other {",
+            "  value = '';",
+            "  item = 1;",
+            "}",
+            "class PlainClass {}",
+          ].join("\n"),
+          settings: {
+            typescriptOxlint: {
+              parserOptions: {
+                tsgo: {
+                  executable: realTsgoBinary,
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.ChildClass).toEqual(["SuperClass", "Other"]);
+    expect(seen.PlainClass).toEqual([]);
+  });
+});

--- a/src/bindings/nodejs/typescript_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/session.ts
@@ -70,19 +70,15 @@ export class TsgoProjectSession {
   }
 
   getTypeOfSymbol(symbol: TsgoSymbol): TsgoType | undefined {
-    return this.client().callJson("getTypeOfSymbol", {
-      snapshot: this.#snapshot,
-      project: this.projectId(),
-      symbol: symbol.id,
-    });
+    return this.client().getTypeOfSymbol(this.#snapshot!, this.projectId(), symbol.id) as
+      | TsgoType
+      | undefined;
   }
 
   getDeclaredTypeOfSymbol(symbol: TsgoSymbol): TsgoType | undefined {
-    return this.client().callJson("getDeclaredTypeOfSymbol", {
-      snapshot: this.#snapshot,
-      project: this.projectId(),
-      symbol: symbol.id,
-    });
+    return this.client().getDeclaredTypeOfSymbol(this.#snapshot!, this.projectId(), symbol.id) as
+      | TsgoType
+      | undefined;
   }
 
   typeToString(type: TsgoType, flags?: number): string {

--- a/src/bindings/nodejs/typescript_oxlint/ts/types.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/types.ts
@@ -107,6 +107,7 @@ export interface TsgoTypeCheckerShape {
   getReturnTypeOfSignature(signature: TsgoSignature): TsgoType | undefined;
   getTypePredicateOfSignature(signature: TsgoSignature): TsgoTypePredicate | undefined;
   getBaseTypes(type: TsgoType): readonly TsgoType[];
+  getImplementedTypes(node: Node | TsgoNode): readonly TsgoType[];
   getTypeArguments(type: TsgoType): readonly TsgoType[];
 }
 

--- a/src/bindings/swift/CorsaUtils/Sources/CorsaUtils/CorsaTsgoApiClient.swift
+++ b/src/bindings/swift/CorsaUtils/Sources/CorsaUtils/CorsaTsgoApiClient.swift
@@ -91,6 +91,22 @@ private func getTypeArgumentsTsgoApiClientNative(
     _ objectFlags: UInt32
 ) -> CorsaString
 
+@_silgen_name("corsa_tsgo_api_client_get_type_of_symbol_json")
+private func getTypeOfSymbolTsgoApiClientNative(
+    _ value: UnsafeMutableRawPointer?,
+    _ snapshot: CorsaStrRef,
+    _ project: CorsaStrRef,
+    _ symbol: CorsaStrRef
+) -> CorsaString
+
+@_silgen_name("corsa_tsgo_api_client_get_declared_type_of_symbol_json")
+private func getDeclaredTypeOfSymbolTsgoApiClientNative(
+    _ value: UnsafeMutableRawPointer?,
+    _ snapshot: CorsaStrRef,
+    _ project: CorsaStrRef,
+    _ symbol: CorsaStrRef
+) -> CorsaString
+
 @_silgen_name("corsa_tsgo_api_client_type_to_string")
 private func typeToStringTsgoApiClientNative(
     _ value: UnsafeMutableRawPointer?,
@@ -188,14 +204,24 @@ public final class CorsaTsgoApiClient {
         }
     }
 
-    public func getTypeAtPositionJSON(snapshot: String, project: String, file: String, position: UInt32) throws -> String {
+    public func getTypeAtPositionJSON(
+        snapshot: String,
+        project: String,
+        file: String,
+        position: UInt32
+    ) throws -> String {
         let refs = BorrowedRefs([snapshot, project, file])
         return try refs.refs.withUnsafeBufferPointer {
             try takeCheckedString(getTypeAtPositionTsgoApiClientNative(handle, $0[0], $0[1], $0[2], position))
         }
     }
 
-    public func getSymbolAtPositionJSON(snapshot: String, project: String, file: String, position: UInt32) throws -> String {
+    public func getSymbolAtPositionJSON(
+        snapshot: String,
+        project: String,
+        file: String,
+        position: UInt32
+    ) throws -> String {
         let refs = BorrowedRefs([snapshot, project, file])
         return try refs.refs.withUnsafeBufferPointer {
             try takeCheckedString(getSymbolAtPositionTsgoApiClientNative(handle, $0[0], $0[1], $0[2], position))
@@ -211,6 +237,20 @@ public final class CorsaTsgoApiClient {
         let refs = BorrowedRefs([snapshot, project, typeHandle])
         return try refs.refs.withUnsafeBufferPointer {
             try takeCheckedString(getTypeArgumentsTsgoApiClientNative(handle, $0[0], $0[1], $0[2], objectFlags))
+        }
+    }
+
+    public func getTypeOfSymbolJSON(snapshot: String, project: String, symbol: String) throws -> String {
+        let refs = BorrowedRefs([snapshot, project, symbol])
+        return try refs.refs.withUnsafeBufferPointer {
+            try takeCheckedString(getTypeOfSymbolTsgoApiClientNative(handle, $0[0], $0[1], $0[2]))
+        }
+    }
+
+    public func getDeclaredTypeOfSymbolJSON(snapshot: String, project: String, symbol: String) throws -> String {
+        let refs = BorrowedRefs([snapshot, project, symbol])
+        return try refs.refs.withUnsafeBufferPointer {
+            try takeCheckedString(getDeclaredTypeOfSymbolTsgoApiClientNative(handle, $0[0], $0[1], $0[2]))
         }
     }
 

--- a/src/bindings/swift/CorsaUtils/Tests/CorsaUtilsTests/CorsaUtilsTests.swift
+++ b/src/bindings/swift/CorsaUtils/Tests/CorsaUtilsTests/CorsaUtilsTests.swift
@@ -97,3 +97,43 @@ import Testing
     let reference = try JSONSerialization.jsonObject(with: Data(referenceJSON.utf8)) as! [[String: Any]]
     #expect(reference[0]["id"] as? String == "t0000000000000001")
 }
+
+@Test func apiClientSymbolTypeBindings() async throws {
+    let root = URL(fileURLWithPath: "../../../..", relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)).standardizedFileURL
+    let binary = root.appending(path: "target/debug/mock_tsgo").path
+    guard FileManager.default.fileExists(atPath: binary) else {
+        return
+    }
+    let client = try CorsaTsgoApiClient(options: CorsaTsgoApiClientOptions(
+        executable: binary,
+        cwd: root.path,
+        mode: .jsonrpc
+    ))
+    defer {
+        try? client.close()
+    }
+
+    let snapshotJSON = try client.updateSnapshotJSON(paramsJSON: #"{"openProject":"/workspace/tsconfig.json"}"#)
+    let snapshot = try JSONSerialization.jsonObject(with: Data(snapshotJSON.utf8)) as! [String: Any]
+    let snapshotID = snapshot["snapshot"] as! String
+    let projects = snapshot["projects"] as! [[String: Any]]
+    let projectID = projects[0]["id"] as! String
+
+    let symbolJSON = try client.getSymbolAtPositionJSON(
+        snapshot: snapshotID,
+        project: projectID,
+        file: "/workspace/src/index.ts",
+        position: 1
+    )
+    let symbol = try JSONSerialization.jsonObject(with: Data(symbolJSON.utf8)) as! [String: Any]
+    #expect(symbol["name"] as? String == "value")
+    let symbolID = symbol["id"] as! String
+
+    let symbolTypeJSON = try client.getTypeOfSymbolJSON(snapshot: snapshotID, project: projectID, symbol: symbolID)
+    let symbolType = try JSONSerialization.jsonObject(with: Data(symbolTypeJSON.utf8)) as! [String: Any]
+    #expect(symbolType["id"] as? String == "t0000000000000001")
+
+    let declaredTypeJSON = try client.getDeclaredTypeOfSymbolJSON(snapshot: snapshotID, project: projectID, symbol: symbolID)
+    let declaredType = try JSONSerialization.jsonObject(with: Data(declaredTypeJSON.utf8)) as! [String: Any]
+    #expect(declaredType["id"] as? String == "t0000000000000001")
+}

--- a/src/bindings/zig/corsa_tsgo_api.zig
+++ b/src/bindings/zig/corsa_tsgo_api.zig
@@ -184,6 +184,46 @@ pub const ApiClient = struct {
         return value;
     }
 
+    pub fn getTypeOfSymbolJson(
+        self: ApiClient,
+        allocator: std.mem.Allocator,
+        snapshot: []const u8,
+        project: []const u8,
+        symbol: []const u8,
+    ) ![]u8 {
+        const value = try utils.takeString(
+            allocator,
+            c.corsa_tsgo_api_client_get_type_of_symbol_json(
+                self.handle,
+                utils.toRef(snapshot),
+                utils.toRef(project),
+                utils.toRef(symbol),
+            ),
+        );
+        if (value.len == 0) return error.CorsaFfiError;
+        return value;
+    }
+
+    pub fn getDeclaredTypeOfSymbolJson(
+        self: ApiClient,
+        allocator: std.mem.Allocator,
+        snapshot: []const u8,
+        project: []const u8,
+        symbol: []const u8,
+    ) ![]u8 {
+        const value = try utils.takeString(
+            allocator,
+            c.corsa_tsgo_api_client_get_declared_type_of_symbol_json(
+                self.handle,
+                utils.toRef(snapshot),
+                utils.toRef(project),
+                utils.toRef(symbol),
+            ),
+        );
+        if (value.len == 0) return error.CorsaFfiError;
+        return value;
+    }
+
     pub fn typeToString(
         self: ApiClient,
         allocator: std.mem.Allocator,


### PR DESCRIPTION
## Summary
- add `getImplementedTypes` support to the corsa-oxlint checker wrapper for class `implements` clauses
- add native Node/NAPI checker methods for type/symbol-at-position and type/declared-type-of-symbol lookups
- expose those checker lookup APIs across C, C++, Go, Swift, and Zig bindings
- add regression coverage for the oxlint wrapper plus C/Go/Node binding tests against the mock tsgo server

## Validation
- `vp run -w build_node_debug`
- `vp check`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/typescript_oxlint/ts/implemented_types.test.ts src/bindings/nodejs/corsa_node/ts/index.test.ts`
- `cargo test -p corsa_node api_client`
- `cargo test -p corsa_ffi resolves_symbol_type_methods_over_ffi`
- `cargo build -p corsa_ffi`
- `GOCACHE=/tmp/corsa-go-cache go test ./...` from `src/bindings/go/corsa_utils`
- `cargo fmt --all --check`
- `zig fmt --check src/bindings/zig/corsa_tsgo_api.zig src/bindings/zig/corsa_utils.zig src/bindings/zig/corsa_virtual_document.zig`
- `cargo test -p corsa --no-default-features --test real_tsgo_regression --test real_tsgo_typecheck`

`swift test` was attempted from `src/bindings/swift/CorsaUtils`, but the local Swift toolchain failed while loading the package manifest with an undefined `PackageDescription.Package.__allocating_init(...)` symbol before project tests were compiled.
