### PR TITLE
chore: add issue forms and pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Report a reproducible problem in corsa-bind.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve corsa-bind. Please include enough detail for maintainers to reproduce the issue.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened, and what did you expect to happen?
+      placeholder: Briefly describe the bug and expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Provide the smallest example, command, or repository that reproduces the issue.
+      placeholder: |
+        1. Run ...
+        2. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include package version, runtime, OS, and any relevant toolchain versions.
+      placeholder: |
+        corsa-bind version:
+        OS:
+        Node.js/Rust/toolchain:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or output
+      description: Paste relevant logs, errors, or stack traces. Redact secrets.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/production_readiness.yml
+++ b/.github/ISSUE_TEMPLATE/production_readiness.yml
@@ -1,0 +1,49 @@
+name: Production readiness
+description: Track a release, operational, security, or reliability readiness concern.
+title: "chore: "
+labels:
+  - production-readiness
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for work that improves confidence in shipping or operating corsa-bind.
+  - type: textarea
+    id: concern
+    attributes:
+      label: Readiness concern
+      description: What risk, gap, or operational need should be addressed?
+      placeholder: Describe the production readiness gap and why it matters.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List the concrete outcomes required to close this issue.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which area is most affected?
+      options:
+        - Release
+        - Security
+        - Observability
+        - Reliability
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add links, constraints, prior discussion, or implementation notes.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Summary
 
-- 
+- Summary of the change
 
 ## Validation
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+- 
+
+## Validation
+
+- [ ] Tests or checks run locally
+- [ ] Not applicable
+
+## Checklist
+
+- [ ] Scope is limited to the described change
+- [ ] Documentation or templates were updated when needed
+- [ ] Follow-up work is tracked in an issue


### PR DESCRIPTION
## Summary

- Add GitHub issue forms for bug reports and production readiness work.
- Add repository pull request template with summary, validation, and checklist sections.

Closes #66

## Validation

- Confirmed all requested template files exist.
- Parsed issue form YAML with Ruby Psych via `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "parsed #{path}" }' .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/production_readiness.yml .github/ISSUE_TEMPLATE/config.yml`.
- Ran `git diff --check` for the new template files.
