### PR TITLE
feat(corsa-oxlint): align utility predicates

### DIFF
--- a/src/bindings/nodejs/typescript_oxlint/ts/api_surface.test.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/api_surface.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import * as astUtilsEntry from "./ast_utils";
 import * as main from "./index";
 import * as eslintUtilsEntry from "./oxlint_utils";
 import * as compatEntry from "./oxlint_compat";
@@ -31,12 +32,44 @@ describe("api surface", () => {
     expect(main.ESLintUtils.NullThrowsReasons.MissingToken("token", "node")).toBe(
       "Expected to find a token for the node.",
     );
+    expect(main.ESLintUtils.applyDefault([{ nested: { enabled: true }, value: 1 }], [{}])).toEqual([
+      { nested: { enabled: true }, value: 1 },
+    ]);
+    expect(
+      main.ESLintUtils.applyDefault(
+        [{ nested: { enabled: true }, value: 1 }],
+        [{ nested: { enabled: false } }],
+      ),
+    ).toEqual([{ nested: { enabled: false }, value: 1 }]);
+    expect(typeof main.RuleCreator.withoutDocs).toBe("function");
     expect(main.TSUtils.isArray([])).toBe(true);
     expect(tsUtilsEntry.TSUtils.isArray({})).toBe(false);
     expect(main.TSESLint.RuleTester).toBe(main.RuleTester);
     expect(tsEslintEntry.TSESLint.RuleTester).toBe(main.RuleTester);
     expect(tsEslintEntry.RuleTester).toBe(main.RuleTester);
     expect(eslintUtilsEntry.ESLintUtils.getParserServices).toBe(main.getParserServices);
+  });
+
+  it("supports typescript-eslint-style ASTUtils predicate factories", () => {
+    const identifier = { type: "Identifier", name: "value" };
+    const optionalCall = { type: "CallExpression", optional: true };
+    const awaitToken = { type: "Identifier", value: "await" };
+    const colonToken = { type: "Punctuator", value: ":" };
+
+    expect(astUtilsEntry.isNodeOfType("Identifier")(identifier)).toBe(true);
+    expect(astUtilsEntry.isNodeOfType(identifier, "Identifier")).toBe(true);
+    expect(astUtilsEntry.isNodeOfTypes(["Identifier"])(identifier)).toBe(true);
+    expect(
+      astUtilsEntry.isNodeOfTypeWithConditions("CallExpression", { optional: true })(optionalCall),
+    ).toBe(true);
+    expect(
+      astUtilsEntry.isTokenOfTypeWithConditions("Punctuator", { value: ":" })(colonToken),
+    ).toBe(true);
+    expect(
+      astUtilsEntry.isNotTokenOfTypeWithConditions("Punctuator", { value: ":" })(awaitToken),
+    ).toBe(true);
+    expect(astUtilsEntry.isAwaitKeyword(awaitToken)).toBe(true);
+    expect(astUtilsEntry.isClassOrTypeElement({ type: "TSPropertySignature" })).toBe(true);
   });
 
   it("re-exports the native rules surface from both entrypoints", () => {

--- a/src/bindings/nodejs/typescript_oxlint/ts/ast_utils.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/ast_utils.ts
@@ -1,23 +1,57 @@
+type TypedValue = { readonly type?: string };
+type ValueToken = { readonly type?: string; readonly value?: string };
+type Predicate<T> = (value: T | null | undefined) => boolean;
+
+export function isNodeOfType(type: string): Predicate<TypedValue>;
+export function isNodeOfType(node: TypedValue | null | undefined, type: string): boolean;
 export function isNodeOfType(
-  node: { readonly type?: string } | null | undefined,
-  type: string,
-): boolean {
-  return node?.type === type;
+  nodeOrType: TypedValue | string | null | undefined,
+  maybeType?: string,
+): boolean | Predicate<TypedValue> {
+  if (typeof nodeOrType === "string" && maybeType === undefined) {
+    return (node) => node?.type === nodeOrType;
+  }
+  return (nodeOrType as TypedValue | null | undefined)?.type === maybeType;
 }
 
+export function isNodeOfTypes(types: readonly string[]): Predicate<TypedValue>;
 export function isNodeOfTypes(
-  node: { readonly type?: string } | null | undefined,
+  node: TypedValue | null | undefined,
   types: readonly string[],
-): boolean {
-  return node?.type !== undefined && types.includes(node.type);
+): boolean;
+export function isNodeOfTypes(
+  nodeOrTypes: TypedValue | readonly string[] | null | undefined,
+  maybeTypes?: readonly string[],
+): boolean | Predicate<TypedValue> {
+  if (Array.isArray(nodeOrTypes) && maybeTypes === undefined) {
+    return (node) => node?.type !== undefined && nodeOrTypes.includes(node.type);
+  }
+  const nodeType = (nodeOrTypes as TypedValue | null | undefined)?.type;
+  return nodeType !== undefined && maybeTypes?.includes(nodeType) === true;
 }
 
 export function isNodeOfTypeWithConditions(
-  node: { readonly type?: string } | null | undefined,
   type: string,
   conditions: Readonly<Record<string, unknown>>,
-): boolean {
-  return isNodeOfType(node, type) && matchesConditions(node, conditions);
+): Predicate<TypedValue>;
+export function isNodeOfTypeWithConditions(
+  node: TypedValue | null | undefined,
+  type: string,
+  conditions: Readonly<Record<string, unknown>>,
+): boolean;
+export function isNodeOfTypeWithConditions(
+  nodeOrType: TypedValue | string | null | undefined,
+  typeOrConditions: string | Readonly<Record<string, unknown>>,
+  maybeConditions?: Readonly<Record<string, unknown>>,
+): boolean | Predicate<TypedValue> {
+  if (typeof nodeOrType === "string") {
+    const type = nodeOrType;
+    const conditions = typeOrConditions as Readonly<Record<string, unknown>>;
+    return (node) => node?.type === type && matchesConditions(node, conditions);
+  }
+  return (
+    nodeOrType?.type === typeOrConditions && matchesConditions(nodeOrType, maybeConditions ?? {})
+  );
 }
 
 export function isIdentifier(
@@ -28,19 +62,52 @@ export function isIdentifier(
 }
 
 export function isTokenOfTypeWithConditions(
-  token: { readonly type?: string } | null | undefined,
   type: string,
   conditions: Readonly<Record<string, unknown>>,
-): boolean {
-  return isNodeOfType(token, type) && matchesConditions(token, conditions);
+): Predicate<ValueToken>;
+export function isTokenOfTypeWithConditions(
+  token: ValueToken | null | undefined,
+  type: string,
+  conditions: Readonly<Record<string, unknown>>,
+): boolean;
+export function isTokenOfTypeWithConditions(
+  tokenOrType: ValueToken | string | null | undefined,
+  typeOrConditions: string | Readonly<Record<string, unknown>>,
+  maybeConditions?: Readonly<Record<string, unknown>>,
+): boolean | Predicate<ValueToken> {
+  if (typeof tokenOrType === "string") {
+    const type = tokenOrType;
+    const conditions = typeOrConditions as Readonly<Record<string, unknown>>;
+    return (token) => token?.type === type && matchesConditions(token, conditions);
+  }
+  return (
+    tokenOrType?.type === typeOrConditions && matchesConditions(tokenOrType, maybeConditions ?? {})
+  );
 }
 
 export function isNotTokenOfTypeWithConditions(
-  token: { readonly type?: string } | null | undefined,
   type: string,
   conditions: Readonly<Record<string, unknown>>,
-): boolean {
-  return !isTokenOfTypeWithConditions(token, type, conditions);
+): Predicate<ValueToken>;
+export function isNotTokenOfTypeWithConditions(
+  token: ValueToken | null | undefined,
+  type: string,
+  conditions: Readonly<Record<string, unknown>>,
+): boolean;
+export function isNotTokenOfTypeWithConditions(
+  tokenOrType: ValueToken | string | null | undefined,
+  typeOrConditions: string | Readonly<Record<string, unknown>>,
+  maybeConditions?: Readonly<Record<string, unknown>>,
+): boolean | Predicate<ValueToken> {
+  if (typeof tokenOrType === "string") {
+    const predicate = isTokenOfTypeWithConditions(tokenOrType, typeOrConditions as never);
+    return (token) => !predicate(token);
+  }
+  return !isTokenOfTypeWithConditions(
+    tokenOrType,
+    typeOrConditions as string,
+    maybeConditions ?? {},
+  );
 }
 
 export function isFunction(node: { readonly type?: string } | null | undefined): boolean {
@@ -52,12 +119,7 @@ export function isFunction(node: { readonly type?: string } | null | undefined):
 }
 
 export function isFunctionType(node: { readonly type?: string } | null | undefined): boolean {
-  return isNodeOfTypes(node, [
-    "TSCallSignatureDeclaration",
-    "TSConstructSignatureDeclaration",
-    "TSConstructorType",
-    "TSFunctionType",
-  ]);
+  return isNodeOfTypes(node, functionTypeTypes);
 }
 
 export function isFunctionOrFunctionType(
@@ -96,6 +158,22 @@ export function isTypeAssertion(node: { readonly type?: string } | null | undefi
   return isNodeOfTypes(node, ["TSAsExpression", "TSTypeAssertion"]);
 }
 
+export function isClassOrTypeElement(node: { readonly type?: string } | null | undefined): boolean {
+  return isNodeOfTypes(node, [
+    "PropertyDefinition",
+    "FunctionExpression",
+    "MethodDefinition",
+    "TSAbstractPropertyDefinition",
+    "TSAbstractMethodDefinition",
+    "TSEmptyBodyFunctionExpression",
+    "TSIndexSignature",
+    "TSCallSignatureDeclaration",
+    "TSConstructSignatureDeclaration",
+    "TSMethodSignature",
+    "TSPropertySignature",
+  ]);
+}
+
 export function isOptionalCallExpression(
   node: { readonly type?: string; readonly optional?: boolean } | null | undefined,
 ): boolean {
@@ -111,17 +189,27 @@ export function isConstructor(
 export function isSetter(
   node: { readonly type?: string; readonly kind?: string } | null | undefined,
 ): boolean {
-  return node?.type === "MethodDefinition" && node.kind === "set";
+  return (node?.type === "MethodDefinition" || node?.type === "Property") && node.kind === "set";
 }
 
 export const LINEBREAK_MATCHER = /\r\n|[\r\n\u2028\u2029]/u;
 
+const IDENTIFIER = "Identifier";
 const PUNCTUATOR = "Punctuator";
 const KEYWORD = "Keyword";
+const functionTypeTypes = [
+  "TSCallSignatureDeclaration",
+  "TSConstructSignatureDeclaration",
+  "TSConstructorType",
+  "TSDeclareFunction",
+  "TSEmptyBodyFunctionExpression",
+  "TSFunctionType",
+  "TSMethodSignature",
+] as const;
 
 export const isArrowToken = tokenWithValue("=>");
 export const isNotArrowToken = not(isArrowToken);
-export const isAwaitKeyword = keywordWithValue("await");
+export const isAwaitKeyword = tokenWithValue("await", IDENTIFIER);
 export const isClosingBraceToken = tokenWithValue("}");
 export const isNotClosingBraceToken = not(isClosingBraceToken);
 export const isClosingBracketToken = tokenWithValue("]");
@@ -149,7 +237,7 @@ export const isOptionalChainPunctuator = tokenWithValue("?.");
 export const isNotOptionalChainPunctuator = not(isOptionalChainPunctuator);
 export const isSemicolonToken = tokenWithValue(";");
 export const isNotSemicolonToken = not(isSemicolonToken);
-export const isTypeKeyword = keywordWithValue("type");
+export const isTypeKeyword = tokenWithValue("type", IDENTIFIER);
 
 export function isTokenOnSameLine(
   left: { readonly loc?: { readonly end?: { readonly line?: number } } },
@@ -182,6 +270,7 @@ export const ASTUtils = Object.freeze({
   isClosingBraceToken,
   isClosingBracketToken,
   isClosingParenToken,
+  isClassOrTypeElement,
   isColonToken,
   isCommaToken,
   isCommentToken,
@@ -234,9 +323,9 @@ function matchesConditions(
   return Object.entries(conditions).every(([key, expected]) => value?.[key] === expected);
 }
 
-function tokenWithValue(expected: string) {
+function tokenWithValue(expected: string, type = PUNCTUATOR) {
   return (token: { readonly type?: string; readonly value?: string } | null | undefined): boolean =>
-    token?.type === PUNCTUATOR && token.value === expected;
+    token?.type === type && token.value === expected;
 }
 
 function keywordWithValue(expected: string) {

--- a/src/bindings/nodejs/typescript_oxlint/ts/oxlint_utils.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/oxlint_utils.ts
@@ -65,29 +65,58 @@ export const NullThrowsReasons = Object.freeze({
   MissingToken: (token: string, thing: string) => `Expected to find a ${token} for the ${thing}.`,
 });
 
-export const RuleCreator = OxlintUtils.RuleCreator;
+export const RuleCreator = Object.assign(OxlintUtils.RuleCreator, {
+  withoutDocs<TRule extends Omit<RuleCreatorRule, "name">>(
+    rule: TRule,
+  ): Omit<TRule, "defaultOptions"> &
+    Rule & {
+      readonly defaultOptions: TRule extends { readonly defaultOptions: infer TOptions }
+        ? TOptions
+        : readonly [];
+    } {
+    return decorateRule({
+      ...rule,
+      defaultOptions: rule.defaultOptions ?? [],
+    } as unknown as Rule) as never;
+  },
+});
 export { getParserServices } from "./parser_services";
 
-export function applyDefault<
-  Values extends readonly unknown[],
-  Defaults extends readonly unknown[],
->(values: Values | undefined, defaults: Defaults): readonly unknown[] {
-  return deepMerge(defaults, values ?? []) as readonly unknown[];
+export function applyDefault<User extends readonly unknown[], Defaults extends readonly unknown[]>(
+  defaultOptions: Defaults,
+  userOptions: User | null | undefined,
+): readonly unknown[] {
+  const options = structuredClone(defaultOptions) as unknown as unknown[];
+  if (userOptions == null) {
+    return options;
+  }
+  options.forEach((option, index) => {
+    if (userOptions[index] === undefined) {
+      return;
+    }
+    const userOption = userOptions[index];
+    options[index] =
+      isObjectNotArray(option) && isObjectNotArray(userOption)
+        ? deepMerge(option, userOption)
+        : userOption;
+  });
+  return options;
 }
 
 export function deepMerge<T>(base: T, override: unknown): T {
-  if (Array.isArray(base) && Array.isArray(override)) {
-    return base.map((value, index) => deepMerge(value, override[index])) as unknown as T;
-  }
   if (isObject(base) && isObject(override)) {
     return Object.fromEntries(
       [...new Set([...Object.keys(base), ...Object.keys(override)])].map((key) => [
         key,
-        deepMerge((base as any)[key], (override as any)[key]),
+        key in base && key in override
+          ? deepMerge((base as any)[key], (override as any)[key])
+          : key in base
+            ? (base as any)[key]
+            : (override as any)[key],
       ]),
     ) as T;
   }
-  return (override ?? base) as T;
+  return (override === undefined ? base : override) as T;
 }
 
 export function nullThrows<T>(


### PR DESCRIPTION
## Summary

- aligns ASTUtils predicate helpers with the @typescript-eslint/utils factory-style API while preserving direct-call compatibility
- adds RuleCreator.withoutDocs and fixes ESLintUtils.applyDefault/deepMerge behavior
- expands API-surface tests for the compatibility helpers

Refs #122

## Validation

- vp lint src/bindings/nodejs/typescript_oxlint/ts/api_surface.test.ts src/bindings/nodejs/typescript_oxlint/ts/ast_utils.ts src/bindings/nodejs/typescript_oxlint/ts/oxlint_utils.ts
- vp test run --config ./vite.config.ts src/bindings/nodejs/typescript_oxlint/ts/api_surface.test.ts
- vp run -w build_typescript_oxlint