### PR TITLE
docs: add production readiness audit

### DIFF
--- a/docs/production_readiness.md
+++ b/docs/production_readiness.md
@@ -2,6 +2,8 @@
 
 This document is the short operational checklist for running `corsa` in production-style environments.
 
+For the current source-level gap register, see [Production Readiness Audit](./production_readiness_audit.md).
+
 ## Scope
 
 The current production target is:

--- a/docs/production_readiness_audit.md
+++ b/docs/production_readiness_audit.md
@@ -1,0 +1,46 @@
+# Production Readiness Audit
+
+This audit records the source-level gaps that currently block a fully
+production-ready posture. It was prepared from the tracked implementation on
+2026-05-21, covering the Rust core, JSON-RPC transport, client lifecycle,
+orchestrator, Node binding, oxlint integration, C ABI, non-Node bindings, CI,
+and release workflows.
+
+The project already has meaningful production controls: bounded defaults,
+release dry runs, cargo-deny, pinned GitHub Actions, npm provenance, Scorecard
+monitoring, and an explicit experimental scope for distributed mode. The items
+below are the remaining issues that should be resolved or explicitly accepted
+before treating every public surface as production-ready.
+
+## Findings
+
+| Priority | Issue                                                     | Area               | Production risk                                                                                                   |
+| -------- | --------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| P0       | [#94](https://github.com/ubugeeei/corsa-bind/issues/94)   | Orchestrator       | `execute_all` can deadlock when bounded work and result queues apply backpressure to larger batches.              |
+| P0       | [#98](https://github.com/ubugeeei/corsa-bind/issues/98)   | C ABI              | Returned strings assume no interior NUL bytes, so user-controlled text can panic across FFI boundaries.           |
+| P1       | [#96](https://github.com/ubugeeei/corsa-bind/issues/96)   | JSON-RPC           | Connection shutdown drops the reader handle instead of deterministically closing and joining it.                  |
+| P1       | [#97](https://github.com/ubugeeei/corsa-bind/issues/97)   | Client lifecycle   | Concurrent `initialize` and capability callers can race and send duplicate handshakes.                            |
+| P1       | [#99](https://github.com/ubugeeei/corsa-bind/issues/99)   | FFI wrappers       | Optional payloads and errors share the same absent-byte shape, making wrappers misclassify valid empty responses. |
+| P1       | [#101](https://github.com/ubugeeei/corsa-bind/issues/101) | oxlint integration | Type-aware lint sessions can compute type data from stale on-disk text instead of the source being linted.        |
+| P2       | [#95](https://github.com/ubugeeei/corsa-bind/issues/95)   | Snapshot cleanup   | Snapshot drop spawns detached cleanup work per release and hides release failures.                                |
+| P2       | [#100](https://github.com/ubugeeei/corsa-bind/issues/100) | Node binding       | Synchronous N-API methods block the JavaScript event loop during tsgo requests.                                   |
+| P2       | [#102](https://github.com/ubugeeei/corsa-bind/issues/102) | CI coverage        | Non-Node language bindings are present without first-class compile or smoke-test coverage.                        |
+| P2       | [#103](https://github.com/ubugeeei/corsa-bind/issues/103) | Supply chain       | Published artifacts do not yet include generated SBOMs.                                                           |
+
+## Readiness Gate
+
+Before declaring the whole project production-ready, the release owner should:
+
+- close or explicitly risk-accept every P0 and P1 issue
+- make each supported binding compile and smoke-test in CI
+- document unsupported or experimental bindings in the public support matrix
+- attach SBOMs, or document a replacement attestation strategy, for public binary
+  distribution
+- rerun the release checklist in [Production Readiness Guide](./production_readiness.md)
+
+## Review Notes
+
+This audit intentionally tracks gaps as issues instead of bundling large behavior
+changes into the documentation pull request. The issues contain implementation
+evidence and acceptance criteria so each fix can be reviewed, tested, and
+released independently.

--- a/docs/production_readiness_audit.md
+++ b/docs/production_readiness_audit.md
@@ -3,8 +3,8 @@
 This audit records the source-level gaps that currently block a fully
 production-ready posture. It was prepared from the tracked implementation on
 2026-05-21, covering the Rust core, JSON-RPC transport, client lifecycle,
-orchestrator, Node binding, oxlint integration, C ABI, non-Node bindings, CI,
-and release workflows.
+orchestrator, real `tsgo` typecheck/type emit coverage, Node binding, oxlint
+integration, C ABI, non-Node bindings, CI, and release workflows.
 
 The project already has meaningful production controls: bounded defaults,
 release dry runs, cargo-deny, pinned GitHub Actions, npm provenance, Scorecard
@@ -22,6 +22,7 @@ before treating every public surface as production-ready.
 | P1       | [#97](https://github.com/ubugeeei/corsa-bind/issues/97)   | Client lifecycle   | Concurrent `initialize` and capability callers can race and send duplicate handshakes.                            |
 | P1       | [#99](https://github.com/ubugeeei/corsa-bind/issues/99)   | FFI wrappers       | Optional payloads and errors share the same absent-byte shape, making wrappers misclassify valid empty responses. |
 | P1       | [#101](https://github.com/ubugeeei/corsa-bind/issues/101) | oxlint integration | Type-aware lint sessions can compute type data from stale on-disk text instead of the source being linted.        |
+| P1       | [#105](https://github.com/ubugeeei/corsa-bind/issues/105) | Semantic coverage  | Real-server tests need positive and negative typecheck/type emit fixtures, not only smoke and speed checks.       |
 | P2       | [#95](https://github.com/ubugeeei/corsa-bind/issues/95)   | Snapshot cleanup   | Snapshot drop spawns detached cleanup work per release and hides release failures.                                |
 | P2       | [#100](https://github.com/ubugeeei/corsa-bind/issues/100) | Node binding       | Synchronous N-API methods block the JavaScript event loop during tsgo requests.                                   |
 | P2       | [#102](https://github.com/ubugeeei/corsa-bind/issues/102) | CI coverage        | Non-Node language bindings are present without first-class compile or smoke-test coverage.                        |
@@ -32,6 +33,7 @@ before treating every public surface as production-ready.
 Before declaring the whole project production-ready, the release owner should:
 
 - close or explicitly risk-accept every P0 and P1 issue
+- prove real typecheck and type emit behavior with paired pass/fail fixtures
 - make each supported binding compile and smoke-test in CI
 - document unsupported or experimental bindings in the public support matrix
 - attach SBOMs, or document a replacement attestation strategy, for public binary


### PR DESCRIPTION
## Summary

- Add a source-level production readiness audit that records the remaining blockers to a fully production-ready posture.
- Link the existing production readiness guide to the audit register.
- Track each finding as a conventional GitHub issue with evidence and acceptance criteria.
- Clarify that real typecheck/type emit correctness needs paired pass/fail fixtures, not only smoke tests or benchmark speed.

## Follow-up issues

- #94 `fix(orchestrator): avoid execute_all backpressure deadlock`
- #95 `fix(snapshot): replace release-on-drop thread spawning with bounded cleanup`
- #96 `fix(jsonrpc): close and join reader threads deterministically`
- #97 `fix(client): serialize initialize and capability handshakes`
- #98 `fix(ffi): make C string returns NUL-safe`
- #99 `fix(ffi): distinguish absent payloads from transport errors`
- #100 `feat(node): add nonblocking async APIs for tsgo requests`
- #101 `fix(oxlint): apply source text overlays in type-aware sessions`
- #102 `ci(bindings): add first-class checks for non-Node language bindings`
- #103 `feat(supply-chain): generate SBOMs for published native artifacts`
- #105 `test(typecheck): add semantic positive and negative fixtures for real tsgo`

## Validation

- `vp fmt docs/production_readiness_audit.md docs/production_readiness.md --check`
- `git diff --check`

Note: local full-repo `vp fmt --check` also sees an unrelated untracked `docs/project_strategy_report.md`, so validation was scoped to the files changed in this PR.
