### PR TITLE
fix(jsonrpc): fail pending requests on reader panic

### DIFF
--- a/src/core/corsa_jsonrpc/src/jsonrpc/connection.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/connection.rs
@@ -237,7 +237,13 @@ impl JsonRpcConnection {
         let read_task = match thread::Builder::new()
             .name("corsa-jsonrpc-reader".into())
             .spawn(move || {
+                let panic_inner = Arc::clone(&read_inner);
                 let result = catch_unwind(AssertUnwindSafe(|| read_inner.read_loop(reader)));
+                if result.is_err() {
+                    panic_inner.fail_pending(TsgoError::Join(CompactString::from(
+                        "jsonrpc reader thread panicked",
+                    )));
+                }
                 let _ = read_done_tx.send(result);
             }) {
             Ok(task) => task,

--- a/src/core/corsa_jsonrpc/src/jsonrpc/connection_tests.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/connection_tests.rs
@@ -105,3 +105,56 @@ fn close_uses_bounded_reader_join_when_peer_stays_open() {
 
     assert!(started.elapsed() < Duration::from_secs(2));
 }
+
+#[test]
+fn reader_panic_fails_pending_requests() {
+    let (client_socket, server_socket) = UnixStream::pair().unwrap();
+    let mut handlers = RpcHandlerMap::default();
+    handlers.insert(
+        "boom".into(),
+        Arc::new(
+            |_| -> std::result::Result<serde_json::Value, crate::RpcResponseError> {
+                panic!("jsonrpc test handler panic");
+            },
+        ),
+    );
+    let client = JsonRpcConnection::try_spawn_with_options(
+        BufReader::new(client_socket.try_clone().unwrap()),
+        client_socket,
+        handlers,
+        JsonRpcConnectionOptions::new().with_request_timeout(Some(Duration::from_secs(5))),
+    )
+    .unwrap();
+    let server = JsonRpcConnection::try_spawn(
+        BufReader::new(server_socket.try_clone().unwrap()),
+        server_socket,
+        RpcHandlerMap::default(),
+    )
+    .unwrap();
+    let server_events = server.subscribe();
+    let pending_client = client.clone();
+    let waiter = thread::spawn(move || {
+        corsa_runtime::block_on(pending_client.request_value("never", json!({})))
+    });
+
+    match server_events
+        .recv_timeout(Duration::from_secs(1))
+        .expect("server should receive pending request")
+    {
+        InboundEvent::Request { method, .. } => assert_eq!(method.as_str(), "never"),
+        _ => panic!("unexpected event"),
+    }
+
+    let started = std::time::Instant::now();
+    server.notify("boom", json!({})).unwrap();
+    let error = waiter.join().unwrap().unwrap_err();
+
+    assert!(started.elapsed() < Duration::from_secs(1));
+    assert!(matches!(
+        error,
+        crate::TsgoError::Join(message) if message.contains("jsonrpc reader thread panicked")
+    ));
+
+    let _ = corsa_runtime::block_on(client.close());
+    let _ = corsa_runtime::block_on(server.close());
+}


### PR DESCRIPTION
## Summary

- Fail all pending JSON-RPC requests immediately when the reader thread unwinds after a local handler panic.
- Add a regression test that keeps a request pending, triggers a handler panic through a notification, and verifies the waiter receives a join error instead of waiting for timeout.

## Why

A production transport should not leave callers blocked until request timeout after an internal reader panic. This keeps failure propagation bounded and makes the panic path observable to pending waiters.

## Validation

- `cargo fmt --all --check`
- `cargo test -p corsa_jsonrpc`
- `cargo clippy -p corsa_jsonrpc --all-targets -- -D warnings`
- `git diff --check`