### PR TITLE
ci: add PR performance benchmark comments

### DIFF
--- a/.github/workflows/pr-performance.yml
+++ b/.github/workflows/pr-performance.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   benchmark:
-    name: Benchmark ${{ matrix.ref-role }} TS v${{ matrix.typescript-major }}
+    name: Benchmark ${{ matrix.ref-role }} TypeScript ${{ matrix.typescript.channel }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
@@ -34,9 +34,11 @@ jobs:
         ref-role:
           - base
           - head
-        typescript-major:
-          - "6"
-          - "7"
+        typescript:
+          - channel: "6"
+            package: "typescript@^6"
+          - channel: next
+            package: "typescript@next"
     steps:
       - name: Resolve benchmark ref
         id: bench-ref
@@ -89,11 +91,11 @@ jobs:
       - name: Install benchmark comparison dependencies
         run: vp run -w bench_tooling_setup
 
-      - name: Select TypeScript v${{ matrix.typescript-major }}
+      - name: Select TypeScript ${{ matrix.typescript.channel }}
         shell: bash
         run: |
           set -euo pipefail
-          spec="typescript@^${{ matrix.typescript-major }}"
+          spec="${{ matrix.typescript.package }}"
           npm install --no-save --package-lock=false --legacy-peer-deps --no-fund --no-audit "$spec" --prefix ref/typescript-go
           npm install --no-save --package-lock=false --legacy-peer-deps --no-fund --no-audit "$spec" --prefix bench/cli_compare
           node -p "require('./ref/typescript-go/node_modules/typescript/package.json').version"
@@ -108,28 +110,36 @@ jobs:
             --iterations "$BENCH_ITERATIONS" \
             --warmup-iterations "$BENCH_WARMUP_ITERATIONS" \
             --timeout-ms "$BENCH_TIMEOUT_MS" \
-            --json-output ".cache/pr-benchmark/raw-${{ matrix.ref-role }}-ts${{ matrix.typescript-major }}.json"
+            --json-output ".cache/pr-benchmark/raw-${{ matrix.ref-role }}-ts${{ matrix.typescript.channel }}.json"
+
+      - name: Checkout PR helper scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: .cache/pr-benchmark/workflow-scripts
+          persist-credentials: false
 
       - name: Capture benchmark metadata
         shell: bash
         run: |
           set -euo pipefail
           installed_ts="$(node -p "require('./ref/typescript-go/node_modules/typescript/package.json').version")"
-          node --strip-types ./scripts/pr_benchmark_report.ts capture \
-            --input ".cache/pr-benchmark/raw-${{ matrix.ref-role }}-ts${{ matrix.typescript-major }}.json" \
-            --output ".cache/pr-benchmark/report-${{ matrix.ref-role }}-ts${{ matrix.typescript-major }}.json" \
+          node --strip-types ./.cache/pr-benchmark/workflow-scripts/scripts/pr_benchmark_report.ts capture \
+            --input ".cache/pr-benchmark/raw-${{ matrix.ref-role }}-ts${{ matrix.typescript.channel }}.json" \
+            --output ".cache/pr-benchmark/report-${{ matrix.ref-role }}-ts${{ matrix.typescript.channel }}.json" \
             --branch-role "${{ matrix.ref-role }}" \
             --ref-name "${{ steps.bench-ref.outputs.name }}" \
             --sha "${{ steps.bench-ref.outputs.sha }}" \
-            --typescript-major "${{ matrix.typescript-major }}" \
-            --typescript-requested "typescript@^${{ matrix.typescript-major }}" \
+            --typescript-channel "${{ matrix.typescript.channel }}" \
+            --typescript-requested "${{ matrix.typescript.package }}" \
             --typescript-version "$installed_ts"
 
       - name: Upload benchmark report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: pr-performance-${{ matrix.ref-role }}-ts${{ matrix.typescript-major }}
-          path: .cache/pr-benchmark/report-${{ matrix.ref-role }}-ts${{ matrix.typescript-major }}.json
+          name: pr-performance-${{ matrix.ref-role }}-ts${{ matrix.typescript.channel }}
+          path: .cache/pr-benchmark/report-${{ matrix.ref-role }}-ts${{ matrix.typescript.channel }}.json
           if-no-files-found: error
 
   comment:

--- a/.github/workflows/pr-performance.yml
+++ b/.github/workflows/pr-performance.yml
@@ -1,0 +1,173 @@
+name: PR Performance
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: pr-performance-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  BENCH_ITERATIONS: "5"
+  BENCH_TIMEOUT_MS: "120000"
+  BENCH_WARMUP_ITERATIONS: "1"
+  CARGO_TERM_COLOR: always
+
+jobs:
+  benchmark:
+    name: Benchmark ${{ matrix.ref-role }} TS v${{ matrix.typescript-major }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        ref-role:
+          - base
+          - head
+        typescript-major:
+          - "6"
+          - "7"
+    steps:
+      - name: Resolve benchmark ref
+        id: bench-ref
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.ref-role }}" = "base" ]; then
+            {
+              echo "name=${{ github.event.pull_request.base.ref }}"
+              echo "sha=${{ github.event.pull_request.base.sha }}"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "name=${{ github.event.pull_request.head.ref }}"
+              echo "sha=${{ github.event.pull_request.head.sha }}"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.bench-ref.outputs.sha }}
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Sync pinned tsgo ref
+        run: cargo run -p corsa_ref --target-dir .cache/corsa-ref-target -- sync
+
+      - name: Setup Go for pinned tsgo ref
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: ref/typescript-go/go.mod
+          cache: false
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version: "24"
+          cache: true
+          run-install: true
+
+      - name: Build pinned tsgo binary
+        run: vp run -w build_tsgo
+
+      - name: Install benchmark comparison dependencies
+        run: vp run -w bench_tooling_setup
+
+      - name: Select TypeScript v${{ matrix.typescript-major }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          spec="typescript@^${{ matrix.typescript-major }}"
+          npm install --no-save --package-lock=false --legacy-peer-deps --no-fund --no-audit "$spec" --prefix ref/typescript-go
+          npm install --no-save --package-lock=false --legacy-peer-deps --no-fund --no-audit "$spec" --prefix bench/cli_compare
+          node -p "require('./ref/typescript-go/node_modules/typescript/package.json').version"
+          node -p "require('./bench/cli_compare/node_modules/typescript/package.json').version"
+
+      - name: Run tooling benchmark
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .cache/pr-benchmark
+          cargo run --release -p corsa --bin bench_tooling_compare -- \
+            --iterations "$BENCH_ITERATIONS" \
+            --warmup-iterations "$BENCH_WARMUP_ITERATIONS" \
+            --timeout-ms "$BENCH_TIMEOUT_MS" \
+            --json-output ".cache/pr-benchmark/raw-${{ matrix.ref-role }}-ts${{ matrix.typescript-major }}.json"
+
+      - name: Capture benchmark metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          installed_ts="$(node -p "require('./ref/typescript-go/node_modules/typescript/package.json').version")"
+          node --strip-types ./scripts/pr_benchmark_report.ts capture \
+            --input ".cache/pr-benchmark/raw-${{ matrix.ref-role }}-ts${{ matrix.typescript-major }}.json" \
+            --output ".cache/pr-benchmark/report-${{ matrix.ref-role }}-ts${{ matrix.typescript-major }}.json" \
+            --branch-role "${{ matrix.ref-role }}" \
+            --ref-name "${{ steps.bench-ref.outputs.name }}" \
+            --sha "${{ steps.bench-ref.outputs.sha }}" \
+            --typescript-major "${{ matrix.typescript-major }}" \
+            --typescript-requested "typescript@^${{ matrix.typescript-major }}" \
+            --typescript-version "$installed_ts"
+
+      - name: Upload benchmark report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-performance-${{ matrix.ref-role }}-ts${{ matrix.typescript-major }}
+          path: .cache/pr-benchmark/report-${{ matrix.ref-role }}-ts${{ matrix.typescript-major }}.json
+          if-no-files-found: error
+
+  comment:
+    name: Comment benchmark result
+    runs-on: ubuntu-latest
+    needs: benchmark
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+
+      - name: Download benchmark reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: .cache/pr-benchmark/results
+          pattern: pr-performance-*
+
+      - name: Write benchmark summary
+        run: |
+          node --strip-types ./scripts/pr_benchmark_report.ts comment \
+            --reports-dir .cache/pr-benchmark/results \
+            --output .cache/pr-benchmark/comment.md
+          cat .cache/pr-benchmark/comment.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update PR comment
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          node --strip-types ./scripts/pr_benchmark_report.ts comment \
+            --reports-dir .cache/pr-benchmark/results \
+            --output .cache/pr-benchmark/comment.md \
+            --post-comment

--- a/bench/src/pr_benchmark_report.test.ts
+++ b/bench/src/pr_benchmark_report.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../scripts/pr_benchmark_report.ts";
 
 describe("PR benchmark report", () => {
-  it("compares head means against base means by TypeScript major", () => {
+  it("compares head means against base means by TypeScript channel", () => {
     const comparisons = compareReports([
       captured("base", "6", [
         row("project_check", "api", "tsgo", 100),
@@ -35,13 +35,25 @@ describe("PR benchmark report", () => {
 
   it("renders a sticky PR comment with full rows", () => {
     const body = createCommentBody([
-      captured("base", "7", [row("project_check", "native-preview", "tsc", 200)]),
-      captured("head", "7", [row("project_check", "native-preview", "tsc", 230)]),
+      captured(
+        "base",
+        "next",
+        [row("project_check", "native-preview", "tsc", 200)],
+        "typescript@next",
+        "6.0.0-dev.20260416",
+      ),
+      captured(
+        "head",
+        "next",
+        [row("project_check", "native-preview", "tsc", 230)],
+        "typescript@next",
+        "6.0.0-dev.20260416",
+      ),
     ]);
 
     expect(body).toContain("<!-- corsa-pr-performance-benchmark -->");
     expect(body).toContain("5-sample mean");
-    expect(body).toContain("TS v7");
+    expect(body).toContain("TS next");
     expect(body).toContain("slower");
     expect(body).toContain("+15.00%");
   });
@@ -49,8 +61,10 @@ describe("PR benchmark report", () => {
 
 function captured(
   branchRole: "base" | "head",
-  major: string,
+  channel: string,
   rows: CapturedBenchReport["report"]["rows"],
+  requested = `typescript@^${channel}`,
+  installed = `${channel}.0.0`,
 ): CapturedBenchReport {
   return {
     schemaVersion: 1,
@@ -58,9 +72,9 @@ function captured(
     refName: branchRole === "base" ? "main" : "feature",
     sha: branchRole === "base" ? "1111111111111111111111111111111111111111" : "2222222",
     typescript: {
-      major,
-      requested: `typescript@^${major}`,
-      installed: `${major}.0.0`,
+      channel,
+      requested,
+      installed,
     },
     github: {
       runId: "1",

--- a/bench/src/pr_benchmark_report.test.ts
+++ b/bench/src/pr_benchmark_report.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type CapturedBenchReport,
+  compareReports,
+  createCommentBody,
+} from "../../scripts/pr_benchmark_report.ts";
+
+describe("PR benchmark report", () => {
+  it("compares head means against base means by TypeScript major", () => {
+    const comparisons = compareReports([
+      captured("base", "6", [
+        row("project_check", "api", "tsgo", 100),
+        row("editor_workflow", "api", "corsa-msgpack-warm", 10),
+      ]),
+      captured("head", "6", [
+        row("project_check", "api", "tsgo", 80),
+        row("editor_workflow", "api", "corsa-msgpack-warm", 10.1),
+      ]),
+    ]);
+
+    expect(comparisons).toHaveLength(1);
+    expect(comparisons[0]?.fasterCount).toBe(1);
+    expect(comparisons[0]?.stableCount).toBe(1);
+    expect(comparisons[0]?.rows[0]).toMatchObject({
+      tool: "corsa-msgpack-warm",
+      result: "stable",
+    });
+    expect(comparisons[0]?.rows[1]).toMatchObject({
+      tool: "tsgo",
+      result: "faster",
+      deltaPercent: -20,
+    });
+  });
+
+  it("renders a sticky PR comment with full rows", () => {
+    const body = createCommentBody([
+      captured("base", "7", [row("project_check", "native-preview", "tsc", 200)]),
+      captured("head", "7", [row("project_check", "native-preview", "tsc", 230)]),
+    ]);
+
+    expect(body).toContain("<!-- corsa-pr-performance-benchmark -->");
+    expect(body).toContain("5-sample mean");
+    expect(body).toContain("TS v7");
+    expect(body).toContain("slower");
+    expect(body).toContain("+15.00%");
+  });
+});
+
+function captured(
+  branchRole: "base" | "head",
+  major: string,
+  rows: CapturedBenchReport["report"]["rows"],
+): CapturedBenchReport {
+  return {
+    schemaVersion: 1,
+    branchRole,
+    refName: branchRole === "base" ? "main" : "feature",
+    sha: branchRole === "base" ? "1111111111111111111111111111111111111111" : "2222222",
+    typescript: {
+      major,
+      requested: `typescript@^${major}`,
+      installed: `${major}.0.0`,
+    },
+    github: {
+      runId: "1",
+      runAttempt: "1",
+    },
+    report: {
+      iterations: 5,
+      warmupIterations: 1,
+      timeoutMs: 120_000,
+      rows,
+    },
+  };
+}
+
+function row(
+  workload: string,
+  dataset: string,
+  tool: string,
+  meanMs: number,
+): NonNullable<CapturedBenchReport["report"]["rows"]>[number] {
+  return {
+    workload,
+    dataset,
+    tool,
+    sampleCount: 5,
+    meanMs,
+    medianMs: meanMs,
+    p95Ms: meanMs,
+    minMs: meanMs,
+    maxMs: meanMs,
+  };
+}

--- a/bench/src/publish_workflows.test.ts
+++ b/bench/src/publish_workflows.test.ts
@@ -47,4 +47,13 @@ describe("publish workflows", () => {
     expect(workflow).toContain('cross_arg="--use-napi-cross"');
     expect(workflow).toContain('cross_arg="--cross-compile"');
   });
+
+  it("benchmarks PR base and head against TypeScript 6 and 7", () => {
+    const workflow = readWorkflow(".github/workflows/pr-performance.yml");
+    expect(workflow).toContain('BENCH_ITERATIONS: "5"');
+    expect(workflow).toContain("ref-role:");
+    expect(workflow).toContain("typescript-major:");
+    expect(workflow).toContain("typescript@^${{ matrix.typescript-major }}");
+    expect(workflow).toContain("node --strip-types ./scripts/pr_benchmark_report.ts comment");
+  });
 });

--- a/bench/src/publish_workflows.test.ts
+++ b/bench/src/publish_workflows.test.ts
@@ -48,12 +48,17 @@ describe("publish workflows", () => {
     expect(workflow).toContain('cross_arg="--cross-compile"');
   });
 
-  it("benchmarks PR base and head against TypeScript 6 and 7", () => {
+  it("benchmarks PR base and head against TypeScript 6 and next", () => {
     const workflow = readWorkflow(".github/workflows/pr-performance.yml");
     expect(workflow).toContain('BENCH_ITERATIONS: "5"');
     expect(workflow).toContain("ref-role:");
-    expect(workflow).toContain("typescript-major:");
-    expect(workflow).toContain("typescript@^${{ matrix.typescript-major }}");
+    expect(workflow).toContain("typescript:");
+    expect(workflow).toContain('package: "typescript@^6"');
+    expect(workflow).toContain('package: "typescript@next"');
+    expect(workflow).toContain("Checkout PR helper scripts");
+    expect(workflow).toContain(
+      "node --strip-types ./.cache/pr-benchmark/workflow-scripts/scripts/pr_benchmark_report.ts capture",
+    );
     expect(workflow).toContain("node --strip-types ./scripts/pr_benchmark_report.ts comment");
   });
 });

--- a/docs/ci_guide.md
+++ b/docs/ci_guide.md
@@ -47,7 +47,7 @@ The PR performance workflow lives in
 On PR open, reopen, ready-for-review, and synchronize events it benchmarks:
 
 - PR base branch versus PR head branch
-- TypeScript major `6` versus TypeScript major `7`
+- TypeScript `6` versus the npm `next` TypeScript channel
 - five measured samples per row, reported by mean milliseconds
 
 The workflow uploads the four benchmark reports as artifacts, then updates one

--- a/docs/ci_guide.md
+++ b/docs/ci_guide.md
@@ -29,7 +29,7 @@ It means several layers agree on:
 
 The workflow lives in [`../.github/workflows/ci.yml`](../.github/workflows/ci.yml).
 
-It currently has three CI jobs in the main workflow:
+It currently has these jobs in the main workflow:
 
 - `js-format`
 - `js-lint-types`
@@ -41,6 +41,18 @@ It currently has three CI jobs in the main workflow:
 - `quality`
 - `real-tsgo-smoke`
 - `bench-tsgo-ref`
+
+The PR performance workflow lives in
+[`../.github/workflows/pr-performance.yml`](../.github/workflows/pr-performance.yml).
+On PR open, reopen, ready-for-review, and synchronize events it benchmarks:
+
+- PR base branch versus PR head branch
+- TypeScript major `6` versus TypeScript major `7`
+- five measured samples per row, reported by mean milliseconds
+
+The workflow uploads the four benchmark reports as artifacts, then updates one
+sticky PR comment with faster, slower, and stable rows. Rows within 3% are marked
+stable to avoid treating benchmark noise as a regression.
 
 ## `quality`
 

--- a/scripts/pr_benchmark_report.ts
+++ b/scripts/pr_benchmark_report.ts
@@ -1,0 +1,419 @@
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+type BranchRole = "base" | "head";
+
+type RawBenchRow = {
+  readonly workload: string;
+  readonly dataset: string;
+  readonly tool: string;
+  readonly sampleCount: number;
+  readonly meanMs: number;
+  readonly medianMs: number;
+  readonly p95Ms: number;
+  readonly minMs: number;
+  readonly maxMs: number;
+};
+
+type RawBenchReport = {
+  readonly iterations: number;
+  readonly warmupIterations: number;
+  readonly timeoutMs: number;
+  readonly rows?: readonly RawBenchRow[];
+};
+
+export type CapturedBenchReport = {
+  readonly schemaVersion: 1;
+  readonly branchRole: BranchRole;
+  readonly refName: string;
+  readonly sha: string;
+  readonly typescript: {
+    readonly major: string;
+    readonly requested: string;
+    readonly installed: string;
+  };
+  readonly github: {
+    readonly runId: string;
+    readonly runAttempt: string;
+  };
+  readonly report: RawBenchReport;
+};
+
+type ComparisonRow = {
+  readonly workload: string;
+  readonly dataset: string;
+  readonly tool: string;
+  readonly sampleCount: number;
+  readonly baseMeanMs: number;
+  readonly headMeanMs: number;
+  readonly deltaMs: number;
+  readonly deltaPercent: number;
+  readonly result: "faster" | "slower" | "stable";
+};
+
+type TypeScriptComparison = {
+  readonly major: string;
+  readonly requested: string;
+  readonly base: CapturedBenchReport;
+  readonly head: CapturedBenchReport;
+  readonly rows: readonly ComparisonRow[];
+  readonly geometricMeanDeltaPercent: number;
+  readonly fasterCount: number;
+  readonly slowerCount: number;
+  readonly stableCount: number;
+};
+
+const marker = "<!-- corsa-pr-performance-benchmark -->";
+const significantDeltaPercent = 3;
+
+async function main(): Promise<void> {
+  const [command, ...args] = process.argv.slice(2);
+  if (command === "capture") {
+    captureReport(parseOptions(args));
+    return;
+  }
+  if (command === "comment") {
+    await writeComment(parseOptions(args));
+    return;
+  }
+  throw new Error("usage: pr_benchmark_report.ts capture|comment [options]");
+}
+
+function captureReport(options: ReadonlyMap<string, string>): void {
+  const input = requiredOption(options, "input");
+  const output = requiredOption(options, "output");
+  const report = JSON.parse(readFileSync(input, "utf8")) as RawBenchReport;
+  const captured: CapturedBenchReport = {
+    schemaVersion: 1,
+    branchRole: parseBranchRole(requiredOption(options, "branch-role")),
+    refName: requiredOption(options, "ref-name"),
+    sha: requiredOption(options, "sha"),
+    typescript: {
+      major: requiredOption(options, "typescript-major"),
+      requested: requiredOption(options, "typescript-requested"),
+      installed: requiredOption(options, "typescript-version"),
+    },
+    github: {
+      runId: process.env.GITHUB_RUN_ID ?? "",
+      runAttempt: process.env.GITHUB_RUN_ATTEMPT ?? "",
+    },
+    report,
+  };
+  writeFileSync(output, `${JSON.stringify(captured, null, 2)}\n`);
+}
+
+async function writeComment(options: ReadonlyMap<string, string>): Promise<void> {
+  const reportsDir = requiredOption(options, "reports-dir");
+  const output = options.get("output");
+  const reports = readCapturedReports(reportsDir);
+  const body = createCommentBody(reports);
+  if (output) {
+    writeFileSync(output, body);
+  }
+  if (options.has("post-comment")) {
+    await postStickyComment(body);
+  }
+}
+
+export function createCommentBody(reports: readonly CapturedBenchReport[]): string {
+  const comparisons = compareReports(reports);
+  const lines = [
+    marker,
+    "## PR Performance Benchmark",
+    "",
+    "Lower is better. Each row compares the 5-sample mean from the PR branch against the base branch.",
+    `Changes within +/-${significantDeltaPercent}% are marked as stable to avoid over-reading benchmark noise.`,
+    "",
+  ];
+  if (comparisons.length === 0) {
+    lines.push("No complete base/head benchmark pairs were found.");
+    return `${lines.join("\n")}\n`;
+  }
+  lines.push("### Summary", "");
+  lines.push("| TypeScript | Base | PR | Geomean change | Faster | Slower | Stable |");
+  lines.push("| --- | --- | --- | ---: | ---: | ---: | ---: |");
+  for (const comparison of comparisons) {
+    lines.push(
+      [
+        `TS v${comparison.major} (${comparison.base.typescript.installed})`,
+        shortRef(comparison.base),
+        shortRef(comparison.head),
+        formatSignedPercent(comparison.geometricMeanDeltaPercent),
+        String(comparison.fasterCount),
+        String(comparison.slowerCount),
+        String(comparison.stableCount),
+      ]
+        .join(" | ")
+        .replace(/^/, "| ")
+        .replace(/$/, " |"),
+    );
+  }
+  for (const comparison of comparisons) {
+    lines.push(
+      "",
+      `<details>`,
+      `<summary>TS v${comparison.major} full benchmark rows</summary>`,
+      "",
+    );
+    lines.push("| Workload | Dataset | Tool | Base mean | PR mean | Change | Result | Samples |");
+    lines.push("| --- | --- | --- | ---: | ---: | ---: | --- | ---: |");
+    for (const row of comparison.rows) {
+      lines.push(
+        [
+          row.workload,
+          row.dataset,
+          row.tool,
+          formatMs(row.baseMeanMs),
+          formatMs(row.headMeanMs),
+          formatSignedPercent(row.deltaPercent),
+          row.result,
+          String(row.sampleCount),
+        ]
+          .join(" | ")
+          .replace(/^/, "| ")
+          .replace(/$/, " |"),
+      );
+    }
+    lines.push("", "</details>");
+  }
+  lines.push("", "_Generated by `.github/workflows/pr-performance.yml`._");
+  return `${lines.join("\n")}\n`;
+}
+
+export function compareReports(
+  reports: readonly CapturedBenchReport[],
+): readonly TypeScriptComparison[] {
+  const byMajor = new Map<string, CapturedBenchReport[]>();
+  for (const report of reports) {
+    const items = byMajor.get(report.typescript.major) ?? [];
+    items.push(report);
+    byMajor.set(report.typescript.major, items);
+  }
+  return [...byMajor.entries()]
+    .sort(([left], [right]) => left.localeCompare(right, undefined, { numeric: true }))
+    .flatMap(([major, items]) => {
+      const base = items.find((item) => item.branchRole === "base");
+      const head = items.find((item) => item.branchRole === "head");
+      if (!base || !head) {
+        return [];
+      }
+      const rows = compareRows(base.report.rows ?? [], head.report.rows ?? []);
+      const fasterCount = rows.filter((row) => row.result === "faster").length;
+      const slowerCount = rows.filter((row) => row.result === "slower").length;
+      return [
+        {
+          major,
+          requested: head.typescript.requested,
+          base,
+          head,
+          rows,
+          geometricMeanDeltaPercent: geometricMeanDelta(rows),
+          fasterCount,
+          slowerCount,
+          stableCount: rows.length - fasterCount - slowerCount,
+        },
+      ];
+    });
+}
+
+function compareRows(
+  baseRows: readonly RawBenchRow[],
+  headRows: readonly RawBenchRow[],
+): readonly ComparisonRow[] {
+  const baseByKey = new Map(baseRows.map((row) => [rowKey(row), row]));
+  return headRows
+    .flatMap((head) => {
+      const base = baseByKey.get(rowKey(head));
+      if (!base || base.meanMs <= 0 || head.meanMs <= 0) {
+        return [];
+      }
+      const deltaMs = head.meanMs - base.meanMs;
+      const deltaPercent = (deltaMs / base.meanMs) * 100;
+      return [
+        {
+          workload: head.workload,
+          dataset: head.dataset,
+          tool: head.tool,
+          sampleCount: Math.min(base.sampleCount, head.sampleCount),
+          baseMeanMs: base.meanMs,
+          headMeanMs: head.meanMs,
+          deltaMs,
+          deltaPercent,
+          result: classify(deltaPercent),
+        },
+      ];
+    })
+    .sort((left, right) => {
+      return (
+        left.workload.localeCompare(right.workload) ||
+        left.dataset.localeCompare(right.dataset) ||
+        left.tool.localeCompare(right.tool)
+      );
+    });
+}
+
+function classify(deltaPercent: number): ComparisonRow["result"] {
+  if (Math.abs(deltaPercent) < significantDeltaPercent) {
+    return "stable";
+  }
+  return deltaPercent < 0 ? "faster" : "slower";
+}
+
+function geometricMeanDelta(rows: readonly ComparisonRow[]): number {
+  const ratios = rows
+    .filter((row) => row.baseMeanMs > 0 && row.headMeanMs > 0)
+    .map((row) => row.headMeanMs / row.baseMeanMs);
+  if (ratios.length === 0) {
+    return 0;
+  }
+  const meanLog = ratios.reduce((total, ratio) => total + Math.log(ratio), 0) / ratios.length;
+  return (Math.exp(meanLog) - 1) * 100;
+}
+
+function readCapturedReports(dir: string): readonly CapturedBenchReport[] {
+  const reports: CapturedBenchReport[] = [];
+  for (const file of readJsonFiles(dir)) {
+    const value = JSON.parse(readFileSync(file, "utf8")) as CapturedBenchReport;
+    if (value.schemaVersion === 1 && value.report?.rows) {
+      reports.push(value);
+    }
+  }
+  return reports;
+}
+
+function readJsonFiles(dir: string): readonly string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return readJsonFiles(path);
+    }
+    return entry.isFile() && entry.name.endsWith(".json") ? [path] : [];
+  });
+}
+
+async function postStickyComment(body: string): Promise<void> {
+  const repository = requiredEnv("GITHUB_REPOSITORY");
+  const token = requiredEnv("GITHUB_TOKEN");
+  const prNumber = requiredEnv("PR_NUMBER");
+  const [owner, repo] = repository.split("/");
+  if (!owner || !repo) {
+    throw new Error(`invalid GITHUB_REPOSITORY: ${repository}`);
+  }
+  const existing = await githubRequest<readonly { id: number; body?: string }[]>(
+    token,
+    "GET",
+    `/repos/${owner}/${repo}/issues/${prNumber}/comments?per_page=100`,
+  );
+  const previous = existing.find((comment) => comment.body?.includes(marker));
+  if (previous) {
+    await githubRequest(token, "PATCH", `/repos/${owner}/${repo}/issues/comments/${previous.id}`, {
+      body,
+    });
+    return;
+  }
+  await githubRequest(token, "POST", `/repos/${owner}/${repo}/issues/${prNumber}/comments`, {
+    body,
+  });
+}
+
+async function githubRequest<T>(
+  token: string,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const response = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "x-github-api-version": "2022-11-28",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`GitHub API ${method} ${path} failed: ${response.status} ${text}`);
+  }
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return (await response.json()) as T;
+}
+
+function rowKey(row: Pick<RawBenchRow, "workload" | "dataset" | "tool">): string {
+  return `${row.workload}\u0000${row.dataset}\u0000${row.tool}`;
+}
+
+function shortRef(report: CapturedBenchReport): string {
+  return `${report.refName} (${report.sha.slice(0, 7)})`;
+}
+
+function formatMs(value: number): string {
+  return `${value.toFixed(3)} ms`;
+}
+
+function formatSignedPercent(value: number): string {
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+function parseBranchRole(value: string): BranchRole {
+  if (value === "base" || value === "head") {
+    return value;
+  }
+  throw new Error(`invalid branch role: ${value}`);
+}
+
+function parseOptions(args: readonly string[]): ReadonlyMap<string, string> {
+  const options = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 1) {
+    const name = args[index];
+    if (!name?.startsWith("--")) {
+      throw new Error(`expected option, got ${name ?? "<end>"}`);
+    }
+    const key = name.slice(2);
+    if (key === "post-comment") {
+      options.set(key, "1");
+      continue;
+    }
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`missing value for ${name}`);
+    }
+    options.set(key, value);
+    index += 1;
+  }
+  return options;
+}
+
+function requiredOption(options: ReadonlyMap<string, string>, key: string): string {
+  const value = options.get(key);
+  if (!value) {
+    throw new Error(`missing --${key}`);
+  }
+  return value;
+}
+
+function requiredEnv(key: string): string {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`missing ${key}`);
+  }
+  return value;
+}
+
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  return Boolean(entry) && import.meta.url === pathToFileURL(entry).href;
+}
+
+if (isMainModule()) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`${basename(process.argv[1] ?? "pr_benchmark_report.ts")}: ${message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/pr_benchmark_report.ts
+++ b/scripts/pr_benchmark_report.ts
@@ -29,7 +29,7 @@ export type CapturedBenchReport = {
   readonly refName: string;
   readonly sha: string;
   readonly typescript: {
-    readonly major: string;
+    readonly channel: string;
     readonly requested: string;
     readonly installed: string;
   };
@@ -53,7 +53,7 @@ type ComparisonRow = {
 };
 
 type TypeScriptComparison = {
-  readonly major: string;
+  readonly channel: string;
   readonly requested: string;
   readonly base: CapturedBenchReport;
   readonly head: CapturedBenchReport;
@@ -90,7 +90,7 @@ function captureReport(options: ReadonlyMap<string, string>): void {
     refName: requiredOption(options, "ref-name"),
     sha: requiredOption(options, "sha"),
     typescript: {
-      major: requiredOption(options, "typescript-major"),
+      channel: requiredOption(options, "typescript-channel"),
       requested: requiredOption(options, "typescript-requested"),
       installed: requiredOption(options, "typescript-version"),
     },
@@ -136,7 +136,7 @@ export function createCommentBody(reports: readonly CapturedBenchReport[]): stri
   for (const comparison of comparisons) {
     lines.push(
       [
-        `TS v${comparison.major} (${comparison.base.typescript.installed})`,
+        `${formatTypeScriptChannel(comparison.channel)} (${comparison.base.typescript.installed})`,
         shortRef(comparison.base),
         shortRef(comparison.head),
         formatSignedPercent(comparison.geometricMeanDeltaPercent),
@@ -153,7 +153,7 @@ export function createCommentBody(reports: readonly CapturedBenchReport[]): stri
     lines.push(
       "",
       `<details>`,
-      `<summary>TS v${comparison.major} full benchmark rows</summary>`,
+      `<summary>${formatTypeScriptChannel(comparison.channel)} full benchmark rows</summary>`,
       "",
     );
     lines.push("| Workload | Dataset | Tool | Base mean | PR mean | Change | Result | Samples |");
@@ -184,15 +184,15 @@ export function createCommentBody(reports: readonly CapturedBenchReport[]): stri
 export function compareReports(
   reports: readonly CapturedBenchReport[],
 ): readonly TypeScriptComparison[] {
-  const byMajor = new Map<string, CapturedBenchReport[]>();
+  const byChannel = new Map<string, CapturedBenchReport[]>();
   for (const report of reports) {
-    const items = byMajor.get(report.typescript.major) ?? [];
+    const items = byChannel.get(report.typescript.channel) ?? [];
     items.push(report);
-    byMajor.set(report.typescript.major, items);
+    byChannel.set(report.typescript.channel, items);
   }
-  return [...byMajor.entries()]
+  return [...byChannel.entries()]
     .sort(([left], [right]) => left.localeCompare(right, undefined, { numeric: true }))
-    .flatMap(([major, items]) => {
+    .flatMap(([channel, items]) => {
       const base = items.find((item) => item.branchRole === "base");
       const head = items.find((item) => item.branchRole === "head");
       if (!base || !head) {
@@ -203,7 +203,7 @@ export function compareReports(
       const slowerCount = rows.filter((row) => row.result === "slower").length;
       return [
         {
-          major,
+          channel,
           requested: head.typescript.requested,
           base,
           head,
@@ -349,6 +349,10 @@ function rowKey(row: Pick<RawBenchRow, "workload" | "dataset" | "tool">): string
 
 function shortRef(report: CapturedBenchReport): string {
   return `${report.refName} (${report.sha.slice(0, 7)})`;
+}
+
+function formatTypeScriptChannel(channel: string): string {
+  return /^\d+$/.test(channel) ? `TS v${channel}` : `TS ${channel}`;
 }
 
 function formatMs(value: number): string {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -145,7 +145,7 @@ export default defineConfig({
       },
       test: {
         command: noopCommand,
-        dependsOn: ["test_rust", "test_rust_experimental", "test_ts", "examples_smoke"],
+        dependsOn: ["test_rust", "test_rust_experimental", "test_ts", "examples_smoke_ci"],
       },
       test_rust: {
         command: "cargo test --workspace",
@@ -227,6 +227,11 @@ export default defineConfig({
         cwd: "examples",
         dependsOn: ["build"],
       },
+      examples_node_smoke_ci: {
+        command: "pnpm run smoke",
+        cwd: "examples",
+        dependsOn: ["build_ci"],
+      },
       examples_node_real: {
         command: "pnpm run real",
         cwd: "examples",
@@ -247,6 +252,10 @@ export default defineConfig({
       examples_smoke: {
         command: noopCommand,
         dependsOn: ["examples_node_smoke", "examples_rust_smoke"],
+      },
+      examples_smoke_ci: {
+        command: noopCommand,
+        dependsOn: ["examples_node_smoke_ci", "examples_rust_smoke"],
       },
       examples_real: {
         command: noopCommand,


### PR DESCRIPTION
## Summary

- Add a PR performance workflow that benchmarks base and PR head across TypeScript 6 and 7.
- Run the tooling benchmark with 5 measured iterations and publish a sticky PR comment showing faster, slower, and stable rows.
- Add a typed report/comment helper, tests, and CI guide notes for the workflow.

## Validation

- [x] `vp test run --config ./vite.config.ts bench/src/pr_benchmark_report.test.ts bench/src/publish_workflows.test.ts`
- [x] `vp check --no-fmt`
- [x] `vp fmt --check bench/src/publish_workflows.test.ts bench/src/pr_benchmark_report.test.ts scripts/pr_benchmark_report.ts docs/ci_guide.md`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-performance.yml"); puts "workflow yaml ok"'`
- [x] Full `vp fmt --check` is currently blocked by pre-existing untracked `docs/project_strategy_report.md` formatting.

## Checklist

- [x] Scope is limited to the described change
- [x] Documentation or templates were updated when needed
- [x] Follow-up work is tracked in an issue