### PR TITLE
fix(production): harden final release readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,9 @@ jobs:
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
-          cache: true
+          # Windows can fail inside setup-vp's dependency cache resolver after
+          # the managed typescript-go checkout has been materialized.
+          cache: ${{ runner.os != 'Windows' }}
           run-install: true
 
       - name: Build pinned tsgo binary

--- a/src/bindings/rust/corsa/src/bin/mock_tsgo/main.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_tsgo/main.rs
@@ -12,7 +12,11 @@ fn main() -> Result<()> {
     let cwd = args
         .windows(2)
         .find_map(|window| (window[0] == "--cwd").then(|| window[1].clone()))
-        .unwrap_or_else(|| std::env::current_dir().unwrap().display().to_string());
+        .unwrap_or_else(|| {
+            std::env::current_dir()
+                .map(|cwd| cwd.display().to_string())
+                .unwrap_or_else(|_| ".".into())
+        });
     let callbacks = args
         .iter()
         .find_map(|arg| arg.strip_prefix("--callbacks="))

--- a/src/core/corsa_client/src/api/client.rs
+++ b/src/core/corsa_client/src/api/client.rs
@@ -254,7 +254,7 @@ impl ApiClient {
             driver.clone(),
             config.profiler.clone(),
             config.release_queue_capacity,
-        ));
+        )?);
         Ok(Self {
             driver,
             initialized: Arc::new(SingleflightCell::default()),
@@ -585,7 +585,7 @@ async fn connect_pipe_socket(path: PathBuf) -> Result<ApiClient> {
         process: None,
         shutdown_timeout: std::time::Duration::from_secs(2),
     });
-    let release_queue = Arc::new(SnapshotReleaseQueue::spawn(driver.clone(), None, 256));
+    let release_queue = Arc::new(SnapshotReleaseQueue::spawn(driver.clone(), None, 256)?);
     Ok(ApiClient {
         driver,
         initialized: Arc::new(SingleflightCell::default()),

--- a/src/core/corsa_client/src/api/methods_diagnostics.rs
+++ b/src/core/corsa_client/src/api/methods_diagnostics.rs
@@ -66,21 +66,18 @@ impl ApiClient {
         project: super::ProjectHandle,
         file: impl Into<DocumentIdentifier>,
     ) -> Result<FileDiagnosticsResponse> {
+        let mut params_value = serde_json::to_value(SnapshotFileRequest {
+            snapshot,
+            file: file.into(),
+        })?;
+        let Some(params) = params_value.as_object_mut() else {
+            return Err(TsgoError::Protocol(
+                "file diagnostics request must serialize to an object".into(),
+            ));
+        };
+        params.insert("project".into(), serde_json::to_value(project)?);
         let value = self
-            .raw_json_request(
-                "getDiagnosticsForFile",
-                serde_json::to_value(SnapshotFileRequest {
-                    snapshot,
-                    file: file.into(),
-                })?
-                .as_object()
-                .cloned()
-                .map(|mut value| {
-                    value.insert("project".into(), serde_json::to_value(project).unwrap());
-                    serde_json::Value::Object(value)
-                })
-                .unwrap_or(serde_json::Value::Null),
-            )
+            .raw_json_request("getDiagnosticsForFile", params_value)
             .await
             .map_err(|error| {
                 ApiClient::map_missing_method(

--- a/src/core/corsa_client/src/api/snapshot.rs
+++ b/src/core/corsa_client/src/api/snapshot.rs
@@ -1,7 +1,7 @@
 use std::{
     panic::{AssertUnwindSafe, catch_unwind},
     sync::{
-        Arc, Mutex,
+        Arc, Mutex, MutexGuard,
         atomic::{AtomicBool, Ordering},
         mpsc,
     },
@@ -35,7 +35,7 @@ impl SnapshotReleaseQueue {
         driver: Arc<ClientDriver>,
         profiler: Option<SharedProfiler>,
         capacity: usize,
-    ) -> Self {
+    ) -> Result<Self> {
         let (tx, rx) =
             mpsc::sync_channel::<SnapshotHandle>(capacity.clamp(1, DEFAULT_RELEASE_QUEUE_CAPACITY));
         let (done_tx, done_rx) = mpsc::sync_channel(1);
@@ -51,18 +51,18 @@ impl SnapshotReleaseQueue {
                 }));
                 let _ = done_tx.send(result);
             })
-            .expect("failed to spawn snapshot release worker");
-        Self {
+            .map_err(TsgoError::Io)?;
+        Ok(Self {
             driver,
             profiler,
             sender: Mutex::new(Some(tx)),
             done: Mutex::new(Some(done_rx)),
             worker: Mutex::new(Some(worker)),
-        }
+        })
     }
 
     pub(crate) fn enqueue(&self, handle: SnapshotHandle) {
-        let Some(sender) = self.sender.lock().unwrap().as_ref().cloned() else {
+        let Some(sender) = lock_unpoisoned(&self.sender).as_ref().cloned() else {
             warn!(
                 "failed to release tsgo snapshot `{}`: release queue is closed",
                 handle.as_str()
@@ -88,7 +88,7 @@ impl SnapshotReleaseQueue {
     }
 
     pub(crate) async fn close(&self, timeout: Duration) -> Result<()> {
-        self.sender.lock().unwrap().take();
+        lock_unpoisoned(&self.sender).take();
         wait_for_worker(self, timeout, "snapshot release queue")
     }
 }
@@ -111,15 +111,15 @@ fn wait_for_worker(
     timeout: Duration,
     operation: &'static str,
 ) -> Result<()> {
-    let done = queue.done.lock().unwrap();
+    let done = lock_unpoisoned(&queue.done);
     let Some(done_rx) = done.as_ref() else {
         return Ok(());
     };
     match done_rx.recv_timeout(timeout) {
         Ok(result) => {
             drop(done);
-            queue.done.lock().unwrap().take();
-            if let Some(worker) = queue.worker.lock().unwrap().take() {
+            lock_unpoisoned(&queue.done).take();
+            if let Some(worker) = lock_unpoisoned(&queue.worker).take() {
                 let _ = worker.join();
             }
             result
@@ -131,6 +131,12 @@ fn wait_for_worker(
         }
         Err(mpsc::RecvTimeoutError::Disconnected) => Err(TsgoError::Closed(operation)),
     }
+}
+
+fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 /// Live snapshot handle with automatic release-on-drop semantics.

--- a/src/core/corsa_orchestrator/src/orchestrator/raft.rs
+++ b/src/core/corsa_orchestrator/src/orchestrator/raft.rs
@@ -161,7 +161,15 @@ impl RaftCluster {
             });
             (leader.current_term, prev_len, prev_term)
         };
-        let entry = nodes.get(leader_id).unwrap().log[prev_len].clone();
+        let entry = nodes
+            .get(leader_id)
+            .and_then(|node| node.log.get(prev_len))
+            .cloned()
+            .ok_or_else(|| {
+                TsgoError::Protocol(compact_format(format_args!(
+                    "raft leader log entry disappeared: {leader_id}"
+                )))
+            })?;
         let mut acknowledgements = 1;
         for (node_id, node) in nodes.iter_mut() {
             if node_id == leader_id {

--- a/src/core/corsa_runtime/src/broadcast.rs
+++ b/src/core/corsa_runtime/src/broadcast.rs
@@ -12,7 +12,7 @@
 
 use smallvec::SmallVec;
 use std::{
-    sync::{Arc, Mutex, mpsc},
+    sync::{Arc, Mutex, MutexGuard, mpsc},
     time::Duration,
 };
 
@@ -60,8 +60,14 @@ impl<T> Sender<T> {
     /// Previously sent values are not replayed.
     pub fn subscribe(&self) -> Receiver<T> {
         let (tx, rx) = mpsc::channel();
-        self.inner.lock().unwrap().push(tx);
+        self.subscribers().push(tx);
         Receiver { inner: rx }
+    }
+
+    fn subscribers(&self) -> MutexGuard<'_, SmallVec<[mpsc::Sender<T>; 4]>> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }
 
@@ -74,7 +80,7 @@ where
     /// Receivers that have been dropped are removed from the subscriber list as
     /// part of this send operation.
     pub fn send(&self, value: T) -> usize {
-        let mut subscribers = self.inner.lock().unwrap();
+        let mut subscribers = self.subscribers();
         let mut delivered = 0;
         subscribers.retain(|subscriber| match subscriber.send(value.clone()) {
             Ok(()) => {
@@ -108,7 +114,7 @@ impl<T> Receiver<T> {
 #[cfg(test)]
 mod tests {
     use super::channel;
-    use std::time::Duration;
+    use std::{thread, time::Duration};
 
     #[test]
     fn broadcast_delivers_to_multiple_receivers() {
@@ -134,5 +140,21 @@ mod tests {
         let (sender, receiver) = channel::<u32>();
         drop(sender);
         assert!(receiver.recv().is_err());
+    }
+
+    #[test]
+    fn sender_recovers_after_subscriber_list_poisoning() {
+        let (sender, first) = channel::<u32>();
+        let inner = sender.inner.clone();
+        let _ = thread::spawn(move || {
+            let _guard = inner.lock().unwrap();
+            panic!("poison subscriber list");
+        })
+        .join();
+
+        let second = sender.subscribe();
+        assert_eq!(sender.send(7_u32), 2);
+        assert_eq!(first.recv_timeout(Duration::from_millis(50)).unwrap(), 7);
+        assert_eq!(second.recv_timeout(Duration::from_millis(50)).unwrap(), 7);
     }
 }

--- a/src/core/corsa_runtime/src/executor.rs
+++ b/src/core/corsa_runtime/src/executor.rs
@@ -8,7 +8,7 @@
 use std::{
     future::Future,
     pin::Pin,
-    sync::{Arc, Condvar, Mutex},
+    sync::{Arc, Condvar, Mutex, MutexGuard},
     task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
 };
 
@@ -27,11 +27,6 @@ use std::{
 /// - `clone`, `wake`, `wake_by_ref`, and `drop` balance the `Arc` strong count
 /// - the parker's notification bit is cleared only immediately before polling,
 ///   so wake-ups emitted during or after the poll are still observed by `park`
-///
-/// # Panics
-///
-/// Panics if writing wake-up state into the internal synchronization primitives
-/// panics, which in practice only happens if a mutex is poisoned.
 ///
 /// # Examples
 ///
@@ -74,20 +69,29 @@ struct Parker {
 
 impl Parker {
     fn clear(&self) {
-        *self.notified.lock().unwrap() = false;
+        *self.lock_notified() = false;
     }
 
     fn wake(&self) {
-        let mut notified = self.notified.lock().unwrap();
+        let mut notified = self.lock_notified();
         *notified = true;
         self.ready.notify_one();
     }
 
     fn park(&self) {
-        let mut notified = self.notified.lock().unwrap();
+        let mut notified = self.lock_notified();
         while !*notified {
-            notified = self.ready.wait(notified).unwrap();
+            notified = self
+                .ready
+                .wait(notified)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
         }
+    }
+
+    fn lock_notified(&self) -> MutexGuard<'_, bool> {
+        self.notified
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }
 
@@ -210,5 +214,21 @@ mod tests {
 
         let value = block_on(SelfWakingFuture { remaining: 256 });
         assert_eq!(value, 123);
+    }
+
+    #[test]
+    fn parker_recovers_after_notification_lock_poisoning() {
+        let parker = super::Parker::default();
+        thread::scope(|scope| {
+            let handle = scope.spawn(|| {
+                let _guard = parker.notified.lock().unwrap();
+                panic!("poison parker");
+            });
+            let _ = handle.join();
+        });
+
+        parker.clear();
+        parker.wake();
+        parker.park();
     }
 }


### PR DESCRIPTION
## Summary

- avoid the Windows `real-tsgo-smoke` setup-vp cache resolver path after the managed `typescript-go` checkout is materialized
- recover from poisoned runtime/snapshot mutexes instead of panicking in production control-plane paths
- propagate snapshot release worker spawn failures, remove a diagnostics serialization `unwrap`, and harden the experimental Raft append invariant
- make the mock tsgo fallback cwd non-panicking

## Validation

- `cargo check --workspace --all-targets`
- `cargo fmt --all --check`
- `git diff --check`
- `vp check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p corsa_runtime -p corsa_client -p corsa_orchestrator`
- `cargo test -p corsa --no-default-features --test orchestrator`
- `vp run -w build_ci`
- `vp run -w test`
- `cargo deny check advisories bans licenses sources`
- `vp run -w release_dry_run`

## Local limitation

- `vp run -w bench_verify` was attempted, but local Go is `go1.22.0` and failed to auto-download the pinned `go 1.26` toolchain for `darwin/arm64`. CI uses `actions/setup-go` from `ref/typescript-go/go.mod`, so the PR CI should exercise this with `go1.26.3`.