### PR TITLE
fix: type corsa-oxlint rule creator return

### DIFF
--- a/scripts/bench_bindings.ts
+++ b/scripts/bench_bindings.ts
@@ -49,12 +49,7 @@ function main(): void {
 
   run("cargo", ["build", "-p", "corsa_ffi"], { cwd: workspaceRoot });
 
-  const targets = [
-    buildCTarget(),
-    buildCppTarget(),
-    buildGoTarget(),
-    buildSwiftTarget(),
-  ];
+  const targets = [buildCTarget(), buildCppTarget(), buildGoTarget(), buildSwiftTarget()];
 
   const rows: BenchRow[] = [];
   for (const target of targets) {
@@ -163,7 +158,10 @@ function buildSwiftTarget(): BuiltTarget {
   }).trim();
   return {
     language: "swift",
-    executable: join(binPath, process.platform === "win32" ? "CorsaUtilsBench.exe" : "CorsaUtilsBench"),
+    executable: join(
+      binPath,
+      process.platform === "win32" ? "CorsaUtilsBench.exe" : "CorsaUtilsBench",
+    ),
   };
 }
 

--- a/src/bindings/nodejs/typescript_oxlint/ts/oxlint_utils.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/oxlint_utils.ts
@@ -1,13 +1,46 @@
+import type { Rule, RuleMeta, Visitor } from "@oxlint/plugins";
+
 import { getParserServices } from "./parser_services";
 import { decorateRule } from "./plugin";
 import type { ContextWithParserOptions } from "./types";
+
+export type RuleCreatorRule<
+  TOptions extends readonly unknown[] = readonly unknown[],
+  TMessageIds extends string = string,
+> = {
+  readonly name: string;
+  readonly meta: RuleMeta & {
+    readonly messages?: Record<TMessageIds, string>;
+  };
+  readonly defaultOptions?: TOptions;
+  readonly create: (context: ContextWithParserOptions) => Visitor;
+};
+
+export type RuleCreatorCreatedRule<TRule extends RuleCreatorRule> = Omit<
+  TRule,
+  "defaultOptions" | "meta"
+> & {
+  readonly defaultOptions: TRule extends { readonly defaultOptions: infer TOptions }
+    ? TOptions
+    : readonly [];
+  readonly meta: TRule["meta"] & {
+    readonly docs: NonNullable<TRule["meta"]["docs"]> & {
+      readonly url: string;
+    };
+  };
+} & Rule &
+  Record<string, unknown>;
+
+export type RuleCreatorFactory = <TRule extends RuleCreatorRule>(
+  rule: TRule,
+) => RuleCreatorCreatedRule<TRule>;
 
 /**
  * Self-hosted type-aware utilities for Oxlint rules backed by tsgo.
  */
 export const OxlintUtils = Object.freeze({
-  RuleCreator(urlCreator: (ruleName: string) => string) {
-    return (rule: any) => {
+  RuleCreator(urlCreator: (ruleName: string) => string): RuleCreatorFactory {
+    return ((rule) => {
       const docs = rule.meta?.docs;
       return decorateRule({
         ...rule,
@@ -19,8 +52,8 @@ export const OxlintUtils = Object.freeze({
           },
         },
         defaultOptions: rule.defaultOptions ?? [],
-      } as never);
-    };
+      } as unknown as Rule) as RuleCreatorCreatedRule<typeof rule>;
+    }) as RuleCreatorFactory;
   },
   getParserServices(context: ContextWithParserOptions, allowWithoutFullTypeInformation = false) {
     return getParserServices(context, allowWithoutFullTypeInformation);

--- a/src/bindings/nodejs/typescript_oxlint/ts/rule_creator_types.test.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rule_creator_types.test.ts
@@ -1,0 +1,53 @@
+import type { Rule } from "@oxlint/plugins";
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import { OxlintUtils } from "./oxlint_utils";
+
+describe("corsa-oxlint RuleCreator types", () => {
+  it("preserves typed RuleCreator return values", () => {
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "typed-options",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "typed rule",
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [{ allow: true }] as const,
+      create(context) {
+        expectTypeOf(context.parserServices).toMatchTypeOf<object | undefined>();
+        return {};
+      },
+    });
+    const ruleWithoutOptions = createRule({
+      name: "typed-default-options",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "typed rule with defaulted options",
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      create() {
+        return {};
+      },
+    });
+
+    expectTypeOf(rule).toMatchTypeOf<Rule>();
+    expectTypeOf(rule.defaultOptions).toEqualTypeOf<readonly [{ readonly allow: true }]>();
+    expectTypeOf(rule.meta.docs.url).toEqualTypeOf<string>();
+    expectTypeOf(rule.meta.messages.unexpected).toMatchTypeOf<string>();
+    expectTypeOf(ruleWithoutOptions.defaultOptions).toEqualTypeOf<readonly []>();
+    expect(rule.defaultOptions).toEqual([{ allow: true }]);
+    expect(ruleWithoutOptions.defaultOptions).toEqual([]);
+    expect(rule.meta.docs.url).toBe("https://example.com/rules/typed-options");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #27.

- Add explicit `RuleCreatorRule`, `RuleCreatorCreatedRule`, and `RuleCreatorFactory` types for `OxlintUtils.RuleCreator`.
- Preserve rule option tuple types, docs URL typing, message id typing, and assignability to Oxlint `Rule` / `Record<string, unknown>`.
- Remove the `as never` return path that made `RuleCreator` appear as `(rule: any) => never`.
- Add dedicated type-level and runtime coverage for typed options and defaulted options.

## Validation

- `vp test run --config ./vite.config.ts src/bindings/nodejs/typescript_oxlint/ts/rule_creator_types.test.ts`
- `vp check`
