### PR TITLE
fix: harden examples and bench helpers

### DIFF
--- a/examples/rust/observer_events.rs
+++ b/examples/rust/observer_events.rs
@@ -20,7 +20,10 @@ struct EventCollector {
 
 impl TsgoObserver for EventCollector {
     fn on_event(&self, event: &TsgoEvent) {
-        self.events.lock().unwrap().push(event.clone());
+        self.events
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(event.clone());
     }
 }
 
@@ -96,7 +99,7 @@ fn main() -> Result<(), corsa::TsgoError> {
         let events = observer
             .events
             .lock()
-            .unwrap()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
             .iter()
             .map(event_to_value)
             .collect::<Vec<_>>();

--- a/examples/rust/orchestrator_cache.rs
+++ b/examples/rust/orchestrator_cache.rs
@@ -4,6 +4,7 @@ use std::{sync::Arc, time::Duration};
 
 use corsa::{
     api::{ApiMode, ApiProfile, UpdateSnapshotParams},
+    fast::compact_format,
     orchestrator::ApiOrchestrator,
     runtime::block_on,
 };
@@ -53,7 +54,17 @@ fn main() -> Result<(), corsa::TsgoError> {
                 let echoed = client
                     .raw_json_request("echo", json!({ "value": value }))
                     .await?;
-                Ok::<_, corsa::TsgoError>(echoed["value"].as_u64().unwrap() as u32)
+                let Some(echoed_value) = echoed.get("value").and_then(Value::as_u64) else {
+                    return Err(corsa::TsgoError::Protocol(compact_format(format_args!(
+                        "echo response did not contain a numeric `value`: {echoed}"
+                    ))));
+                };
+                let echoed_value = u32::try_from(echoed_value).map_err(|_| {
+                    corsa::TsgoError::Protocol(compact_format(format_args!(
+                        "echo response value is outside u32 range: {echoed_value}"
+                    )))
+                })?;
+                Ok::<_, corsa::TsgoError>(echoed_value)
             })
             .await?;
         let stats = orchestrator.stats();

--- a/examples/rust/support/mod.rs
+++ b/examples/rust/support/mod.rs
@@ -19,17 +19,24 @@ pub fn workspace_root() -> PathBuf {
         if dir.join("pnpm-workspace.yaml").exists() {
             return dir;
         }
-        assert!(
-            dir.pop(),
-            "failed to locate workspace root from {}",
-            env!("CARGO_MANIFEST_DIR")
-        );
+        if !dir.pop() {
+            eprintln!(
+                "failed to locate workspace root from {}; falling back to the crate manifest directory",
+                env!("CARGO_MANIFEST_DIR")
+            );
+            return PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        }
     }
 }
 
 pub fn example_cwd(name: &str) -> PathBuf {
     let cwd = workspace_root().join("target/examples").join(name);
-    std::fs::create_dir_all(&cwd).unwrap();
+    if let Err(error) = std::fs::create_dir_all(&cwd) {
+        eprintln!(
+            "failed to create example working directory at {}: {error}",
+            cwd.display()
+        );
+    }
     cwd
 }
 
@@ -134,5 +141,8 @@ pub fn normalize_path(workspace_root: &Path, value: &str) -> String {
 }
 
 pub fn print_json(value: Value) {
-    println!("{}", serde_json::to_string_pretty(&value).unwrap());
+    match serde_json::to_string_pretty(&value) {
+        Ok(body) => println!("{body}"),
+        Err(error) => eprintln!("failed to render example JSON output: {error}"),
+    }
 }

--- a/src/bindings/rust/corsa/src/bin/bench_real_tsgo/profile.rs
+++ b/src/bindings/rust/corsa/src/bin/bench_real_tsgo/profile.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, sync::Mutex, time::Duration};
+use std::{
+    collections::BTreeMap,
+    sync::{Mutex, MutexGuard},
+    time::Duration,
+};
 
 use corsa::{
     api::{ApiProfileEvent, ApiProfiler},
@@ -21,11 +25,11 @@ pub struct BenchProfiler {
 
 impl BenchProfiler {
     pub fn clear(&self) {
-        self.events.lock().unwrap().clear();
+        self.events().clear();
     }
 
     pub fn drain_iteration_totals(&self) -> BTreeMap<(CompactString, CompactString), Duration> {
-        let mut events = self.events.lock().unwrap();
+        let mut events = self.events();
         let drained = std::mem::take(&mut *events);
         let mut totals = BTreeMap::<(CompactString, CompactString), Duration>::new();
         for event in drained {
@@ -37,11 +41,17 @@ impl BenchProfiler {
         }
         totals
     }
+
+    fn events(&self) -> MutexGuard<'_, SmallVec<[ApiProfileEvent; 32]>> {
+        self.events
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 }
 
 impl ApiProfiler for BenchProfiler {
     fn on_profile(&self, event: &ApiProfileEvent) {
-        self.events.lock().unwrap().push(event.clone());
+        self.events().push(event.clone());
     }
 }
 

--- a/src/bindings/rust/corsa/src/bin/bench_real_tsgo/stats.rs
+++ b/src/bindings/rust/corsa/src/bin/bench_real_tsgo/stats.rs
@@ -18,6 +18,18 @@ impl Stats {
     pub fn from_samples(mut samples: SmallVec<[Duration; 32]>) -> Self {
         samples.sort_unstable();
         let sample_count = samples.len();
+        if sample_count == 0 {
+            return Self {
+                sample_count,
+                min: Duration::ZERO,
+                max: Duration::ZERO,
+                mean: Duration::ZERO,
+                median: Duration::ZERO,
+                p95: Duration::ZERO,
+                p99: Duration::ZERO,
+                stddev: Duration::ZERO,
+            };
+        }
         let min = samples[0];
         let max = samples[samples.len() - 1];
         let median = samples[samples.len() / 2];
@@ -124,5 +136,13 @@ mod tests {
         assert_eq!(stats.max_ms(), 9.0);
         assert!(stats.stddev_ms() > 0.0);
         assert!(stats.cv_percent() > 0.0);
+    }
+
+    #[test]
+    fn stats_handle_empty_samples() {
+        let stats = Stats::from_samples(SmallVec::<[Duration; 32]>::new());
+        assert_eq!(stats.sample_count(), 0);
+        assert_eq!(stats.median_ms(), 0.0);
+        assert_eq!(stats.p95_ms(), 0.0);
     }
 }

--- a/src/bindings/rust/corsa/src/bin/bench_tooling_compare/stats.rs
+++ b/src/bindings/rust/corsa/src/bin/bench_tooling_compare/stats.rs
@@ -18,6 +18,18 @@ impl Stats {
     pub fn from_samples(mut samples: SmallVec<[Duration; 32]>) -> Self {
         samples.sort_unstable();
         let sample_count = samples.len();
+        if sample_count == 0 {
+            return Self {
+                sample_count,
+                min: Duration::ZERO,
+                max: Duration::ZERO,
+                mean: Duration::ZERO,
+                median: Duration::ZERO,
+                p95: Duration::ZERO,
+                p99: Duration::ZERO,
+                stddev: Duration::ZERO,
+            };
+        }
         let min = samples[0];
         let max = samples[samples.len() - 1];
         let median = samples[samples.len() / 2];
@@ -124,5 +136,13 @@ mod tests {
         assert_eq!(stats.max_ms(), 9.0);
         assert!(stats.stddev_ms() > 0.0);
         assert!(stats.cv_percent() > 0.0);
+    }
+
+    #[test]
+    fn stats_handle_empty_samples() {
+        let stats = Stats::from_samples(SmallVec::<[Duration; 32]>::new());
+        assert_eq!(stats.sample_count(), 0);
+        assert_eq!(stats.median_ms(), 0.0);
+        assert_eq!(stats.p95_ms(), 0.0);
     }
 }


### PR DESCRIPTION
## What changed

- Recover from poisoned Mutexes in the observer example and benchmark profiler.
- Replace example response `unwrap` usage with protocol errors that include the unexpected response payload.
- Make example workspace discovery and JSON printing fail with explicit messages instead of panicking.
- Make benchmark `Stats::from_samples` handle empty sample sets defensively.

## Why

These are smaller failure-path cleanups around examples and benchmark helpers. They keep demos and tooling from panicking on incidental setup or poisoning failures, and make surprising responses easier to diagnose.

## Validation

- `cargo test -p corsa --bins`
- `cargo check -p corsa --examples`
- `cargo fmt --all -- --check`
- `git diff --check`