### PR TITLE
fix(production): make transport workers fallible

### DIFF
--- a/src/core/corsa_client/src/api/client.rs
+++ b/src/core/corsa_client/src/api/client.rs
@@ -579,7 +579,7 @@ async fn connect_pipe_socket(path: PathBuf) -> Result<ApiClient> {
     let stream = std::os::unix::net::UnixStream::connect(path)?;
     let reader = BufReader::new(stream.try_clone()?);
     let writer = BufWriter::new(stream);
-    let rpc = JsonRpcConnection::spawn(reader, writer, Default::default());
+    let rpc = JsonRpcConnection::try_spawn(reader, writer, Default::default())?;
     let driver = Arc::new(ClientDriver::JsonRpc {
         rpc,
         process: None,

--- a/src/core/corsa_client/src/api/msgpack_worker.rs
+++ b/src/core/corsa_client/src/api/msgpack_worker.rs
@@ -75,36 +75,37 @@ impl MsgpackWorker {
         let process = Arc::new(std::sync::Mutex::new(Some(child)));
         let worker_process = process.clone();
         let (tx, rx) = mpsc::sync_channel::<WorkerCommand>(queue_capacity.max(1));
-        let join = thread::spawn(move || {
-            let mut writer = BufWriter::new(stdin);
-            let mut reader = BufReader::new(stdout);
-            while let Ok(command) = rx.recv() {
-                match command {
-                    WorkerCommand::Request {
-                        method,
-                        payload,
-                        reply,
-                    } => {
-                        let result = write_tuple(&mut writer, MSG_REQUEST, &method, &payload)
-                            .and_then(|_| {
-                                read_response(
-                                    &mut reader,
-                                    &mut writer,
-                                    &method,
-                                    filesystem.as_deref(),
-                                )
-                            });
-                        let _ = reply.send(result.map(|bytes| WorkerResponse { bytes }));
+        let join = thread::Builder::new()
+            .name("corsa-msgpack-worker".into())
+            .spawn(move || {
+                let mut writer = BufWriter::new(stdin);
+                let mut reader = BufReader::new(stdout);
+                while let Ok(command) = rx.recv() {
+                    match command {
+                        WorkerCommand::Request {
+                            method,
+                            payload,
+                            reply,
+                        } => {
+                            let result = write_tuple(&mut writer, MSG_REQUEST, &method, &payload)
+                                .and_then(|_| {
+                                    read_response(
+                                        &mut reader,
+                                        &mut writer,
+                                        &method,
+                                        filesystem.as_deref(),
+                                    )
+                                });
+                            let _ = reply.send(result.map(|bytes| WorkerResponse { bytes }));
+                        }
+                        WorkerCommand::Shutdown => break,
                     }
-                    WorkerCommand::Shutdown => break,
                 }
-            }
-            if let Ok(mut child) = worker_process.lock()
-                && let Some(mut child) = child.take()
-            {
-                let _ = terminate_child_process(&mut child);
-            }
-        });
+                if let Some(mut child) = lock_unpoisoned(&worker_process).take() {
+                    let _ = terminate_child_process(&mut child);
+                }
+            })
+            .map_err(TsgoError::Io)?;
         Ok(Self {
             tx: Mutex::new(Some(tx)),
             join: Mutex::new(Some(join)),
@@ -179,9 +180,7 @@ impl MsgpackWorker {
     }
 
     fn terminate_process(&self, reason: &str) {
-        if let Ok(mut child) = self.process.lock()
-            && let Some(mut child) = child.take()
-        {
+        if let Some(mut child) = lock_unpoisoned(&self.process).take() {
             let _ = terminate_child_process(&mut child);
             observe(
                 self.observer.as_ref(),
@@ -191,6 +190,12 @@ impl MsgpackWorker {
             );
         }
     }
+}
+
+fn lock_unpoisoned<T>(mutex: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 /// Reads tuples until the matching response for `method` arrives.
@@ -263,5 +268,25 @@ fn handle_callback(
             method.as_bytes(),
             error.to_string().as_bytes(),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lock_unpoisoned;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn process_lock_recovers_after_poisoning() {
+        let lock = Arc::new(Mutex::new(1_u8));
+        let poisoned = Arc::clone(&lock);
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoned.lock().unwrap();
+            panic!("poison msgpack process lock");
+        })
+        .join();
+
+        *lock_unpoisoned(&lock) = 2;
+        assert_eq!(*lock_unpoisoned(&lock), 2);
     }
 }

--- a/src/core/corsa_client/src/api/spawn_stdio.rs
+++ b/src/core/corsa_client/src/api/spawn_stdio.rs
@@ -36,7 +36,7 @@ pub(super) async fn spawn_jsonrpc_stdio(
     let stdin = child.stdin.take().ok_or(TsgoError::Closed("api stdin"))?;
     let stdout = child.stdout.take().ok_or(TsgoError::Closed("api stdout"))?;
     let handlers = filesystem.map(jsonrpc_handlers).unwrap_or_default();
-    let rpc = JsonRpcConnection::spawn_with_options(
+    let rpc = JsonRpcConnection::try_spawn_with_options(
         BufReader::new(stdout),
         BufWriter::new(stdin),
         handlers,
@@ -44,7 +44,7 @@ pub(super) async fn spawn_jsonrpc_stdio(
             .with_request_timeout(request_timeout)
             .with_outbound_capacity(outbound_capacity)
             .with_observer_if_some(observer),
-    );
+    )?;
     Ok(ClientDriver::JsonRpc {
         rpc,
         process: Some(Arc::new(AsyncChildGuard::new(child))),

--- a/src/core/corsa_jsonrpc/src/jsonrpc/connection.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/connection.rs
@@ -156,7 +156,21 @@ impl JsonRpcConnection {
         R: BufRead + Send + 'static,
         W: Write + Send + 'static,
     {
-        Self::spawn_with_options(
+        Self::try_spawn(reader, writer, handlers)
+            .expect("failed to spawn jsonrpc connection threads")
+    }
+
+    /// Tries to spawn a connection around a buffered reader and writer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if an operating-system thread cannot be created.
+    pub fn try_spawn<R, W>(reader: R, writer: W, handlers: RpcHandlerMap) -> Result<Self>
+    where
+        R: BufRead + Send + 'static,
+        W: Write + Send + 'static,
+    {
+        Self::try_spawn_with_options(
             reader,
             writer,
             handlers,
@@ -171,6 +185,25 @@ impl JsonRpcConnection {
         handlers: RpcHandlerMap,
         options: JsonRpcConnectionOptions,
     ) -> Self
+    where
+        R: BufRead + Send + 'static,
+        W: Write + Send + 'static,
+    {
+        Self::try_spawn_with_options(reader, writer, handlers, options)
+            .expect("failed to spawn jsonrpc connection threads")
+    }
+
+    /// Tries to spawn a connection around a buffered reader and writer with runtime options.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if an operating-system thread cannot be created.
+    pub fn try_spawn_with_options<R, W>(
+        reader: R,
+        writer: W,
+        handlers: RpcHandlerMap,
+        options: JsonRpcConnectionOptions,
+    ) -> Result<Self>
     where
         R: BufRead + Send + 'static,
         W: Write + Send + 'static,
@@ -191,16 +224,34 @@ impl JsonRpcConnection {
             read_done: Mutex::new(Some(read_done_rx)),
             write_task: Mutex::new(None),
         });
-        let read_inner = Arc::clone(&inner);
         let write_inner = Arc::clone(&inner);
-        *inner.read_task.lock() = Some(thread::spawn(move || {
-            let result = catch_unwind(AssertUnwindSafe(|| read_inner.read_loop(reader)));
-            let _ = read_done_tx.send(result);
-        }));
-        *inner.write_task.lock() = Some(thread::spawn(move || {
-            write_inner.write_loop(writer, outbound_rx);
-        }));
-        Self { inner }
+        let write_task = thread::Builder::new()
+            .name("corsa-jsonrpc-writer".into())
+            .spawn(move || {
+                write_inner.write_loop(writer, outbound_rx);
+            })
+            .map_err(TsgoError::Io)?;
+        *inner.write_task.lock() = Some(write_task);
+
+        let read_inner = Arc::clone(&inner);
+        let read_task = match thread::Builder::new()
+            .name("corsa-jsonrpc-reader".into())
+            .spawn(move || {
+                let result = catch_unwind(AssertUnwindSafe(|| read_inner.read_loop(reader)));
+                let _ = read_done_tx.send(result);
+            }) {
+            Ok(task) => task,
+            Err(error) => {
+                inner.closed.store(true, Ordering::SeqCst);
+                inner.outbound.lock().take();
+                if let Some(task) = inner.write_task.lock().take() {
+                    let _ = task.join();
+                }
+                return Err(TsgoError::Io(error));
+            }
+        };
+        *inner.read_task.lock() = Some(read_task);
+        Ok(Self { inner })
     }
 
     /// Subscribes to inbound events that are not matched by local handlers.

--- a/src/core/corsa_jsonrpc/src/jsonrpc/connection_tests.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/connection_tests.rs
@@ -21,16 +21,18 @@ impl TsgoObserver for EventCollector {
 #[test]
 fn routes_request_and_response() {
     let (client_socket, server_socket) = UnixStream::pair().unwrap();
-    let client = JsonRpcConnection::spawn(
+    let client = JsonRpcConnection::try_spawn(
         BufReader::new(client_socket.try_clone().unwrap()),
         client_socket,
         RpcHandlerMap::default(),
-    );
-    let server = JsonRpcConnection::spawn(
+    )
+    .unwrap();
+    let server = JsonRpcConnection::try_spawn(
         BufReader::new(server_socket.try_clone().unwrap()),
         server_socket,
         RpcHandlerMap::default(),
-    );
+    )
+    .unwrap();
     let events = server.subscribe();
     let waiter = thread::spawn(move || match events.recv().unwrap() {
         InboundEvent::Request { id, method, params } => {
@@ -50,14 +52,15 @@ fn routes_request_and_response() {
 fn request_times_out_when_no_response_arrives() {
     let (client_socket, _server_socket) = UnixStream::pair().unwrap();
     let observer = Arc::new(EventCollector::default());
-    let client = JsonRpcConnection::spawn_with_options(
+    let client = JsonRpcConnection::try_spawn_with_options(
         BufReader::new(client_socket.try_clone().unwrap()),
         client_socket,
         RpcHandlerMap::default(),
         JsonRpcConnectionOptions::new()
             .with_request_timeout(Some(Duration::from_millis(10)))
             .with_observer(observer.clone()),
-    );
+    )
+    .unwrap();
     let error =
         corsa_runtime::block_on(client.request_value("ping", json!({"value": 1}))).unwrap_err();
     assert!(matches!(
@@ -76,11 +79,12 @@ fn request_times_out_when_no_response_arrives() {
 #[test]
 fn close_joins_reader_after_peer_closes() {
     let (client_socket, server_socket) = UnixStream::pair().unwrap();
-    let client = JsonRpcConnection::spawn(
+    let client = JsonRpcConnection::try_spawn(
         BufReader::new(client_socket.try_clone().unwrap()),
         client_socket,
         RpcHandlerMap::default(),
-    );
+    )
+    .unwrap();
     drop(server_socket);
 
     corsa_runtime::block_on(client.close()).unwrap();
@@ -89,11 +93,12 @@ fn close_joins_reader_after_peer_closes() {
 #[test]
 fn close_uses_bounded_reader_join_when_peer_stays_open() {
     let (client_socket, _server_socket) = UnixStream::pair().unwrap();
-    let client = JsonRpcConnection::spawn(
+    let client = JsonRpcConnection::try_spawn(
         BufReader::new(client_socket.try_clone().unwrap()),
         client_socket,
         RpcHandlerMap::default(),
-    );
+    )
+    .unwrap();
     let started = std::time::Instant::now();
 
     corsa_runtime::block_on(client.close()).unwrap();

--- a/src/core/corsa_lsp/src/lsp/client.rs
+++ b/src/core/corsa_lsp/src/lsp/client.rs
@@ -138,7 +138,7 @@ impl LspClient {
         let stdin = child.stdin.take().ok_or(TsgoError::Closed("lsp stdin"))?;
         let stdout = child.stdout.take().ok_or(TsgoError::Closed("lsp stdout"))?;
         Ok(Self {
-            rpc: JsonRpcConnection::spawn_with_options(
+            rpc: JsonRpcConnection::try_spawn_with_options(
                 BufReader::new(stdout),
                 stdin,
                 Default::default(),
@@ -146,7 +146,7 @@ impl LspClient {
                     .with_request_timeout(config.request_timeout)
                     .with_outbound_capacity(config.outbound_capacity)
                     .with_observer_if_some(config.observer.clone()),
-            ),
+            )?,
             process: Arc::new(AsyncChildGuard::new(child)),
             shutdown_timeout: config.shutdown_timeout,
         })


### PR DESCRIPTION
## Summary

- add fallible `try_spawn` / `try_spawn_with_options` constructors for JSON-RPC connections
- use fallible JSON-RPC startup from API, pipe, and LSP production paths so OS thread creation failures surface as `TsgoError::Io`
- make the msgpack worker use a named `thread::Builder` and recover its process guard lock after poisoning during shutdown

## Why

The release hardening pass removed several panic paths, but the long-lived transport workers still created OS threads through infallible `thread::spawn` in production startup paths. Under resource pressure, that can panic instead of returning an actionable error to Node/Rust/FFI callers.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p corsa_jsonrpc -p corsa_client -p corsa_lsp --all-targets`
- `cargo test -p corsa_jsonrpc -p corsa_client -p corsa_lsp`
- `cargo clippy -p corsa_jsonrpc -p corsa_client -p corsa_lsp --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo test -p corsa --test api_async --test api_msgpack --test lsp_stdio`