### PR TITLE
ci: limit pull request checks to linux build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     name: JS/TS Format (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    if: ${{ github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -57,6 +58,7 @@ jobs:
     name: JS/TS Lint and Types (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    if: ${{ github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -84,6 +86,7 @@ jobs:
     name: Rust Format (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    if: ${{ github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -109,6 +112,7 @@ jobs:
     name: Rust Lint (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    if: ${{ github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -140,10 +144,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest","macos-latest","windows-latest"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -170,6 +171,7 @@ jobs:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
+    if: ${{ github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -203,6 +205,7 @@ jobs:
     name: Public Facade (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    if: ${{ github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -232,6 +235,7 @@ jobs:
     name: Non-Node Bindings
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    if: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -293,7 +297,7 @@ jobs:
       - test
       - public-facade
       - non-node-bindings
-    if: ${{ always() }}
+    if: ${{ always() && github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -336,6 +340,7 @@ jobs:
     name: Real tsgo Smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
+    if: ${{ github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -386,6 +391,7 @@ jobs:
     name: tsgo Ref Bench
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    if: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,7 +1,9 @@
 name: Release Dry Run
 
 on:
-  pull_request:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,7 +1,6 @@
 name: Supply Chain
 
 on:
-  pull_request:
   push:
     branches:
       - main
@@ -14,7 +13,7 @@ permissions:
 
 concurrency:
   group: supply-chain-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
   cargo-deny:


### PR DESCRIPTION
## Summary\n- run the full CI matrix only on main pushes and manual dispatches\n- keep pull-request CI to Build (ubuntu-latest)\n- move release dry run and supply-chain automation off PRs and onto main pushes\n\n## Notes\n- Updated main branch protection required status checks to Build (ubuntu-latest) only.\n\nRefs #121