### PR TITLE
chore: integrate production-readiness work

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Automation and release policy
+/.github/workflows/ @ubugeeei
+/.github/dependabot.yml @ubugeeei
+/deny.toml @ubugeeei
+
+# Package and Cargo manifests
+**/package.json @ubugeeei
+**/package-lock.json @ubugeeei
+**/pnpm-lock.yaml @ubugeeei
+/pnpm-workspace.yaml @ubugeeei
+**/Cargo.toml @ubugeeei
+/Cargo.lock @ubugeeei
+
+# Release scripts and docs
+/scripts/ @ubugeeei
+/docs/ @ubugeeei
+
+# Language bindings
+/src/bindings/ @ubugeeei

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Report a reproducible problem in corsa-bind.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve corsa-bind. Please include enough detail for maintainers to reproduce the issue.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened, and what did you expect to happen?
+      placeholder: Briefly describe the bug and expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Provide the smallest example, command, or repository that reproduces the issue.
+      placeholder: |
+        1. Run ...
+        2. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include package version, runtime, OS, and any relevant toolchain versions.
+      placeholder: |
+        corsa-bind version:
+        OS:
+        Node.js/Rust/toolchain:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or output
+      description: Paste relevant logs, errors, or stack traces. Redact secrets.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/production_readiness.yml
+++ b/.github/ISSUE_TEMPLATE/production_readiness.yml
@@ -1,0 +1,49 @@
+name: Production readiness
+description: Track a release, operational, security, or reliability readiness concern.
+title: "chore: "
+labels:
+  - production-readiness
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for work that improves confidence in shipping or operating corsa-bind.
+  - type: textarea
+    id: concern
+    attributes:
+      label: Readiness concern
+      description: What risk, gap, or operational need should be addressed?
+      placeholder: Describe the production readiness gap and why it matters.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List the concrete outcomes required to close this issue.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which area is most affected?
+      options:
+        - Release
+        - Security
+        - Observability
+        - Reliability
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add links, constraints, prior discussion, or implementation notes.
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,21 +2,81 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
+    labels:
+      - "dependencies"
+      - "rust"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    open-pull-requests-limit: 5
     schedule:
       interval: "weekly"
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/"
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    open-pull-requests-limit: 5
     schedule:
       interval: "weekly"
+    groups:
+      root-npm-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/bench/cli_compare"
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    open-pull-requests-limit: 5
     schedule:
       interval: "weekly"
+    groups:
+      bench-cli-compare-npm-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/nix/vite-plus"
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    open-pull-requests-limit: 5
     schedule:
       interval: "weekly"
+    groups:
+      nix-vite-plus-npm-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
+    labels:
+      - "dependencies"
+      - "github_actions"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    open-pull-requests-limit: 5
     schedule:
       interval: "weekly"
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Summary
 
-- 
+- Summary of the change
 
 ## Validation
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+- 
+
+## Validation
+
+- [ ] Tests or checks run locally
+- [ ] Not applicable
+
+## Checklist
+
+- [ ] Scope is limited to the described change
+- [ ] Documentation or templates were updated when needed
+- [ ] Follow-up work is tracked in an issue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,10 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  quality:
-    name: Quality (${{ matrix.os }})
+  js-format:
+    name: JS/TS Format (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -30,44 +31,32 @@ jobs:
           - windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
           cache: true
           run-install: true
 
-      - name: Check JS and TS
-        run: vp check
+      - name: Check JS and TS formatting
+        run: vp fmt --check
 
-      - name: Check Rust formatting
-        run: vp run -w fmt_check_rust
-
-      - name: Lint Rust
-        run: vp run -w lint_rust
-
-      - name: Build
-        run: vp run -w build_ci
-
-      - name: Test
-        run: vp run -w test
-
-      - name: Validate public facade without experimental features
-        run: cargo test -p corsa --no-default-features --test orchestrator
-
-  real-tsgo-smoke:
-    name: Real tsgo Smoke (${{ matrix.os }})
+  js-lint-types:
+    name: JS/TS Lint and Types (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -77,22 +66,248 @@ jobs:
           - windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version: "24"
+          cache: true
+          run-install: true
+
+      - name: Check JS and TS lint and types
+        run: vp check --no-fmt
+
+  rust-format:
+    name: Rust Format (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: rustfmt
+
+      - name: Check Rust formatting
+        run: cargo fmt --all --check
+
+  rust-lint:
+    name: Rust Lint (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: clippy
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Lint Rust
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version: "24"
+          cache: true
+          run-install: true
+
+      - name: Build workspace
+        run: vp run -w build_ci
+
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version: "24"
+          cache: true
+          run-install: true
+
+      - name: Test workspace
+        run: vp run -w test
+
+  public-facade:
+    name: Public Facade (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Build mock tsgo binary
+        run: cargo build -p corsa --bin mock_tsgo
+
+      - name: Validate public facade without experimental features
+        run: cargo test -p corsa --no-default-features --test orchestrator
+
+  quality:
+    name: Quality (${{ matrix.os }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - js-format
+      - js-lint-types
+      - rust-format
+      - rust-lint
+      - build
+      - test
+      - public-facade
+    if: ${{ always() }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: Verify focused quality checks
+        env:
+          JS_FORMAT: ${{ needs['js-format'].result }}
+          JS_LINT_TYPES: ${{ needs['js-lint-types'].result }}
+          RUST_FORMAT: ${{ needs['rust-format'].result }}
+          RUST_LINT: ${{ needs['rust-lint'].result }}
+          BUILD: ${{ needs.build.result }}
+          TEST: ${{ needs.test.result }}
+          PUBLIC_FACADE: ${{ needs['public-facade'].result }}
+        run: |
+          failed=0
+          for check in \
+            "JS_FORMAT=$JS_FORMAT" \
+            "JS_LINT_TYPES=$JS_LINT_TYPES" \
+            "RUST_FORMAT=$RUST_FORMAT" \
+            "RUST_LINT=$RUST_LINT" \
+            "BUILD=$BUILD" \
+            "TEST=$TEST" \
+            "PUBLIC_FACADE=$PUBLIC_FACADE"; do
+            name="${check%%=*}"
+            result="${check#*=}"
+            echo "$name: $result"
+            if [ "$result" != "success" ]; then
+              failed=1
+            fi
+          done
+          exit "$failed"
+
+  real-tsgo-smoke:
+    name: Real tsgo Smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Setup Go for pinned tsgo ref
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.26.0"
           cache: false
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
           cache: true
@@ -110,24 +325,27 @@ jobs:
   bench-tsgo-ref:
     name: tsgo Ref Bench
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Setup Go for pinned tsgo ref
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.26.0"
           cache: false
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
           cache: true

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -31,16 +31,18 @@ jobs:
     if: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'push' && startsWith(github.event.workflow_run.head_branch, 'v') && github.event.workflow_run.conclusion == 'success') || (github.event_name == 'workflow_dispatch' && inputs.confirm == 'github-release') }}
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     environment: release
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || inputs.tag }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -34,26 +34,29 @@ jobs:
     if: ${{ (github.event_name == 'push' || inputs.confirm == 'publish-npm') && github.ref_type == 'tag' }}
     name: Release Gates
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Setup Go for pinned tsgo ref
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.26.0"
           cache: false
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
           cache: true
@@ -80,7 +83,7 @@ jobs:
         run: vp run -w bench_verify
 
       - name: Cargo deny
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2
         with:
           command: check advisories bans licenses sources
 
@@ -93,14 +96,17 @@ jobs:
     needs:
       - release-gates
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
 
@@ -117,23 +123,26 @@ jobs:
       - release-gates
       - resolve-native-targets
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.resolve-native-targets.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
           cache: true
@@ -141,7 +150,7 @@ jobs:
 
       - name: Setup Zig for cross-built Linux targets
         if: ${{ matrix.useZig }}
-        uses: goto-bus-stop/setup-zig@v2
+        uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2
 
       - name: Build native binding
         shell: bash
@@ -157,11 +166,12 @@ jobs:
           node ../../../../node_modules/@napi-rs/cli/scripts/index.js "${args[@]}"
 
       - name: Upload native binding artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: native-binding-${{ matrix.target }}
           path: src/bindings/nodejs/corsa_node/*.node
           if-no-files-found: error
+          retention-days: 7
 
   publish:
     if: ${{ (github.event_name == 'push' || inputs.confirm == 'publish-npm') && github.ref_type == 'tag' }}
@@ -170,35 +180,38 @@ jobs:
       - release-gates
       - build-native-bindings
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     environment: release
     permissions:
       contents: read
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Setup Node.js for npm trusted publishing
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
           cache: true
           run-install: true
 
       - name: Download native binding artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           merge-multiple: true
           path: artifacts

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -34,26 +34,29 @@ jobs:
     if: ${{ (github.event_name == 'push' || inputs.confirm == 'publish-rust') && github.ref_type == 'tag' }}
     name: Release Gates
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Setup Go for pinned tsgo ref
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.26.0"
           cache: false
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
           cache: true
@@ -80,7 +83,7 @@ jobs:
         run: vp run -w bench_verify
 
       - name: Cargo deny
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2
         with:
           command: check advisories bans licenses sources
 
@@ -93,29 +96,32 @@ jobs:
     needs:
       - release-gates
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: release
     permissions:
       contents: read
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js for release scripts
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Exchange OIDC token for crates.io token
         if: ${{ github.event_name == 'push' || inputs.auth_mode == 'trusted' }}
         id: auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
 
       - name: Publish ordered crates with trusted publishing
         if: ${{ github.event_name == 'push' || inputs.auth_mode == 'trusted' }}

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -31,5 +31,8 @@ jobs:
           cache: true
           run-install: true
 
+      - name: Verify upstream ref
+        run: vp run -w verify_ref
+
       - name: Validate release artifacts
         run: vp run -w release_dry_run

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: release-dry-run-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -14,18 +18,21 @@ jobs:
   release-dry-run:
     name: Release Dry Run
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
           cache: true

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -12,18 +12,25 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: supply-chain-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   cargo-deny:
     name: Cargo Deny
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Run cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2
         with:
           command: check advisories bans licenses sources

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 
 /ref/corsa-upstream/
 /ref/typescript-go/
+/origin/
 .DS_Store
 .cache
 src/bindings/moonbit/**/_build

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ Current focus:
 Pinned upstream at the time of writing:
 
 - Repository: `https://github.com/microsoft/typescript-go.git`
-- Commit: `9c19dee6ab88ae11444837f16efa16a6b3dc9f59`
-- Lock file: [`tsgo_ref.lock.toml`](./tsgo_ref.lock.toml)
+- Commit: `f4a1d2a1d0d5df4333f2440500e3a6c4b4702d9a`
+- Lock file: [`tsgo_ref.lock.toml`](./tsgo_ref.lock.toml), which is the
+  source of truth for the exact upstream ref and tree.
 
 ## Workspace Layout
 

--- a/bench/src/publish_workflows.test.ts
+++ b/bench/src/publish_workflows.test.ts
@@ -30,7 +30,7 @@ describe("publish workflows", () => {
   it("sets up Node 24 before running the Rust publish script", () => {
     const workflow = readWorkflow(".github/workflows/publish-rust.yml");
     expect(workflow).toContain("Setup Node.js for release scripts");
-    expect(workflow).toContain("uses: actions/setup-node@v6");
+    expect(workflow).toMatch(/uses: actions\/setup-node@[a-f0-9]{40} # v6/);
     expect(workflow).toContain('node-version: "24"');
     expect(workflow).toContain("node --strip-types ./scripts/publish_rust.ts");
   });
@@ -43,7 +43,7 @@ describe("publish workflows", () => {
       "matrix: ${{ fromJSON(needs.resolve-native-targets.outputs.matrix) }}",
     );
     expect(workflow).toContain("Setup Zig for cross-built Linux targets");
-    expect(workflow).toContain("uses: goto-bus-stop/setup-zig@v2");
+    expect(workflow).toMatch(/uses: goto-bus-stop\/setup-zig@[a-f0-9]{40} # v2/);
     expect(workflow).toContain('args+=(--zig-abi-suffix "${{ matrix.zigAbiSuffix }}")');
   });
 });

--- a/docs/ci_guide.md
+++ b/docs/ci_guide.md
@@ -329,6 +329,39 @@ The most important files for this CI stabilization work are:
 - [`../src/bindings/nodejs/typescript_oxlint/ts/rules/type_utils.ts`](../src/bindings/nodejs/typescript_oxlint/ts/rules/type_utils.ts)
 - [`../ref/typescript-go/go.mod`](../ref/typescript-go/go.mod)
 
+## Branch Protection Readiness
+
+Production releases assume that `main` represents reviewed, fully validated
+state. Configure branch protection so direct pushes are blocked and pull
+requests cannot merge until the current CI surface is green.
+
+Required status checks for `main` should include:
+
+- `Quality (ubuntu-latest)`
+- `Quality (macos-latest)`
+- `Quality (windows-latest)`
+- `Real tsgo Smoke (ubuntu-latest)`
+- `Real tsgo Smoke (macos-latest)`
+- `Real tsgo Smoke (windows-latest)`
+- `tsgo Ref Bench`
+- `Cargo Deny`
+- `Release Dry Run`
+
+Enable merge queue once the repository starts accepting concurrent feature PRs
+or release-prep PRs from more than one maintainer. The queue should use the same
+required checks as normal pull requests so release tags are cut only from a
+post-merge commit that has been validated in final `main` order.
+
+The `release` environment should require maintainer approval for workflows that
+publish public artifacts:
+
+- [`publish-rust.yml`](../.github/workflows/publish-rust.yml)
+- [`publish-npm.yml`](../.github/workflows/publish-npm.yml)
+- [`github-release.yml`](../.github/workflows/github-release.yml)
+
+Keep temporary bootstrap secrets scoped to that environment, and remove them
+after trusted publishing is configured for crates.io and npm.
+
 ## Troubleshooting
 
 ## `vp check` says `@corsa-bind/napi` cannot be found

--- a/src/bindings/c/corsa_ffi/src/tests.rs
+++ b/src/bindings/c/corsa_ffi/src/tests.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, ptr};
 
 use crate::{
     api_client::{
@@ -15,7 +15,8 @@ use crate::{
     types::{CorsaStrRef, CorsaString, corsa_utils_string_free, corsa_utils_string_list_free},
     utils::{
         corsa_utils_classify_type_text, corsa_utils_has_unsafe_any_flow,
-        corsa_utils_is_error_like_type_texts, corsa_utils_split_type_text,
+        corsa_utils_is_any_like_type_texts, corsa_utils_is_error_like_type_texts,
+        corsa_utils_split_top_level_type_text, corsa_utils_split_type_text,
     },
     virtual_document::{
         corsa_virtual_document_free, corsa_virtual_document_splice, corsa_virtual_document_text,
@@ -27,6 +28,28 @@ fn text_ref(text: &str) -> CorsaStrRef {
     CorsaStrRef {
         ptr: text.as_ptr(),
         len: text.len(),
+    }
+}
+
+fn null_text_ref() -> CorsaStrRef {
+    CorsaStrRef {
+        ptr: ptr::null(),
+        len: 8,
+    }
+}
+
+fn empty_text_ref() -> CorsaStrRef {
+    CorsaStrRef {
+        ptr: ptr::dangling(),
+        len: 0,
+    }
+}
+
+fn invalid_utf8_ref() -> CorsaStrRef {
+    static INVALID_UTF8: [u8; 3] = [0x66, 0x80, 0x6f];
+    CorsaStrRef {
+        ptr: INVALID_UTF8.as_ptr(),
+        len: INVALID_UTF8.len(),
     }
 }
 
@@ -48,6 +71,28 @@ fn take_string(value: CorsaString) -> String {
     text
 }
 
+fn take_string_list(value: crate::types::CorsaStringList) -> Vec<String> {
+    let values = if value.ptr.is_null() {
+        Vec::new()
+    } else {
+        unsafe { std::slice::from_raw_parts(value.ptr, value.len) }
+            .iter()
+            .map(|value| unsafe {
+                std::str::from_utf8(std::slice::from_raw_parts(
+                    value.ptr.cast::<u8>(),
+                    value.len,
+                ))
+                .unwrap()
+                .to_owned()
+            })
+            .collect::<Vec<_>>()
+    };
+    unsafe {
+        corsa_utils_string_list_free(value);
+    }
+    values
+}
+
 fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .ancestors()
@@ -66,6 +111,83 @@ fn mock_tsgo_binary() -> Option<PathBuf> {
 }
 
 #[test]
+fn treats_null_and_empty_str_refs_as_empty_utility_inputs() {
+    assert_eq!(
+        take_string(unsafe { corsa_utils_classify_type_text(null_text_ref()) }),
+        "other"
+    );
+    assert_eq!(
+        take_string(unsafe { corsa_utils_classify_type_text(empty_text_ref()) }),
+        "other"
+    );
+    assert_eq!(
+        take_string_list(unsafe { corsa_utils_split_type_text(null_text_ref()) }),
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        take_string_list(unsafe {
+            corsa_utils_split_top_level_type_text(empty_text_ref(), b'|' as u32)
+        }),
+        Vec::<String>::new()
+    );
+
+    let type_texts = [null_text_ref(), empty_text_ref()];
+    assert!(!unsafe { corsa_utils_is_any_like_type_texts(type_texts.as_ptr(), type_texts.len()) });
+    assert!(!unsafe {
+        corsa_utils_has_unsafe_any_flow(
+            type_texts.as_ptr(),
+            type_texts.len(),
+            type_texts.as_ptr(),
+            type_texts.len(),
+        )
+    });
+}
+
+#[test]
+fn returns_safe_defaults_for_invalid_utf8_utility_inputs() {
+    assert_eq!(
+        take_string(unsafe { corsa_utils_classify_type_text(invalid_utf8_ref()) }),
+        "other"
+    );
+    assert_eq!(
+        take_string_list(unsafe { corsa_utils_split_type_text(invalid_utf8_ref()) }),
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        take_string_list(unsafe {
+            corsa_utils_split_top_level_type_text(invalid_utf8_ref(), b'|' as u32)
+        }),
+        Vec::<String>::new()
+    );
+
+    let type_texts = [text_ref("any"), invalid_utf8_ref()];
+    assert!(!unsafe { corsa_utils_is_any_like_type_texts(type_texts.as_ptr(), type_texts.len()) });
+    assert!(!unsafe {
+        corsa_utils_has_unsafe_any_flow(
+            type_texts.as_ptr(),
+            type_texts.len(),
+            type_texts.as_ptr(),
+            type_texts.len(),
+        )
+    });
+}
+
+#[test]
+fn reports_invalid_utf8_for_ffi_inputs_that_set_last_error() {
+    let document = unsafe {
+        corsa_virtual_document_untitled(
+            text_ref("/demo.ts"),
+            invalid_utf8_ref(),
+            text_ref("const value = 1;"),
+        )
+    };
+    assert!(document.is_null());
+
+    let message = take_string(corsa_error_message_take());
+    assert!(message.contains("language_id must be valid UTF-8"));
+}
+
+#[test]
 fn classifies_type_texts_over_ffi() {
     let result = unsafe { corsa_utils_classify_type_text(text_ref("Promise<string> | null")) };
     let text = take_string(result);
@@ -75,20 +197,7 @@ fn classifies_type_texts_over_ffi() {
 #[test]
 fn splits_type_texts_over_ffi() {
     let result = unsafe { corsa_utils_split_type_text(text_ref("string | Array<any>")) };
-    let values = unsafe { std::slice::from_raw_parts(result.ptr, result.len) }
-        .iter()
-        .map(|value| unsafe {
-            std::str::from_utf8(std::slice::from_raw_parts(
-                value.ptr.cast::<u8>(),
-                value.len,
-            ))
-            .unwrap()
-            .to_owned()
-        })
-        .collect::<Vec<_>>();
-    unsafe {
-        corsa_utils_string_list_free(result);
-    }
+    let values = take_string_list(result);
     assert_eq!(values, vec!["string", "Array<any>"]);
 }
 

--- a/src/bindings/rust/corsa/tests/orchestrator.rs
+++ b/src/bindings/rust/corsa/tests/orchestrator.rs
@@ -123,6 +123,46 @@ fn orchestrator_executes_parallel_batches() {
 }
 
 #[test]
+fn orchestrator_executes_batches_larger_than_work_queue_capacity() {
+    run_async_test(async {
+        let orchestrator = ApiOrchestrator::new(ApiOrchestratorConfig {
+            work_queue_capacity: 1,
+            ..ApiOrchestratorConfig::default()
+        });
+        let profile = support::api_profile("async-batch-backpressure", ApiMode::AsyncJsonRpcStdio);
+        let values = orchestrator
+            .execute_all(&profile, 2, 0_u32..8, |_, value| async move {
+                Ok::<_, corsa::TsgoError>(value)
+            })
+            .await
+            .unwrap();
+        assert_eq!(values.as_slice(), &[0, 1, 2, 3, 4, 5, 6, 7]);
+    });
+}
+
+#[test]
+fn orchestrator_reports_batch_task_panics() {
+    run_async_test(async {
+        let orchestrator = ApiOrchestrator::default();
+        let profile = support::api_profile("async-batch-panic", ApiMode::AsyncJsonRpcStdio);
+        let error = orchestrator
+            .execute_all(&profile, 1, [1_u32], |_, _| async move {
+                panic!("batch task exploded");
+                #[allow(unreachable_code)]
+                Ok::<_, corsa::TsgoError>(0_u32)
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("orchestrator batch worker panicked: batch task exploded"),
+            "{error}"
+        );
+    });
+}
+
+#[test]
 fn orchestrator_skips_worker_start_for_empty_batches() {
     run_async_test(async {
         let orchestrator = ApiOrchestrator::default();

--- a/src/core/corsa_core/src/process.rs
+++ b/src/core/corsa_core/src/process.rs
@@ -1,12 +1,12 @@
 use crate::{
-    Result,
+    Result, TsgoError,
     fast::{CompactString, SmallVec},
 };
 use std::{
     ffi::OsStr,
     path::PathBuf,
     process::{Child, Stdio},
-    sync::Mutex,
+    sync::{Mutex, TryLockError},
     thread,
     time::{Duration, Instant},
 };
@@ -137,23 +137,40 @@ impl AsyncChildGuard {
     ///
     /// The process is always reaped before this method returns successfully.
     pub async fn shutdown(&self, wait_for: Duration) -> Result<()> {
-        let mut child = self.child.lock().unwrap();
+        let (mut child, poisoned) = match self.child.lock() {
+            Ok(child) => (child, false),
+            Err(poisoned) => (poisoned.into_inner(), true),
+        };
         let Some(mut child) = child.take() else {
-            return Ok(());
+            return if poisoned {
+                Err(process_guard_poisoned())
+            } else {
+                Ok(())
+            };
         };
         wait_for_child_exit(&mut child, wait_for)?;
+        if poisoned {
+            return Err(process_guard_poisoned());
+        }
         Ok(())
     }
 }
 
 impl Drop for AsyncChildGuard {
     fn drop(&mut self) {
-        if let Ok(mut child) = self.child.try_lock()
-            && let Some(child) = child.as_mut()
-        {
+        let mut child = match self.child.try_lock() {
+            Ok(child) => child,
+            Err(TryLockError::Poisoned(poisoned)) => poisoned.into_inner(),
+            Err(TryLockError::WouldBlock) => return,
+        };
+        if let Some(child) = child.as_mut() {
             let _ = terminate_child_process(child);
         }
     }
+}
+
+fn process_guard_poisoned() -> TsgoError {
+    TsgoError::Join(CompactString::from("process guard lock poisoned"))
 }
 
 /// Waits for a child process to exit and forcefully terminates it after a timeout.

--- a/src/core/corsa_orchestrator/src/orchestrator/api.rs
+++ b/src/core/corsa_orchestrator/src/orchestrator/api.rs
@@ -10,7 +10,9 @@ use log::warn;
 use parking_lot::{Mutex, RwLock};
 use serde::{Serialize, de::DeserializeOwned};
 use std::{
+    any::Any,
     collections::VecDeque,
+    panic::{AssertUnwindSafe, catch_unwind},
     sync::mpsc,
     sync::{
         Arc,
@@ -290,7 +292,7 @@ impl ApiOrchestrator {
         let queue_capacity = self.config.work_queue_capacity.max(1);
         let (work_tx, work_rx) = mpsc::sync_channel::<(usize, T)>(queue_capacity);
         let work_rx = Arc::new(std::sync::Mutex::new(work_rx));
-        let (result_tx, result_rx) = mpsc::sync_channel::<Result<(usize, R)>>(queue_capacity);
+        let (result_tx, result_rx) = mpsc::channel::<Result<(usize, R)>>();
         thread::scope(|scope| {
             for _ in 0..replicas.max(1) {
                 let profile = profile.clone();
@@ -298,14 +300,25 @@ impl ApiOrchestrator {
                 let result_tx = result_tx.clone();
                 scope.spawn(move || {
                     loop {
-                        let job = work_rx.lock().unwrap().recv();
+                        let job = match work_rx.lock() {
+                            Ok(work_rx) => work_rx.recv(),
+                            Err(_) => {
+                                let _ = result_tx.send(Err(crate::TsgoError::Join(
+                                    CompactString::from("orchestrator work queue lock poisoned"),
+                                )));
+                                break;
+                            }
+                        };
                         let Ok((index, input)) = job else {
                             break;
                         };
-                        let output = block_on(async {
-                            let client = self.lease(&profile).await?;
-                            Ok::<_, crate::TsgoError>((index, task(client, input).await?))
-                        });
+                        let output = catch_unwind(AssertUnwindSafe(|| {
+                            block_on(async {
+                                let client = self.lease(&profile).await?;
+                                Ok::<_, crate::TsgoError>((index, task(client, input).await?))
+                            })
+                        }))
+                        .unwrap_or_else(|panic| Err(batch_worker_panic(panic)));
                         if result_tx.send(output).is_err() {
                             break;
                         }
@@ -386,4 +399,15 @@ impl ApiOrchestrator {
             }
         }
     }
+}
+
+fn batch_worker_panic(panic: Box<dyn Any + Send>) -> crate::TsgoError {
+    let message = panic
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("unknown panic payload");
+    crate::TsgoError::Join(compact_format(format_args!(
+        "orchestrator batch worker panicked: {message}"
+    )))
 }

--- a/src/core/corsa_orchestrator/src/orchestrator/api.rs
+++ b/src/core/corsa_orchestrator/src/orchestrator/api.rs
@@ -1,3 +1,4 @@
+use super::panic_payload::panic_payload_message;
 use crate::Result;
 use crate::api::{ApiClient, ApiProfile, ManagedSnapshot, UpdateSnapshotParams};
 use corsa_core::{
@@ -402,11 +403,7 @@ impl ApiOrchestrator {
 }
 
 fn batch_worker_panic(panic: Box<dyn Any + Send>) -> crate::TsgoError {
-    let message = panic
-        .downcast_ref::<&str>()
-        .copied()
-        .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
-        .unwrap_or("unknown panic payload");
+    let message = panic_payload_message(panic.as_ref());
     crate::TsgoError::Join(compact_format(format_args!(
         "orchestrator batch worker panicked: {message}"
     )))

--- a/src/core/corsa_orchestrator/src/orchestrator/mod.rs
+++ b/src/core/corsa_orchestrator/src/orchestrator/mod.rs
@@ -7,6 +7,7 @@
 mod api;
 #[cfg(feature = "experimental-distributed")]
 mod distributed;
+mod panic_payload;
 #[cfg(feature = "experimental-distributed")]
 mod raft;
 #[cfg(feature = "experimental-distributed")]

--- a/src/core/corsa_orchestrator/src/orchestrator/panic_payload.rs
+++ b/src/core/corsa_orchestrator/src/orchestrator/panic_payload.rs
@@ -1,0 +1,9 @@
+use std::{any::Any, string::String};
+
+pub(crate) fn panic_payload_message(panic: &(dyn Any + Send)) -> &str {
+    panic
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("unknown panic payload")
+}


### PR DESCRIPTION
## Summary

- locally merge the production-readiness PR stack so we can debug CI once instead of waiting on ten independent queues
- include CODEOWNERS, Dependabot grouping, GitHub issue/PR templates, README upstream pin docs, release-ref verification, FFI edge coverage, process/orchestrator hardening, branch protection docs, and CI/CD hardening
- fix integrated CI fallout from action SHA pinning by updating workflow assertions to accept immutable SHAs with readable version comments
- keep the orchestrator panic hardening while moving panic payload string handling out of the fast-path policy surface
- remove stale tracked `origin/*` gitlinks that had no `.gitmodules` entries and caused hardened Windows checkout to fail before tests ran

Supersedes #76, #77, #78, #79, #80, #81, #82, #85, #86, and #88.

Closes #65
Closes #66
Closes #67
Closes #68
Closes #69
Closes #70
Closes #71
Closes #72
Closes #73
Closes #75
Closes #87
Closes #89

## Validation

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "YAML OK #{f}" }'`
- verified no workflow action references still use moving tags or branches
- verified no workflow action references are missing `@<sha>`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.yml`
- `vp install`
- `vp fmt --check`
- `vp check --no-fmt`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p corsa --test policy`
- `cargo test -p corsa --no-default-features --test orchestrator`
- `vp run -w build_ci`
- `vp run -w test`
- `git submodule foreach --recursive 'echo ok'`
- `git diff --check`

## Notes

Local validation initially exposed two real integration issues: workflow tests still expected moving action tags after SHA pinning, and the orchestrator panic fix tripped the fast-path allocation policy. Both are fixed in this integration branch. GitHub Actions then exposed a Windows checkout failure caused by stale tracked `origin/*` gitlinks without `.gitmodules` entries; those legacy gitlinks are now removed and ignored.
