### PR TITLE
fix: improve CLI failure diagnostics

### DIFF
--- a/src/bindings/rust/corsa/src/bin/bench_real_tsgo/args.rs
+++ b/src/bindings/rust/corsa/src/bin/bench_real_tsgo/args.rs
@@ -79,7 +79,7 @@ pub fn parse() -> Result<Option<Cli>, CompactString> {
                 warm_iterations = parse_usize(read_value(&mut args, &argument)?, &argument)?;
             }
             _ => {
-                return Err(argument);
+                return Err(CompactString::from(format!("unknown option `{argument}`")));
             }
         }
     }
@@ -91,8 +91,21 @@ pub fn parse() -> Result<Option<Cli>, CompactString> {
             "no datasets found; pass --dataset PATH explicitly",
         ));
     }
+    if cold_iterations == 0 {
+        return Err(CompactString::from(
+            "--cold-iterations must be greater than 0",
+        ));
+    }
+    if warm_iterations == 0 {
+        return Err(CompactString::from(
+            "--warm-iterations must be greater than 0",
+        ));
+    }
     if !tsgo_path.exists() {
-        return Err(CompactString::from(tsgo_path.display().to_string()));
+        return Err(CompactString::from(format!(
+            "tsgo executable does not exist: {}",
+            tsgo_path.display()
+        )));
     }
     Ok(Some(Cli {
         root_dir,
@@ -191,7 +204,7 @@ fn read_value(
     flag: &CompactString,
 ) -> Result<CompactString, CompactString> {
     let Some(value) = args.next() else {
-        return Err(CompactString::from(flag.as_str()));
+        return Err(CompactString::from(format!("missing value for `{flag}`")));
     };
     Ok(CompactString::from(value.to_string_lossy().as_ref()))
 }
@@ -209,7 +222,9 @@ fn parse_transport(value: CompactString) -> Result<SmallVec<[ApiMode; 2]>, Compa
             Ok(modes)
         }
         "both" => Ok(both_modes()),
-        _ => Err(value),
+        _ => Err(CompactString::from(format!(
+            "invalid transport `{value}`; expected jsonrpc, msgpack, or both"
+        ))),
     }
 }
 
@@ -217,14 +232,16 @@ fn parse_run_mode(value: CompactString) -> Result<RunMode, CompactString> {
     match value.as_str() {
         "benchmark" => Ok(RunMode::Benchmark),
         "profiling" => Ok(RunMode::Profiling),
-        _ => Err(value),
+        _ => Err(CompactString::from(format!(
+            "invalid run mode `{value}`; expected benchmark or profiling"
+        ))),
     }
 }
 
-fn parse_usize(value: CompactString, _flag: &CompactString) -> Result<usize, CompactString> {
+fn parse_usize(value: CompactString, flag: &CompactString) -> Result<usize, CompactString> {
     value
         .parse::<usize>()
-        .map_err(|_| CompactString::from(value.as_str()))
+        .map_err(|_| CompactString::from(format!("`{flag}` must be an integer, got `{value}`")))
 }
 
 #[cfg(test)]

--- a/src/bindings/rust/corsa/src/bin/bench_real_tsgo/main.rs
+++ b/src/bindings/rust/corsa/src/bin/bench_real_tsgo/main.rs
@@ -15,14 +15,14 @@ fn main() -> ExitCode {
         Ok(Some(cli)) => cli,
         Ok(None) => return ExitCode::SUCCESS,
         Err(message) => {
-            eprintln!("{message}");
+            eprintln!("error: {message}\nhelp: pass --help to see benchmark options");
             return ExitCode::FAILURE;
         }
     };
     match block_on(run(cli)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
-            eprintln!("{error}");
+            eprintln!("{}", error.diagnostic());
             ExitCode::FAILURE
         }
     }

--- a/src/bindings/rust/corsa/src/bin/bench_tooling_compare/args.rs
+++ b/src/bindings/rust/corsa/src/bin/bench_tooling_compare/args.rs
@@ -78,7 +78,7 @@ pub fn parse() -> Result<Option<Cli>, CompactString> {
             "--timeout-ms" => {
                 timeout_ms = parse_u64(read_value(&mut args, &argument)?, &argument)?;
             }
-            _ => return Err(argument),
+            _ => return Err(CompactString::from(format!("unknown option `{argument}`"))),
         }
     }
     if dataset_paths.is_empty() {
@@ -90,10 +90,13 @@ pub fn parse() -> Result<Option<Cli>, CompactString> {
         ));
     }
     if iterations == 0 {
-        return Err(CompactString::from("--iterations must be > 0"));
+        return Err(CompactString::from("--iterations must be greater than 0"));
     }
     if !tsgo_path.exists() {
-        return Err(CompactString::from(tsgo_path.display().to_string()));
+        return Err(CompactString::from(format!(
+            "tsgo executable does not exist: {}",
+            tsgo_path.display()
+        )));
     }
     Ok(Some(Cli {
         root_dir,
@@ -183,7 +186,7 @@ fn read_value(
     flag: &CompactString,
 ) -> Result<CompactString, CompactString> {
     let Some(value) = args.next() else {
-        return Err(CompactString::from(flag.as_str()));
+        return Err(CompactString::from(format!("missing value for `{flag}`")));
     };
     Ok(CompactString::from(value.to_string_lossy().as_ref()))
 }
@@ -201,20 +204,22 @@ fn parse_suite(value: CompactString) -> Result<SmallVec<[Suite; 2]>, CompactStri
             Ok(suites)
         }
         "both" => Ok(both_suites()),
-        _ => Err(value),
+        _ => Err(CompactString::from(format!(
+            "invalid suite `{value}`; expected project-check, workflow, or both"
+        ))),
     }
 }
 
-fn parse_usize(value: CompactString, _flag: &CompactString) -> Result<usize, CompactString> {
+fn parse_usize(value: CompactString, flag: &CompactString) -> Result<usize, CompactString> {
     value
         .parse::<usize>()
-        .map_err(|_| CompactString::from(value.as_str()))
+        .map_err(|_| CompactString::from(format!("`{flag}` must be an integer, got `{value}`")))
 }
 
-fn parse_u64(value: CompactString, _flag: &CompactString) -> Result<u64, CompactString> {
+fn parse_u64(value: CompactString, flag: &CompactString) -> Result<u64, CompactString> {
     value
         .parse::<u64>()
-        .map_err(|_| CompactString::from(value.as_str()))
+        .map_err(|_| CompactString::from(format!("`{flag}` must be an integer, got `{value}`")))
 }
 
 #[cfg(test)]

--- a/src/bindings/rust/corsa/src/bin/bench_tooling_compare/main.rs
+++ b/src/bindings/rust/corsa/src/bin/bench_tooling_compare/main.rs
@@ -15,14 +15,14 @@ fn main() -> ExitCode {
         Ok(Some(cli)) => cli,
         Ok(None) => return ExitCode::SUCCESS,
         Err(message) => {
-            eprintln!("{message}");
+            eprintln!("error: {message}\nhelp: pass --help to see benchmark options");
             return ExitCode::FAILURE;
         }
     };
     match block_on(run(cli)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
-            eprintln!("{error}");
+            eprintln!("{}", error.diagnostic());
             ExitCode::FAILURE
         }
     }

--- a/src/core/corsa_core/src/error.rs
+++ b/src/core/corsa_core/src/error.rs
@@ -46,6 +46,43 @@ pub enum TsgoError {
 pub type Result<T, E = TsgoError> = std::result::Result<T, E>;
 
 impl TsgoError {
+    /// Formats the error for command-line tools with a short recovery hint.
+    pub fn diagnostic(&self) -> CompactString {
+        let mut message = compact_format(format_args!("error: {self}"));
+        if let Some(hint) = self.recovery_hint() {
+            message.push_str("\nhelp: ");
+            message.push_str(hint);
+        }
+        message
+    }
+
+    /// Returns a user-facing hint for broad classes of operational failures.
+    pub fn recovery_hint(&self) -> Option<&'static str> {
+        match self {
+            Self::Io(_) => Some(
+                "check that the referenced paths exist and that the current user has permission to read, write, and execute them",
+            ),
+            Self::Json(_) => {
+                Some("check the JSON payload shape and ensure the peer is returning valid JSON")
+            }
+            Self::Base64(_) => Some("check that binary JSON fields are valid base64"),
+            Self::Closed(_) => Some("retry after starting a fresh tsgo process or client session"),
+            Self::Unsupported(_) => {
+                Some("use a compatible tsgo build or disable the unsupported feature for this run")
+            }
+            Self::Join(_) => Some(
+                "retry the operation; if it repeats, inspect the worker thread or child-process logs above this message",
+            ),
+            Self::Timeout(_) => Some(
+                "increase the request timeout or check whether the tsgo process is still responsive",
+            ),
+            Self::Rpc(_)
+            | Self::Protocol(_)
+            | Self::UnexpectedMessage(_)
+            | Self::InvalidHandle(_) => None,
+        }
+    }
+
     /// Clones an error into a form safe to send to pending waiters.
     ///
     /// Some inner error types are not cheaply cloneable, so this method

--- a/src/core/corsa_ref/src/git.rs
+++ b/src/core/corsa_ref/src/git.rs
@@ -109,18 +109,14 @@ pub fn metadata(path: &Path, revision: &str) -> Result<CommitMetadata> {
 
 /// Clones a repository without checking out a working tree.
 pub fn clone_no_checkout(repository: &str, path: &Path) -> Result<()> {
-    run_git_inherit(
-        None,
-        &[
-            "clone",
-            "--origin",
-            "origin",
-            "--no-checkout",
-            repository,
-            path.to_str().unwrap(),
-        ],
-    )?;
-    Ok(())
+    let status = Command::new("git")
+        .args(["clone", "--origin", "origin", "--no-checkout", repository])
+        .arg(path)
+        .status()?;
+    if status.success() {
+        return Ok(());
+    }
+    Err(git_clone_error(repository, path, status))
 }
 
 /// Fetches a specific commit into the local repository.
@@ -156,26 +152,61 @@ fn run_git_inherit(path: Option<&Path>, args: &[&str]) -> Result<()> {
     if status.success() {
         return Ok(());
     }
-    Err(git_command_error(args))
+    Err(git_command_error(path, args, status, None))
 }
 
 fn run_git_at(path: Option<&Path>, args: &[&str]) -> Result<CompactString> {
     let output = command(path, args).output()?;
     if !output.status.success() {
-        return Err(git_command_error(args));
+        return Err(git_command_error(
+            path,
+            args,
+            output.status,
+            Some(&output.stderr),
+        ));
     }
     Ok(CompactString::from_utf8_lossy(&output.stdout).trim().into())
 }
 
-fn git_command_error(args: &[&str]) -> TsgoError {
+fn git_command_error(
+    path: Option<&Path>,
+    args: &[&str],
+    status: std::process::ExitStatus,
+    stderr: Option<&[u8]>,
+) -> TsgoError {
+    let command = git_command_line(args);
+    let cwd = path
+        .map(|path| compact_format(format_args!("{}", path.display())))
+        .unwrap_or_else(|| CompactString::from("<current directory>"));
+    let stderr = stderr
+        .map(CompactString::from_utf8_lossy)
+        .map(|stderr| CompactString::from(stderr.trim()))
+        .filter(|stderr| !stderr.is_empty());
+    let message = match stderr {
+        Some(stderr) => compact_format(format_args!(
+            "git command failed: {command}\n  cwd: {cwd}\n  status: {status}\n  stderr: {stderr}"
+        )),
+        None => compact_format(format_args!(
+            "git command failed: {command}\n  cwd: {cwd}\n  status: {status}"
+        )),
+    };
+    TsgoError::Protocol(message)
+}
+
+fn git_clone_error(repository: &str, path: &Path, status: std::process::ExitStatus) -> TsgoError {
+    TsgoError::Protocol(compact_format(format_args!(
+        "git command failed: git clone --origin origin --no-checkout {repository} {}\n  cwd: <current directory>\n  status: {status}",
+        path.display()
+    )))
+}
+
+fn git_command_line(args: &[&str]) -> CompactString {
     let mut command = CompactString::from("git");
     for arg in args {
         command.push(' ');
         command.push_str(arg);
     }
-    TsgoError::Protocol(compact_format(format_args!(
-        "git command failed: {command}"
-    )))
+    command
 }
 
 fn command(path: Option<&Path>, args: &[&str]) -> Command {

--- a/src/core/corsa_ref/src/main.rs
+++ b/src/core/corsa_ref/src/main.rs
@@ -3,11 +3,21 @@ use std::{env, path::PathBuf, process::ExitCode};
 use corsa_core::fast::{CompactString, SmallVec, compact_format};
 use corsa_ref::TsgoRefManager;
 
+const HELP: &str = "\
+usage: tsgo_ref [status|verify|sync|pin-current] [LOCKFILE]
+
+commands:
+  status        print the current managed-ref status
+  verify        fail when the managed ref drifts from the lockfile (default)
+  sync          clone/fetch/switch the managed ref to the lockfile pin
+  pin-current   rewrite the lockfile from the current managed ref
+";
+
 fn main() -> ExitCode {
     match run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
-            eprintln!("{err}");
+            eprintln!("{}", err.diagnostic());
             ExitCode::FAILURE
         }
     }
@@ -19,6 +29,10 @@ fn run() -> corsa_core::Result<()> {
         .map(CompactString::from)
         .collect::<SmallVec<[CompactString; 4]>>();
     let command = args.first().map(CompactString::as_str).unwrap_or("verify");
+    if matches!(command, "--help" | "-h" | "help") {
+        println!("{HELP}");
+        return Ok(());
+    }
     let lock_path = args
         .get(1)
         .map(|path| PathBuf::from(path.as_str()))
@@ -34,7 +48,9 @@ fn run() -> corsa_core::Result<()> {
         "sync" => manager.sync(),
         "pin-current" => manager.pin_current(),
         other => Err(corsa_core::TsgoError::Protocol(compact_format(
-            format_args!("unknown tsgo_ref command: {other}"),
+            format_args!(
+                "unknown tsgo_ref command: {other}\nhelp: valid commands are status, verify, sync, and pin-current"
+            ),
         ))),
     }
 }


### PR DESCRIPTION
## What changed

- Add `TsgoError::diagnostic()` and recovery hints for broad operational failure classes.
- Use the richer diagnostic output in `tsgo_ref` and benchmark CLIs.
- Improve benchmark argument errors for missing values, invalid enum values, invalid numbers, zero iterations, and missing tsgo executables.
- Remove a non-UTF-8-sensitive git path unwrap and include git command, cwd, status, and stderr details when git operations fail.
- Add `tsgo_ref --help` output.

## Why

Failure paths were technically handled in many places, but the resulting output was often too terse to act on. This keeps failures non-panicking and gives users enough context to fix the command or environment.

## Validation

- `cargo test -p corsa_ref -p corsa --bins`
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo run -q -p corsa_ref --bin tsgo_ref -- nope`
- `cargo run -q -p corsa --bin bench_tooling_compare -- --iterations nope`