### PR TITLE
fix: harden orchestrator batch workers

### DIFF
--- a/src/bindings/rust/corsa/tests/orchestrator.rs
+++ b/src/bindings/rust/corsa/tests/orchestrator.rs
@@ -123,6 +123,46 @@ fn orchestrator_executes_parallel_batches() {
 }
 
 #[test]
+fn orchestrator_executes_batches_larger_than_work_queue_capacity() {
+    run_async_test(async {
+        let orchestrator = ApiOrchestrator::new(ApiOrchestratorConfig {
+            work_queue_capacity: 1,
+            ..ApiOrchestratorConfig::default()
+        });
+        let profile = support::api_profile("async-batch-backpressure", ApiMode::AsyncJsonRpcStdio);
+        let values = orchestrator
+            .execute_all(&profile, 2, 0_u32..8, |_, value| async move {
+                Ok::<_, corsa::TsgoError>(value)
+            })
+            .await
+            .unwrap();
+        assert_eq!(values.as_slice(), &[0, 1, 2, 3, 4, 5, 6, 7]);
+    });
+}
+
+#[test]
+fn orchestrator_reports_batch_task_panics() {
+    run_async_test(async {
+        let orchestrator = ApiOrchestrator::default();
+        let profile = support::api_profile("async-batch-panic", ApiMode::AsyncJsonRpcStdio);
+        let error = orchestrator
+            .execute_all(&profile, 1, [1_u32], |_, _| async move {
+                panic!("batch task exploded");
+                #[allow(unreachable_code)]
+                Ok::<_, corsa::TsgoError>(0_u32)
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("orchestrator batch worker panicked: batch task exploded"),
+            "{error}"
+        );
+    });
+}
+
+#[test]
 fn orchestrator_skips_worker_start_for_empty_batches() {
     run_async_test(async {
         let orchestrator = ApiOrchestrator::default();

--- a/src/core/corsa_orchestrator/src/orchestrator/api.rs
+++ b/src/core/corsa_orchestrator/src/orchestrator/api.rs
@@ -10,7 +10,9 @@ use log::warn;
 use parking_lot::{Mutex, RwLock};
 use serde::{Serialize, de::DeserializeOwned};
 use std::{
+    any::Any,
     collections::VecDeque,
+    panic::{AssertUnwindSafe, catch_unwind},
     sync::mpsc,
     sync::{
         Arc,
@@ -290,7 +292,7 @@ impl ApiOrchestrator {
         let queue_capacity = self.config.work_queue_capacity.max(1);
         let (work_tx, work_rx) = mpsc::sync_channel::<(usize, T)>(queue_capacity);
         let work_rx = Arc::new(std::sync::Mutex::new(work_rx));
-        let (result_tx, result_rx) = mpsc::sync_channel::<Result<(usize, R)>>(queue_capacity);
+        let (result_tx, result_rx) = mpsc::channel::<Result<(usize, R)>>();
         thread::scope(|scope| {
             for _ in 0..replicas.max(1) {
                 let profile = profile.clone();
@@ -298,14 +300,25 @@ impl ApiOrchestrator {
                 let result_tx = result_tx.clone();
                 scope.spawn(move || {
                     loop {
-                        let job = work_rx.lock().unwrap().recv();
+                        let job = match work_rx.lock() {
+                            Ok(work_rx) => work_rx.recv(),
+                            Err(_) => {
+                                let _ = result_tx.send(Err(crate::TsgoError::Join(
+                                    CompactString::from("orchestrator work queue lock poisoned"),
+                                )));
+                                break;
+                            }
+                        };
                         let Ok((index, input)) = job else {
                             break;
                         };
-                        let output = block_on(async {
-                            let client = self.lease(&profile).await?;
-                            Ok::<_, crate::TsgoError>((index, task(client, input).await?))
-                        });
+                        let output = catch_unwind(AssertUnwindSafe(|| {
+                            block_on(async {
+                                let client = self.lease(&profile).await?;
+                                Ok::<_, crate::TsgoError>((index, task(client, input).await?))
+                            })
+                        }))
+                        .unwrap_or_else(|panic| Err(batch_worker_panic(panic)));
                         if result_tx.send(output).is_err() {
                             break;
                         }
@@ -386,4 +399,15 @@ impl ApiOrchestrator {
             }
         }
     }
+}
+
+fn batch_worker_panic(panic: Box<dyn Any + Send>) -> crate::TsgoError {
+    let message = panic
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("unknown panic payload");
+    crate::TsgoError::Join(compact_format(format_args!(
+        "orchestrator batch worker panicked: {message}"
+    )))
 }


### PR DESCRIPTION
## Summary

- convert `execute_all` worker panics into `TsgoError::Join` instead of letting scoped threads unwind through callers
- recover a poisoned work-queue lock as a structured join error
- make the result channel unbounded so batches larger than `work_queue_capacity` cannot deadlock while the caller is still feeding work
- add regression tests for backpressure and panic reporting

Closes #72

## Validation

- `cargo fmt --all --check`
- `cargo build -p corsa --bin mock_tsgo`
- `cargo test -p corsa --test orchestrator orchestrator_executes_batches_larger_than_work_queue_capacity`
- `cargo test -p corsa --test orchestrator orchestrator_reports_batch_task_panics`

## Risk

Medium-low. The public API is unchanged, but batch execution now normalizes panic paths and removes bounded result-channel backpressure.