### PR TITLE
ci(tsgo): derive Go toolchain from upstream go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,10 +300,13 @@ jobs:
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
+      - name: Sync pinned tsgo ref
+        run: cargo run -p corsa_ref --target-dir .cache/corsa-ref-target -- sync
+
       - name: Setup Go for pinned tsgo ref
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.0"
+          go-version-file: ref/typescript-go/go.mod
           cache: false
 
       - name: Setup Vite+
@@ -338,10 +341,13 @@ jobs:
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
+      - name: Sync pinned tsgo ref
+        run: cargo run -p corsa_ref --target-dir .cache/corsa-ref-target -- sync
+
       - name: Setup Go for pinned tsgo ref
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.0"
+          go-version-file: ref/typescript-go/go.mod
           cache: false
 
       - name: Setup Vite+

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -54,10 +54,13 @@ jobs:
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
+      - name: Sync pinned tsgo ref
+        run: cargo run -p corsa_ref --target-dir .cache/corsa-ref-target -- sync
+
       - name: Setup Go for pinned tsgo ref
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.0"
+          go-version-file: ref/typescript-go/go.mod
           cache: false
 
       - name: Setup Vite+

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -49,10 +49,13 @@ jobs:
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
+      - name: Sync pinned tsgo ref
+        run: cargo run -p corsa_ref --target-dir .cache/corsa-ref-target -- sync
+
       - name: Setup Go for pinned tsgo ref
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.0"
+          go-version-file: ref/typescript-go/go.mod
           cache: false
 
       - name: Setup Vite+

--- a/docs/ci_guide.md
+++ b/docs/ci_guide.md
@@ -317,6 +317,9 @@ Using `go-version-file` means:
 - CI follows upstream automatically when the pinned ref moves
 - there is less room for silent drift
 
+Because `ref/typescript-go` is a managed checkout, fresh CI jobs must run
+`corsa_ref sync` before `actions/setup-go` can read `ref/typescript-go/go.mod`.
+
 ## Reproducibility Beats Convenience
 
 Repo-local caches, explicit shell environments, and strict ref verification all make the workflow a little more opinionated.

--- a/docs/production_readiness_audit.md
+++ b/docs/production_readiness_audit.md
@@ -27,6 +27,7 @@ before treating every public surface as production-ready.
 | P2       | [#100](https://github.com/ubugeeei/corsa-bind/issues/100) | Node binding       | Synchronous N-API methods block the JavaScript event loop during tsgo requests.                                   |
 | P2       | [#102](https://github.com/ubugeeei/corsa-bind/issues/102) | CI coverage        | Non-Node language bindings are present without first-class compile or smoke-test coverage.                        |
 | P2       | [#103](https://github.com/ubugeeei/corsa-bind/issues/103) | Supply chain       | Published artifacts do not yet include generated SBOMs.                                                           |
+| P2       | [#108](https://github.com/ubugeeei/corsa-bind/issues/108) | CI reproducibility | Real-tsgo CI and release gates hardcode Go instead of deriving it from the pinned upstream go.mod.                |
 
 ## Readiness Gate
 


### PR DESCRIPTION
## Summary

- Replace hardcoded Go versions in real `tsgo` CI and release gates with `go-version-file: ref/typescript-go/go.mod`.
- Sync the managed upstream checkout before `setup-go` reads the upstream `go.mod` in fresh CI jobs.
- Track the new production readiness finding in the audit register.

## Why

The upstream checkout already declares the required Go version. Reading that file directly keeps CI and release validation aligned when the pinned `typescript-go` ref moves.

Closes #108.

## Validation

- `vp fmt --check .github/workflows/ci.yml .github/workflows/publish-rust.yml .github/workflows/publish-npm.yml docs/production_readiness_audit.md docs/ci_guide.md`
- `git diff --check`

Note: full `vp fmt --check` currently fails only on pre-existing untracked `docs/project_strategy_report.md`, which is intentionally left out of this PR.