### PR TITLE
chore: update typescript-go pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Current focus:
 Pinned upstream at the time of writing:
 
 - Repository: `https://github.com/microsoft/typescript-go.git`
-- Commit: `9c19dee6ab88ae11444837f16efa16a6b3dc9f59`
+- Commit: `47ca64821ddc972ae77ed3b75337ac3a2d635562`
 - Lock file: [`tsgo_ref.lock.toml`](./tsgo_ref.lock.toml)
 
 ## Workspace Layout

--- a/tsgo_ref.lock.toml
+++ b/tsgo_ref.lock.toml
@@ -3,8 +3,8 @@ version = 1
 [typescript_go]
 path = "ref/typescript-go"
 repository = "https://github.com/microsoft/typescript-go.git"
-commit = "ba858e5c6852160ff69184d7fd7db77b348e246c"
-tree = "49248a2c230e711b1c49ea17b84fee7767d97c4c"
-committer_date = "2026-04-23T21:55:46Z"
+commit = "47ca64821ddc972ae77ed3b75337ac3a2d635562"
+tree = "d99b63f642baffa5969e65e16943b33767fe5d4a"
+committer_date = "2026-05-13T22:03:10Z"
 author = "Andrew Branch"
-subject = "Include compilerOptions.types in auto-import packages (#3536)"
+subject = "Don't recursively scan auto-import packages for non-main .d.ts files unless option is set (#3823)"


### PR DESCRIPTION
## Summary

- Update the pinned `microsoft/typescript-go` ref from `ba858e5c6852160ff69184d7fd7db77b348e246c` to `47ca64821ddc972ae77ed3b75337ac3a2d635562`.
- Refresh the README pinned upstream commit to match `tsgo_ref.lock.toml`.

Upstream commit: https://github.com/microsoft/typescript-go/commit/47ca64821ddc972ae77ed3b75337ac3a2d635562

## Validation

- `vp run -w build_tsgo`
- `cargo test -p corsa_ref`
- `cargo test -p corsa --no-default-features --test real_tsgo_regression --test real_tsgo_typecheck`
