### PR TITLE
fix(nix): restore dev shell toolchain

### DIFF
--- a/nix/flake-outputs.nix
+++ b/nix/flake-outputs.nix
@@ -18,7 +18,7 @@ in
           version = "latest";
           src = pkgs.fetchzip {
             url = "https://cli.moonbitlang.com/binaries/latest/moonbit-darwin-aarch64.tar.gz";
-            sha256 = "sha256-6Xqco29NFzQ0s4vNzq6yj1rBeLETfajZowLwiHvhqfY=";
+            sha256 = "sha256-iYuvOpa4DK08AZQ5H3FM10W+SQWD6tb9S8UbQqd0ciY=";
             stripRoot = false;
           };
           dontBuild = true;
@@ -35,7 +35,7 @@ in
         src = vitePlusRuntimeSrc;
         pnpm = pnpmForVp;
         fetcherVersion = 3;
-        hash = "sha256-vE+ceyHw7Sju/lo2cay0osRWOg4LaIn2TGdK8KBZWkw=";
+        hash = "sha256-Ov4jbNVpNL1FH6wo4XDEJwdUQeo/pPn4BQaW77nRIRQ=";
       };
       vitePlusRuntime = pkgs.stdenvNoCC.mkDerivation {
         pname = "vite-plus-runtime";
@@ -149,6 +149,7 @@ in
           ${vitePlus}/bin/vp env use --unset >/dev/null 2>&1 || true
           ${vitePlus}/bin/vp env install >/dev/null
           eval "$(${vitePlus}/bin/vp env print | ${pkgs.gnugrep}/bin/grep '^export PATH=')"
+          export PATH="${toolchainPath}:$PATH"
           corepack enable >/dev/null 2>&1 || true
           corepack prepare pnpm@10.0.0 --activate >/dev/null 2>&1 || true
 


### PR DESCRIPTION
## Summary
- refresh fixed-output hashes for the MoonBit and Vite+ dev shell inputs
- re-prepend the Nix toolchain path after Vite+ rewrites PATH so Nix Go/Rust stay first

## Validation
- nix flake show --allow-import-from-derivation --no-write-lock-file
- nix develop -c bash -c 'go version; which go; case "$(go version)" in *go1.26.1*) ;; *) exit 1;; esac; case "$(which go)" in /nix/store/*-go-1.26.1/bin/go) ;; *) exit 1;; esac'\n- git diff --check\n\nRefs #131