### PR TITLE
feat(corsa-oxlint): stub unsupported utility APIs

### DIFF
--- a/src/bindings/nodejs/typescript_oxlint/ts/api_surface.test.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/api_surface.test.ts
@@ -50,6 +50,25 @@ describe("api surface", () => {
     expect(eslintUtilsEntry.ESLintUtils.getParserServices).toBe(main.getParserServices);
   });
 
+  it("tracks the pinned typescript-eslint utility namespace keys", async () => {
+    const upstream =
+      await import("../../../../../bench/cli_compare/node_modules/@typescript-eslint/utils/dist/index.js");
+
+    expectMissingKeys("root", main, upstream, ["__esModule", "default", "module.exports"]);
+    expectMissingKeys("AST_NODE_TYPES", main.AST_NODE_TYPES, upstream.AST_NODE_TYPES);
+    expectMissingKeys("AST_TOKEN_TYPES", main.AST_TOKEN_TYPES, upstream.AST_TOKEN_TYPES);
+    expectMissingKeys("ASTUtils", astUtilsEntry, upstream.ASTUtils);
+    expectMissingKeys("ESLintUtils", eslintUtilsEntry.ESLintUtils, upstream.ESLintUtils);
+    expectMissingKeys("TSESLint", tsEslintEntry.TSESLint, upstream.TSESLint);
+    expectMissingKeys("TSUtils", tsUtilsEntry.TSUtils, upstream.TSUtils);
+  });
+
+  it("marks ESLint-only utility exports as unsupported", () => {
+    expect(() => astUtilsEntry.findVariable()).toThrow(/ASTUtils\.findVariable/);
+    expect(() => new astUtilsEntry.ReferenceTracker()).toThrow(/ASTUtils\.ReferenceTracker/);
+    expect(() => new main.TSESLint.Linter()).toThrow(/TSESLint\.Linter/);
+  });
+
   it("supports typescript-eslint-style ASTUtils predicate factories", () => {
     const identifier = { type: "Identifier", name: "value" };
     const optionalCall = { type: "CallExpression", optional: true };
@@ -87,3 +106,17 @@ describe("api surface", () => {
     ]);
   });
 });
+
+function expectMissingKeys(
+  label: string,
+  local: Record<string, unknown>,
+  upstream: Record<string, unknown>,
+  ignored: readonly string[] = [],
+): void {
+  const localKeys = new Set(Object.keys(local));
+  const ignoredKeys = new Set(ignored);
+  const missing = Object.keys(upstream)
+    .filter((key) => !ignoredKeys.has(key))
+    .filter((key) => !localKeys.has(key));
+  expect(missing, `${label} missing keys`).toEqual([]);
+}

--- a/src/bindings/nodejs/typescript_oxlint/ts/ast_utils.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/ast_utils.ts
@@ -261,8 +261,68 @@ export function isParenthesized(
   );
 }
 
+export const findVariable = unsupportedAstUtilsFunction("findVariable");
+export const getFunctionHeadLocation = unsupportedAstUtilsFunction("getFunctionHeadLocation");
+export const getFunctionNameWithKind = unsupportedAstUtilsFunction("getFunctionNameWithKind");
+export const getInnermostScope = unsupportedAstUtilsFunction("getInnermostScope");
+export const getPropertyName = unsupportedAstUtilsFunction("getPropertyName");
+export const getStaticValue = unsupportedAstUtilsFunction("getStaticValue");
+export const getStringIfConstant = unsupportedAstUtilsFunction("getStringIfConstant");
+export const hasSideEffect = unsupportedAstUtilsFunction("hasSideEffect");
+
+export class PatternMatcher {
+  constructor(..._args: unknown[]) {
+    throw unsupportedAstUtilsError("PatternMatcher");
+  }
+
+  execAll(..._args: unknown[]): never {
+    throw unsupportedAstUtilsError("PatternMatcher.execAll");
+  }
+
+  test(..._args: unknown[]): never {
+    throw unsupportedAstUtilsError("PatternMatcher.test");
+  }
+}
+
+export class ReferenceTracker {
+  static readonly READ = Symbol("read");
+  static readonly CALL = Symbol("call");
+  static readonly CONSTRUCT = Symbol("construct");
+  static readonly ESM = Symbol("esm");
+
+  constructor(..._args: unknown[]) {
+    throw unsupportedAstUtilsError("ReferenceTracker");
+  }
+
+  iterateGlobalReferences(..._args: unknown[]): never {
+    throw unsupportedAstUtilsError("ReferenceTracker.iterateGlobalReferences");
+  }
+
+  iterateCjsReferences(..._args: unknown[]): never {
+    throw unsupportedAstUtilsError("ReferenceTracker.iterateCjsReferences");
+  }
+
+  iterateEsmReferences(..._args: unknown[]): never {
+    throw unsupportedAstUtilsError("ReferenceTracker.iterateEsmReferences");
+  }
+
+  iteratePropertyReferences(..._args: unknown[]): never {
+    throw unsupportedAstUtilsError("ReferenceTracker.iteratePropertyReferences");
+  }
+}
+
 export const ASTUtils = Object.freeze({
   LINEBREAK_MATCHER,
+  PatternMatcher,
+  ReferenceTracker,
+  findVariable,
+  getFunctionHeadLocation,
+  getFunctionNameWithKind,
+  getInnermostScope,
+  getPropertyName,
+  getStaticValue,
+  getStringIfConstant,
+  hasSideEffect,
   isIdentifier,
   isArrowToken,
   isAwaitExpression,
@@ -335,4 +395,16 @@ function keywordWithValue(expected: string) {
 
 function not<T extends readonly unknown[]>(predicate: (...args: T) => boolean) {
   return (...args: T): boolean => !predicate(...args);
+}
+
+function unsupportedAstUtilsFunction(name: string): (...args: unknown[]) => never {
+  return (..._args: unknown[]): never => {
+    throw unsupportedAstUtilsError(name);
+  };
+}
+
+function unsupportedAstUtilsError(name: string): Error {
+  return new Error(
+    `ASTUtils.${name} is not supported by corsa-oxlint because it depends on ESLint SourceCode or scope internals.`,
+  );
 }

--- a/src/bindings/nodejs/typescript_oxlint/ts/ts_eslint.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/ts_eslint.ts
@@ -2,6 +2,29 @@ import { RuleTester } from "./rule_tester";
 
 export { RuleTester } from "./rule_tester";
 
+export const ESLint = unsupportedTSESLintClass("ESLint");
+export const FlatESLint = unsupportedTSESLintClass("FlatESLint");
+export const LegacyESLint = unsupportedTSESLintClass("LegacyESLint");
+export const Linter = unsupportedTSESLintClass("Linter");
+export const Scope = Object.freeze({});
+export const SourceCode = unsupportedTSESLintClass("SourceCode");
+
 export const TSESLint = Object.freeze({
+  ESLint,
+  FlatESLint,
+  LegacyESLint,
+  Linter,
   RuleTester,
+  Scope,
+  SourceCode,
 });
+
+function unsupportedTSESLintClass(name: string) {
+  return class UnsupportedTSESLintClass {
+    constructor(..._args: unknown[]) {
+      throw new Error(
+        `TSESLint.${name} is not supported by corsa-oxlint because it depends on ESLint runtime internals.`,
+      );
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- export explicit unsupported stubs for ESLint-only ASTUtils helpers
- add TSESLint runtime-class stubs while keeping RuleTester wired to the Oxlint tester
- compare key runtime utility namespaces against the pinned @typescript-eslint/utils package

## Validation
- vp fmt src/bindings/nodejs/typescript_oxlint/ts/ast_utils.ts src/bindings/nodejs/typescript_oxlint/ts/ts_eslint.ts src/bindings/nodejs/typescript_oxlint/ts/api_surface.test.ts
- vp lint src/bindings/nodejs/typescript_oxlint/ts/ast_utils.ts src/bindings/nodejs/typescript_oxlint/ts/ts_eslint.ts src/bindings/nodejs/typescript_oxlint/ts/api_surface.test.ts
- vp test run --config ./vite.config.ts src/bindings/nodejs/typescript_oxlint/ts/api_surface.test.ts
- vp run -w build_typescript_oxlint

Refs #122