### PR TITLE
chore: add CODEOWNERS for release-critical surfaces

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Automation and release policy
+/.github/workflows/ @ubugeeei
+/.github/dependabot.yml @ubugeeei
+/deny.toml @ubugeeei
+
+# Package and Cargo manifests
+**/package.json @ubugeeei
+**/package-lock.json @ubugeeei
+**/pnpm-lock.yaml @ubugeeei
+/pnpm-workspace.yaml @ubugeeei
+**/Cargo.toml @ubugeeei
+/Cargo.lock @ubugeeei
+
+# Release scripts and docs
+/scripts/ @ubugeeei
+/docs/ @ubugeeei
+
+# Language bindings
+/src/bindings/ @ubugeeei


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` for release-critical surfaces owned by @ubugeeei.
- Cover workflows, Dependabot, package and Cargo manifests/lockfiles, `deny.toml`, release scripts, docs, and language binding directories.

Closes #67

## Validation
- `git diff --cached --check`
- reviewed staged `git diff --cached -- .github/CODEOWNERS`