### PR TITLE
fix: guard transport frame allocations

### DIFF
--- a/src/bindings/rust/corsa/src/bin/mock_tsgo/msgpack.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_tsgo/msgpack.rs
@@ -10,6 +10,7 @@ use std::{
 const MSG_REQUEST: u8 = 1;
 const MSG_CALL_RESPONSE: u8 = 2;
 const MSG_RESPONSE: u8 = 4;
+const MAX_BIN_BYTES: usize = 512 * 1024 * 1024;
 
 pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
     let stdin = std::io::stdin();
@@ -174,7 +175,17 @@ fn read_bin<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
         0xc6 => read_len(reader, 4)?,
         _ => return Err("invalid bin tag".into()),
     };
-    let mut payload = vec![0_u8; len];
+    if len > MAX_BIN_BYTES {
+        return Err(format!(
+            "msgpack bin is too large: {len} bytes exceeds {MAX_BIN_BYTES} byte safety limit"
+        )
+        .into());
+    }
+    let mut payload = Vec::new();
+    payload.try_reserve_exact(len).map_err(|error| {
+        format!("failed to reserve msgpack bin buffer for {len} bytes: {error}")
+    })?;
+    payload.resize(len, 0);
     reader.read_exact(&mut payload)?;
     Ok(payload)
 }
@@ -208,6 +219,13 @@ fn write_tuple<W: Write>(writer: &mut W, kind: u8, method: &[u8], payload: &[u8]
 }
 
 fn write_bin<W: Write>(writer: &mut W, payload: &[u8]) -> Result<()> {
+    if payload.len() > MAX_BIN_BYTES {
+        return Err(format!(
+            "msgpack bin is too large: {} bytes exceeds {MAX_BIN_BYTES} byte safety limit",
+            payload.len()
+        )
+        .into());
+    }
     match payload.len() {
         0..=255 => writer.write_all(&[0xc4, payload.len() as u8])?,
         256..=65535 => {

--- a/src/core/corsa_client/src/api/msgpack_codec.rs
+++ b/src/core/corsa_client/src/api/msgpack_codec.rs
@@ -8,6 +8,7 @@ pub(crate) const MSG_CALL_ERROR: u8 = 3;
 pub(crate) const MSG_RESPONSE: u8 = 4;
 pub(crate) const MSG_ERROR: u8 = 5;
 pub(crate) const MSG_CALL: u8 = 6;
+const MAX_BIN_BYTES: usize = 512 * 1024 * 1024;
 
 #[derive(Debug)]
 pub(crate) struct MsgpackTuple {
@@ -78,7 +79,18 @@ fn read_bin<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
             ))));
         }
     };
-    let mut buf = vec![0_u8; len];
+    if len > MAX_BIN_BYTES {
+        return Err(TsgoError::Protocol(compact_format(format_args!(
+            "msgpack bin is too large: {len} bytes exceeds {MAX_BIN_BYTES} byte safety limit"
+        ))));
+    }
+    let mut buf = Vec::new();
+    buf.try_reserve_exact(len).map_err(|err| {
+        TsgoError::Protocol(compact_format(format_args!(
+            "failed to reserve msgpack bin buffer for {len} bytes: {err}"
+        )))
+    })?;
+    buf.resize(len, 0);
     reader.read_exact(&mut buf)?;
     Ok(buf)
 }
@@ -100,11 +112,19 @@ fn read_len<const N: usize, R: Read>(reader: &mut R) -> Result<usize> {
             reader.read_exact(&mut buf)?;
             Ok(u32::from_be_bytes(buf) as usize)
         }
-        _ => unreachable!(),
+        _ => Err(TsgoError::Protocol(compact_format(format_args!(
+            "unsupported msgpack length width: {N}"
+        )))),
     }
 }
 
 fn write_bin<W: Write>(writer: &mut W, bytes: &[u8]) -> Result<()> {
+    if bytes.len() > MAX_BIN_BYTES {
+        return Err(TsgoError::Protocol(compact_format(format_args!(
+            "msgpack bin is too large: {} bytes exceeds {MAX_BIN_BYTES} byte safety limit",
+            bytes.len()
+        ))));
+    }
     match bytes.len() {
         0..=255 => writer.write_all(&[0xc4, bytes.len() as u8])?,
         256..=65535 => {

--- a/src/core/corsa_client/src/api/msgpack_codec_tests.rs
+++ b/src/core/corsa_client/src/api/msgpack_codec_tests.rs
@@ -1,4 +1,4 @@
-use super::{MSG_CALL, MSG_RESPONSE, TsgoError, read_tuple, write_tuple};
+use super::{MAX_BIN_BYTES, MSG_CALL, MSG_RESPONSE, TsgoError, read_tuple, write_tuple};
 use std::io::Cursor;
 
 #[test]
@@ -54,6 +54,14 @@ fn rejects_invalid_bin_marker() {
     let bytes = [0x93_u8, MSG_CALL, 0xa1, b'x', 0xc4, 0];
     let err = read_tuple(&mut Cursor::new(bytes)).unwrap_err();
     assert!(matches!(err, TsgoError::Protocol(message) if message.contains("expected bin marker")));
+}
+
+#[test]
+fn rejects_oversized_bin_length_before_allocation() {
+    let len = ((MAX_BIN_BYTES as u32) + 1).to_be_bytes();
+    let bytes = [&[0x93_u8, MSG_CALL, 0xc4, 0, 0xc6][..], &len, &[][..]].concat();
+    let err = read_tuple(&mut Cursor::new(bytes)).unwrap_err();
+    assert!(matches!(err, TsgoError::Protocol(message) if message.contains("too large")));
 }
 
 #[test]

--- a/src/core/corsa_core/src/fast.rs
+++ b/src/core/corsa_core/src/fast.rs
@@ -50,6 +50,6 @@ pub type FastSet<T> = FxHashSet<T>;
 /// ```
 pub fn compact_format(args: fmt::Arguments<'_>) -> CompactString {
     let mut value = CompactString::default();
-    value.write_fmt(args).expect("writing into CompactString");
+    let _ = value.write_fmt(args);
     value
 }

--- a/src/core/corsa_jsonrpc/src/jsonrpc/connection.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/connection.rs
@@ -151,13 +151,18 @@ impl JsonRpcConnection {
     /// Spawns a connection around a buffered reader and writer.
     ///
     /// The connection starts background reader/writer threads immediately.
+    #[track_caller]
     pub fn spawn<R, W>(reader: R, writer: W, handlers: RpcHandlerMap) -> Self
     where
         R: BufRead + Send + 'static,
         W: Write + Send + 'static,
     {
-        Self::try_spawn(reader, writer, handlers)
-            .expect("failed to spawn jsonrpc connection threads")
+        match Self::try_spawn(reader, writer, handlers) {
+            Ok(connection) => connection,
+            Err(error) => panic!(
+                "failed to spawn jsonrpc connection threads: {error}. use `JsonRpcConnection::try_spawn` to handle this failure without panicking"
+            ),
+        }
     }
 
     /// Tries to spawn a connection around a buffered reader and writer.
@@ -179,6 +184,7 @@ impl JsonRpcConnection {
     }
 
     /// Spawns a connection around a buffered reader and writer with runtime options.
+    #[track_caller]
     pub fn spawn_with_options<R, W>(
         reader: R,
         writer: W,
@@ -189,8 +195,12 @@ impl JsonRpcConnection {
         R: BufRead + Send + 'static,
         W: Write + Send + 'static,
     {
-        Self::try_spawn_with_options(reader, writer, handlers, options)
-            .expect("failed to spawn jsonrpc connection threads")
+        match Self::try_spawn_with_options(reader, writer, handlers, options) {
+            Ok(connection) => connection,
+            Err(error) => panic!(
+                "failed to spawn jsonrpc connection threads: {error}. use `JsonRpcConnection::try_spawn_with_options` to handle this failure without panicking"
+            ),
+        }
     }
 
     /// Tries to spawn a connection around a buffered reader and writer with runtime options.

--- a/src/core/corsa_jsonrpc/src/jsonrpc/frame.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/frame.rs
@@ -12,6 +12,7 @@ use std::io::{BufRead, Write};
 const HEADER_END: &[u8] = b"\r\n\r\n";
 const CONTENT_LENGTH: &[u8] = b"content-length";
 const MAX_HEADER_BYTES: usize = 16 * 1024;
+const MAX_BODY_BYTES: usize = 512 * 1024 * 1024;
 
 /// Reads a single stdio JSON-RPC frame.
 ///
@@ -41,7 +42,22 @@ where
     R: BufRead,
 {
     let content_length = read_content_length(reader)?;
-    let mut payload = vec![0_u8; content_length];
+    if content_length > MAX_BODY_BYTES {
+        return Err(TsgoError::Protocol(
+            format!(
+                "jsonrpc body is too large: {content_length} bytes exceeds {MAX_BODY_BYTES} byte safety limit"
+            )
+            .into(),
+        ));
+    }
+    let mut payload = Vec::new();
+    payload.try_reserve_exact(content_length).map_err(|err| {
+        TsgoError::Protocol(
+            format!("failed to reserve jsonrpc body buffer for {content_length} bytes: {err}")
+                .into(),
+        )
+    })?;
+    payload.resize(content_length, 0);
     reader.read_exact(&mut payload)?;
     Ok(payload)
 }

--- a/src/core/corsa_jsonrpc/src/jsonrpc/frame_tests.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/frame_tests.rs
@@ -1,4 +1,4 @@
-use super::{MAX_HEADER_BYTES, read_frame, write_frame};
+use super::{MAX_BODY_BYTES, MAX_HEADER_BYTES, read_frame, write_frame};
 use crate::TsgoError;
 use std::io::BufReader;
 #[cfg(unix)]
@@ -61,6 +61,12 @@ fn rejects_overflowing_content_length() {
         build_frame(b"Content-Length: 184467440737095516161\r\n\r\n", br#"{}"#),
         "overflow",
     );
+}
+
+#[test]
+fn rejects_oversized_body_before_allocation() {
+    let header = format!("Content-Length: {}\r\n\r\n", MAX_BODY_BYTES + 1);
+    assert_protocol(build_frame(header.as_bytes(), b""), "body is too large");
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- Add size limits and fallible allocation paths for JSON-RPC frame bodies and msgpack binary payloads.
- Return protocol errors for oversized payloads or allocation failures before reading bodies.
- Improve the panic message on the infallible JSON-RPC spawn wrappers so callers are pointed at the `try_*` APIs.
- Apply the same msgpack payload guard to the mock tsgo binary used by tests.

## Why

Malformed or hostile peers could advertise very large frame lengths and force an allocation panic/OOM path. These paths now fail as normal `TsgoError::Protocol` errors with actionable detail.

## Validation

- `cargo test -p corsa_client -p corsa_jsonrpc`
- `cargo test -p corsa_client -p corsa_jsonrpc -p corsa --bins`
- `cargo fmt --all -- --check`
- `git diff --check`