### PR TITLE
ci: verify upstream ref before release dry runs

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -31,5 +31,8 @@ jobs:
           cache: true
           run-install: true
 
+      - name: Verify upstream ref
+        run: vp run -w verify_ref
+
       - name: Validate release artifacts
         run: vp run -w release_dry_run


### PR DESCRIPTION
## Summary
- Add an explicit `Verify upstream ref` gate to the release dry-run workflow before release artifact validation.
- Keep the release artifact validation task unchanged and rely on the existing Vite+ task graph.

Closes #69

## Validation
- `yq e '.' .github/workflows/release-dry-run.yml >/dev/null`\n- `git diff --check`