### PR TITLE
ci: serialize Rust test prerequisites

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -149,7 +149,7 @@ export default defineConfig({
       },
       test_rust: {
         command: "cargo test --workspace",
-        dependsOn: ["verify_ref"],
+        dependsOn: ["verify_ref", "build_rust", "build_mock"],
       },
       test_rust_experimental: {
         command: "cargo test -p corsa --no-default-features --test orchestrator",
@@ -157,6 +157,7 @@ export default defineConfig({
       },
       test_rust_experimental_feature: {
         command: "cargo test -p corsa --features experimental-distributed --test orchestrator",
+        dependsOn: ["build_mock"],
       },
       test_ts: {
         command: "vp test run --config ./vite.config.ts",


### PR DESCRIPTION
## Summary

- make `test_rust` wait for `build_rust` and `build_mock`
- make the experimental orchestrator test wait for `build_mock`
- remove reliance on incidental Cargo artifact timing between parallel Vite+ tasks

Closes #83

## Root Cause

A PR check failed on macOS because `vp run -w test` started the experimental orchestrator test while the mock `tsgo` binary build was still racing in another task. The test then tried to spawn the mock binary and hit `No such file or directory`.

## Validation

- `git diff --check`
- attempted `vp run -w test_rust_experimental_feature` locally, but this clean worktree does not have `vite-plus` installed in `node_modules`; CI's `setup-vp` step installs it before loading the task graph.

## Risk

Low. This only adds explicit task dependencies; it does not remove coverage.