### PR TITLE
fix: keep release preflight light

### DIFF
--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -92,13 +92,16 @@ vp run -w release minor
 - requires a clean checkout
 - expects `main` by default
 - bumps every Rust and npm package version together
-- runs the local release gates
+- runs only a lightweight local preflight by default
 - creates `release: vX.Y.Z`
 - creates an annotated `vX.Y.Z` tag
 - pushes the branch and the tag
 
 Pushing the tag triggers both publish workflows. Rust and npm publish from the
 tagged commit through GitHub Actions trusted publishing.
+The heavier release gates run in GitHub Actions after the tag is pushed. Use
+`vp run -w release <patch|minor|major> --full-gates` only when you explicitly
+want to rerun the full gate set locally before tagging.
 After both publish workflows complete successfully, the `GitHub Release`
 workflow creates a GitHub Release for the tag with generated release notes.
 
@@ -121,6 +124,14 @@ This performs:
 CI also runs the same release dry-run workflow.
 
 ## Release Checks
+
+The local release command runs:
+
+- `vp check`
+- `cargo fmt --all --check`
+
+The tag-triggered GitHub Actions release gates run the heavier checks before
+publishing:
 
 Before publishing Rust crates:
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -37,12 +37,13 @@ interface ReleaseOptions {
   push: boolean;
   remote: string;
   requiredBranch: string;
+  runFullGates: boolean;
   skipGates: boolean;
 }
 
 function printUsage(): void {
   console.log(
-    "Usage: vp run -w release <patch|minor|major> [--no-push] [--skip-gates] [--allow-bootstrap-gap]",
+    "Usage: vp run -w release <patch|minor|major> [--no-push] [--full-gates] [--skip-gates] [--allow-bootstrap-gap]",
   );
 }
 
@@ -67,6 +68,7 @@ function parseArgs(argv: string[]): ReleaseOptions {
     push: !args.includes("--no-push"),
     remote: process.env.RELEASE_REMOTE?.trim() || defaultRemote,
     requiredBranch: process.env.RELEASE_BRANCH?.trim() || defaultBranch,
+    runFullGates: args.includes("--full-gates"),
     skipGates: args.includes("--skip-gates"),
   };
 }
@@ -199,7 +201,13 @@ async function assertBootstrapComplete(): Promise<void> {
   throw new Error(lines.join("\n"));
 }
 
-function runReleaseGates(): void {
+function runReleasePreflight(): void {
+  console.log("running local release preflight; full release gates run in GitHub Actions");
+  runCommand(vpCommand, ["check"], { cwd: rootDir });
+  runCommand(vpCommand, ["run", "-w", "fmt_check_rust"], { cwd: rootDir });
+}
+
+function runFullReleaseGates(): void {
   runCommand(vpCommand, ["check"], { cwd: rootDir });
   runCommand(vpCommand, ["run", "-w", "fmt_check_rust"], { cwd: rootDir });
   runCommand(vpCommand, ["run", "-w", "lint_rust"], { cwd: rootDir });
@@ -228,11 +236,15 @@ async function main(): Promise<void> {
   const tag = versionToTag(nextVersion);
 
   assertTagAbsent(options.remote, tag);
+  if (!options.skipGates && !options.runFullGates) {
+    runReleasePreflight();
+  }
+
   updateWorkspaceVersion(nextVersion);
   syncCargoLockfile();
 
-  if (!options.skipGates) {
-    runReleaseGates();
+  if (!options.skipGates && options.runFullGates) {
+    runFullReleaseGates();
   }
 
   assertReleaseTagMatchesWorkspace(tag);


### PR DESCRIPTION
## Summary
- keep `vp run -w release` on a lightweight local preflight by default
- move the old heavy local gate set behind `--full-gates`
- document that tag-triggered GitHub Actions run the full release gates

## Local checks
- `node --strip-types ./scripts/release.ts --help`
- `git diff --check`