### PR TITLE
perf(corsa-oxlint): trim native bridge type lookups

### DIFF
--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/await_thenable.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/await_thenable.ts
@@ -1,3 +1,15 @@
 import { createRustNativeRule } from "./native_bridge";
 
-export const awaitThenableRule = createRustNativeRule("await-thenable");
+export const awaitThenableRule = createRustNativeRule(
+  "await-thenable",
+  {},
+  {
+    includePropertyNames: includeAwaitTypeMetadata,
+    includeTypeTexts: includeAwaitTypeMetadata,
+    maxDepth: 3,
+  },
+);
+
+function includeAwaitTypeMetadata(_node: any, depth: number): boolean {
+  return depth === 1 || depth === 2;
+}

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/native_bridge.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/native_bridge.ts
@@ -16,9 +16,13 @@ type RangedNode = {
 };
 
 type NativeRuleBridgeOptions = {
-  readonly shouldRun?: (node: RangedNode) => boolean;
-  readonly includeTypeTexts?: boolean | ((node: RangedNode) => boolean);
+  readonly shouldRun?: (node: RangedNode, context: ContextWithParserOptions) => boolean;
+  readonly includeTypeTexts?: NodeMetadataOption;
+  readonly includePropertyNames?: NodeMetadataOption;
+  readonly maxDepth?: number;
 };
+
+type NodeMetadataOption = boolean | ((node: RangedNode, depth: number) => boolean);
 
 const MAX_NATIVE_NODE_DEPTH = 4;
 const nativeRuleMetasByName = new Map(nativeLintRuleMetas().map((meta) => [meta.name, meta]));
@@ -44,15 +48,23 @@ export function createRustNativeRule(
         meta.listeners.map((listener) => [
           listener,
           (node: RangedNode) => {
-            if (bridgeOptions.shouldRun?.(node) === false) {
+            if (bridgeOptions.shouldRun?.(node, context) === false) {
               return;
             }
+            const includeTypeTexts = includeTypeTextsOption(bridgeOptions, meta);
             reportNativeDiagnostics(
               context,
               node,
               runNativeLintRule(
                 ruleName,
-                toNativeNode(context, node, shouldIncludeTypeTexts(bridgeOptions, node, meta)),
+                toNativeNode(
+                  context,
+                  node,
+                  includeTypeTexts,
+                  bridgeOptions.maxDepth ?? MAX_NATIVE_NODE_DEPTH,
+                  true,
+                  includePropertyNamesOption(bridgeOptions, includeTypeTexts),
+                ),
               ),
             );
           },
@@ -64,9 +76,11 @@ export function createRustNativeRule(
 export function toNativeNode(
   context: ContextWithParserOptions,
   node: RangedNode,
-  includeTypeTexts = true,
+  includeTypeTexts: NodeMetadataOption = true,
   maxDepth = MAX_NATIVE_NODE_DEPTH,
   includeRuleOptions = true,
+  includePropertyNames: NodeMetadataOption = includeTypeTexts,
+  depth = 0,
 ): NativeLintNode {
   const fields: Record<string, unknown> = {};
   const children: Record<string, NativeLintNode> = {};
@@ -78,14 +92,30 @@ export function toNativeNode(
     }
     if (isNativeChildNode(value)) {
       if (maxDepth > 0) {
-        children[key] = toNativeNode(context, value, includeTypeTexts, maxDepth - 1, false);
+        children[key] = toNativeNode(
+          context,
+          value,
+          includeTypeTexts,
+          maxDepth - 1,
+          false,
+          includePropertyNames,
+          depth + 1,
+        );
       }
       continue;
     }
     if (Array.isArray(value)) {
       if (maxDepth > 0 && value.every(isNativeChildNode)) {
         childLists[key] = value.map((child) =>
-          toNativeNode(context, child, includeTypeTexts, maxDepth - 1, false),
+          toNativeNode(
+            context,
+            child,
+            includeTypeTexts,
+            maxDepth - 1,
+            false,
+            includePropertyNames,
+            depth + 1,
+          ),
         );
       } else if (value.every(isJsonPrimitive)) {
         fields[key] = value;
@@ -118,8 +148,10 @@ export function toNativeNode(
     kind: node.type,
     range: nativeRange(node.range),
   };
-  if (includeTypeTexts) {
+  if (includeMetadataForNode(includeTypeTexts, node, depth)) {
     nativeNode.typeTexts = typeTextsAtNode(context, node);
+  }
+  if (includeMetadataForNode(includePropertyNames, node, depth)) {
     nativeNode.propertyNames = propertyNamesOfNode(context, node);
   }
   if (Object.keys(fields).length > 0) {
@@ -206,15 +238,26 @@ function nativeRuleMeta(ruleName: string): NativeLintRuleMeta {
   return meta;
 }
 
-function shouldIncludeTypeTexts(
+function includeTypeTextsOption(
   options: NativeRuleBridgeOptions,
-  node: RangedNode,
   meta: NativeLintRuleMeta,
-): boolean {
-  if (typeof options.includeTypeTexts === "function") {
-    return options.includeTypeTexts(node);
-  }
+): NodeMetadataOption {
   return options.includeTypeTexts ?? meta.requiresTypeTexts;
+}
+
+function includePropertyNamesOption(
+  options: NativeRuleBridgeOptions,
+  includeTypeTexts: NodeMetadataOption,
+): NodeMetadataOption {
+  return options.includePropertyNames ?? includeTypeTexts;
+}
+
+function includeMetadataForNode(
+  option: NodeMetadataOption,
+  node: RangedNode,
+  depth: number,
+): boolean {
+  return typeof option === "function" ? option(node, depth) : option;
 }
 
 function sourceTypeAnnotationText(

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/no_array_delete.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/no_array_delete.ts
@@ -1,3 +1,16 @@
 import { createRustNativeRule } from "./native_bridge";
 
-export const noArrayDeleteRule = createRustNativeRule("no-array-delete");
+export const noArrayDeleteRule = createRustNativeRule(
+  "no-array-delete",
+  {},
+  {
+    includePropertyNames: false,
+    includeTypeTexts: (_node, depth) => depth === 2,
+    maxDepth: 2,
+    shouldRun: shouldRunNoArrayDelete,
+  },
+);
+
+function shouldRunNoArrayDelete(node: any): boolean {
+  return node.type !== "UnaryExpression" || node.operator === "delete";
+}

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/no_base_to_string.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/no_base_to_string.ts
@@ -5,6 +5,9 @@ export const noBaseToStringRule = createRustNativeRule(
   "no-base-to-string",
   {},
   {
+    includePropertyNames: false,
+    includeTypeTexts: (_node, depth) => depth === 1 || depth === 2,
+    maxDepth: 2,
     shouldRun: shouldRunNoBaseToString,
   },
 );

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/no_floating_promises.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/no_floating_promises.ts
@@ -1,3 +1,21 @@
+import { stripChainExpression } from "./ast";
 import { createRustNativeRule } from "./native_bridge";
 
-export const noFloatingPromisesRule = createRustNativeRule("no-floating-promises");
+export const noFloatingPromisesRule = createRustNativeRule(
+  "no-floating-promises",
+  {},
+  {
+    includePropertyNames: includeFloatingPromiseTypeMetadata,
+    includeTypeTexts: includeFloatingPromiseTypeMetadata,
+    shouldRun: shouldRunNoFloatingPromises,
+  },
+);
+
+function includeFloatingPromiseTypeMetadata(_node: any, depth: number): boolean {
+  return depth === 1 || depth === 2;
+}
+
+function shouldRunNoFloatingPromises(node: any): boolean {
+  const expression = stripChainExpression(node.expression);
+  return !(expression?.type === "UnaryExpression" && expression.operator === "void");
+}

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/no_for_in_array.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/no_for_in_array.ts
@@ -1,3 +1,11 @@
 import { createRustNativeRule } from "./native_bridge";
 
-export const noForInArrayRule = createRustNativeRule("no-for-in-array");
+export const noForInArrayRule = createRustNativeRule(
+  "no-for-in-array",
+  {},
+  {
+    includePropertyNames: false,
+    includeTypeTexts: (_node, depth) => depth === 1,
+    maxDepth: 1,
+  },
+);

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/no_implied_eval.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/no_implied_eval.ts
@@ -1,3 +1,42 @@
+import {
+  calleePropertyName,
+  isIdentifierNamed,
+  memberPropertyName,
+  stripChainExpression,
+} from "./ast";
 import { createRustNativeRule } from "./native_bridge";
 
-export const noImpliedEvalRule = createRustNativeRule("no-implied-eval");
+export const noImpliedEvalRule = createRustNativeRule(
+  "no-implied-eval",
+  {},
+  {
+    includePropertyNames: false,
+    includeTypeTexts: (_node, depth) => depth === 1,
+    maxDepth: 2,
+    shouldRun: shouldRunNoImpliedEval,
+  },
+);
+
+function shouldRunNoImpliedEval(node: any): boolean {
+  switch (node.type) {
+    case "CallExpression":
+      return (
+        node.arguments?.length > 0 &&
+        ["execScript", "setInterval", "setTimeout"].includes(
+          calleeName(node) ?? "",
+        )
+      );
+    case "NewExpression":
+      return node.arguments?.length > 0 && isIdentifierNamed(node.callee, "Function");
+    default:
+      return true;
+  }
+}
+
+function calleeName(node: any): string | undefined {
+  const callee = stripChainExpression(node.callee) as any;
+  if (callee?.type === "Identifier") {
+    return callee.name;
+  }
+  return calleePropertyName(node) ?? memberPropertyName(callee);
+}

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/no_unsafe_assignment.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/no_unsafe_assignment.ts
@@ -4,6 +4,9 @@ export const noUnsafeAssignmentRule = createRustNativeRule(
   "no-unsafe-assignment",
   {},
   {
+    includePropertyNames: false,
+    includeTypeTexts: (_node, depth) => depth === 1,
+    maxDepth: 2,
     shouldRun: shouldRunNoUnsafeAssignment,
   },
 );

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/no_unsafe_return.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/no_unsafe_return.ts
@@ -1,3 +1,23 @@
 import { createRustNativeRule } from "./native_bridge";
 
-export const noUnsafeReturnRule = createRustNativeRule("no-unsafe-return");
+export const noUnsafeReturnRule = createRustNativeRule(
+  "no-unsafe-return",
+  {},
+  {
+    includePropertyNames: false,
+    includeTypeTexts: (_node, depth) => depth === 1,
+    maxDepth: 1,
+    shouldRun: shouldRunNoUnsafeReturn,
+  },
+);
+
+function shouldRunNoUnsafeReturn(node: any): boolean {
+  switch (node.type) {
+    case "ArrowFunctionExpression":
+      return Boolean(node.body) && node.body.type !== "BlockStatement";
+    case "ReturnStatement":
+      return Boolean(node.argument);
+    default:
+      return true;
+  }
+}

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/no_unsafe_unary_minus.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/no_unsafe_unary_minus.ts
@@ -1,3 +1,16 @@
 import { createRustNativeRule } from "./native_bridge";
 
-export const noUnsafeUnaryMinusRule = createRustNativeRule("no-unsafe-unary-minus");
+export const noUnsafeUnaryMinusRule = createRustNativeRule(
+  "no-unsafe-unary-minus",
+  {},
+  {
+    includePropertyNames: false,
+    includeTypeTexts: (_node, depth) => depth === 1,
+    maxDepth: 1,
+    shouldRun: shouldRunNoUnsafeUnaryMinus,
+  },
+);
+
+function shouldRunNoUnsafeUnaryMinus(node: any): boolean {
+  return node.type !== "UnaryExpression" || node.operator === "-";
+}

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/only_throw_error.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/only_throw_error.ts
@@ -1,3 +1,20 @@
 import { createRustNativeRule } from "./native_bridge";
 
-export const onlyThrowErrorRule = createRustNativeRule("only-throw-error");
+export const onlyThrowErrorRule = createRustNativeRule(
+  "only-throw-error",
+  {},
+  {
+    includePropertyNames: includeThrowTypeMetadata,
+    includeTypeTexts: includeThrowTypeMetadata,
+    maxDepth: 2,
+    shouldRun: shouldRunOnlyThrowError,
+  },
+);
+
+function includeThrowTypeMetadata(_node: any, depth: number): boolean {
+  return depth === 1 || depth === 2;
+}
+
+function shouldRunOnlyThrowError(node: any): boolean {
+  return node.type !== "ThrowStatement" || Boolean(node.argument);
+}

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/prefer_promise_reject_errors.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/prefer_promise_reject_errors.ts
@@ -1,5 +1,52 @@
+import { isIdentifierNamed, memberPropertyName, stripChainExpression } from "./ast";
 import { createRustNativeRule } from "./native_bridge";
+import type { ContextWithParserOptions } from "../types";
 
-export const preferPromiseRejectErrorsRule = createRustNativeRule("prefer-promise-reject-errors", {
-  schema: { type: "array" },
-});
+export const preferPromiseRejectErrorsRule = createRustNativeRule(
+  "prefer-promise-reject-errors",
+  {
+    schema: { type: "array" },
+  },
+  {
+    includePropertyNames: includeRejectTypeMetadata,
+    includeTypeTexts: includeRejectTypeMetadata,
+    maxDepth: 2,
+    shouldRun: shouldRunPreferPromiseRejectErrors,
+  },
+);
+
+function includeRejectTypeMetadata(_node: any, depth: number): boolean {
+  return depth === 1 || depth === 2;
+}
+
+function shouldRunPreferPromiseRejectErrors(
+  node: any,
+  context: ContextWithParserOptions,
+): boolean {
+  const callee = stripChainExpression(node.callee) as any;
+  if (memberPropertyName(callee) === "reject") {
+    return true;
+  }
+  return (
+    callee?.type === "Identifier" &&
+    isPromiseExecutorRejectCandidate(context, node, callee.name)
+  );
+}
+
+function isPromiseExecutorRejectCandidate(
+  context: ContextWithParserOptions,
+  node: any,
+  name: string,
+): boolean {
+  const nearestFunction = ((context.sourceCode as any)?.getAncestors?.(node) ?? [])
+    .toReversed()
+    .find((ancestor: any) => ancestor.type?.includes("Function"));
+  const rejectParam = nearestFunction?.params?.[1];
+  if (!rejectParam || rejectParam.type !== "Identifier" || rejectParam.name !== name) {
+    return false;
+  }
+  const promiseConstructor = stripChainExpression(nearestFunction.parent?.parent) as any;
+  const owner =
+    nearestFunction.parent?.type === "NewExpression" ? nearestFunction.parent : promiseConstructor;
+  return owner?.type === "NewExpression" && isIdentifierNamed(owner.callee, "Promise");
+}

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/require_array_sort_compare.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/require_array_sort_compare.ts
@@ -1,5 +1,22 @@
+import { calleePropertyName } from "./ast";
 import { createRustNativeRule } from "./native_bridge";
 
-export const requireArraySortCompareRule = createRustNativeRule("require-array-sort-compare", {
-  schema: { type: "array" },
-});
+export const requireArraySortCompareRule = createRustNativeRule(
+  "require-array-sort-compare",
+  {
+    schema: { type: "array" },
+  },
+  {
+    includePropertyNames: false,
+    includeTypeTexts: (_node, depth) => depth === 2,
+    maxDepth: 2,
+    shouldRun: shouldRunRequireArraySortCompare,
+  },
+);
+
+function shouldRunRequireArraySortCompare(node: any): boolean {
+  return (
+    node.arguments?.length === 0 &&
+    ["sort", "toSorted"].includes(calleePropertyName(node) ?? "")
+  );
+}

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/restrict_plus_operands.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/restrict_plus_operands.ts
@@ -1,5 +1,25 @@
 import { createRustNativeRule } from "./native_bridge";
 
-export const restrictPlusOperandsRule = createRustNativeRule("restrict-plus-operands", {
-  schema: { type: "array" },
-});
+export const restrictPlusOperandsRule = createRustNativeRule(
+  "restrict-plus-operands",
+  {
+    schema: { type: "array" },
+  },
+  {
+    includePropertyNames: false,
+    includeTypeTexts: (_node, depth) => depth === 1,
+    maxDepth: 1,
+    shouldRun: shouldRunRestrictPlusOperands,
+  },
+);
+
+function shouldRunRestrictPlusOperands(node: any): boolean {
+  switch (node.type) {
+    case "AssignmentExpression":
+      return node.operator === "+=";
+    case "BinaryExpression":
+      return node.operator === "+";
+    default:
+      return true;
+  }
+}

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/type_utils.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/type_utils.ts
@@ -17,6 +17,11 @@ import {
 import { isIdentifierNamed, memberPropertyName, stripChainExpression } from "./ast";
 import type { ContextWithParserOptions, TsgoType, TsgoTypeCheckerShape } from "../types";
 
+const baseTypeCache = new WeakMap<object, TsgoType | null>();
+const propertyNamesCache = new WeakMap<object, readonly string[]>();
+const symbolTypeCache = new WeakMap<object, TsgoType | null>();
+const typeTextsCache = new WeakMap<object, readonly string[]>();
+
 export function checkerFor(context: ContextWithParserOptions): TsgoTypeCheckerShape {
   return OxlintUtils.getParserServices(context).program.getTypeChecker();
 }
@@ -32,23 +37,35 @@ export function baseTypeAtNode(
   context: ContextWithParserOptions,
   node: Node | { readonly range: readonly [number, number] },
 ): TsgoType | undefined {
-  const type = typeAtNode(context, node);
-  if (!type) {
-    return undefined;
+  const key = nodeCacheKey(node);
+  if (key && baseTypeCache.has(key)) {
+    return baseTypeCache.get(key) ?? undefined;
   }
-  return checkerFor(context).getBaseTypeOfLiteralType(type) ?? type;
+  const type = typeAtNode(context, node);
+  const resolved = type ? (checkerFor(context).getBaseTypeOfLiteralType(type) ?? type) : undefined;
+  if (key) {
+    baseTypeCache.set(key, resolved ?? null);
+  }
+  return resolved;
 }
 
 export function symbolTypeAtNode(
   context: ContextWithParserOptions,
   node: Node | { readonly range: readonly [number, number] },
 ): TsgoType | undefined {
+  const key = nodeCacheKey(node);
+  if (key && symbolTypeCache.has(key)) {
+    return symbolTypeCache.get(key) ?? undefined;
+  }
   const checker = checkerFor(context);
   const symbol = checker.getSymbolAtLocation(node as Node);
-  if (!symbol) {
-    return undefined;
+  const resolved = symbol
+    ? (checker.getTypeOfSymbol(symbol) ?? checker.getDeclaredTypeOfSymbol(symbol))
+    : undefined;
+  if (key) {
+    symbolTypeCache.set(key, resolved ?? null);
   }
-  return checker.getTypeOfSymbol(symbol) ?? checker.getDeclaredTypeOfSymbol(symbol);
+  return resolved;
 }
 
 export function typeTextAtNode(
@@ -75,6 +92,11 @@ export function propertyNamesOfNode(
   context: ContextWithParserOptions,
   node: Node | { readonly range: readonly [number, number] },
 ): readonly string[] {
+  const key = nodeCacheKey(node);
+  const cached = key ? propertyNamesCache.get(key) : undefined;
+  if (cached) {
+    return cached;
+  }
   const checker = checkerFor(context);
   const names = new Set<string>();
   for (const type of [baseTypeAtNode(context, node), symbolTypeAtNode(context, node)]) {
@@ -85,7 +107,11 @@ export function propertyNamesOfNode(
       names.add(property.name);
     }
   }
-  return [...names];
+  const resolved = [...names];
+  if (key) {
+    propertyNamesCache.set(key, resolved);
+  }
+  return resolved;
 }
 
 export function isPromiseLikeNode(
@@ -184,11 +210,20 @@ export function typeTextsAtNode(
   context: ContextWithParserOptions,
   node: Node | { readonly range: readonly [number, number] },
 ): readonly string[] {
+  const key = nodeCacheKey(node);
+  const cached = key ? typeTextsCache.get(key) : undefined;
+  if (cached) {
+    return cached;
+  }
   const values = new Set<string>();
   const checker = checkerFor(context);
   collectTexts(baseTypeAtNode(context, node));
   collectTexts(symbolTypeAtNode(context, node));
-  return [...values];
+  const resolved = [...values];
+  if (key) {
+    typeTextsCache.set(key, resolved);
+  }
+  return resolved;
 
   function collectTexts(type: TsgoType | undefined): void {
     if (!type) {
@@ -201,6 +236,12 @@ export function typeTextsAtNode(
       }
     }
   }
+}
+
+function nodeCacheKey(
+  node: Node | { readonly range: readonly [number, number] },
+): object | undefined {
+  return typeof node === "object" && node !== null ? node : undefined;
 }
 
 export function classifyTypeText(


### PR DESCRIPTION
## Summary

- add native bridge controls for listener prefilters, serialization depth, type text selection, and property-name selection
- cache repeated type/property lookups per AST node in corsa-oxlint type utilities
- tune Rust-backed rule wrappers so they only serialize and type-check nodes each rule actually reads

## Benchmarks

Nix dev shell, `bench_tooling_compare --suite project-check --iterations 1 --warmup-iterations 0 --timeout-ms 60000`:

- `native-preview` corsa-oxlint: 76,476.878 ms before -> 5,094.147 ms after
- `_extension` corsa-oxlint: 1,044.658 ms after, in the same range as typescript-eslint at 1,080.345 ms
- the default 60s project-check timeout now passes

Closes #131.

## Validation

- `nix develop -c bash -c 'vp pack >/tmp/corsa-vp-pack.log && vp test run --config ./vite.config.ts src/bindings/nodejs/typescript_oxlint/ts/native_rules.test.ts src/bindings/nodejs/typescript_oxlint/ts/native_rule_edges.test.ts'`\n- `nix develop -c bash -c 'cargo run --release -p corsa --bin bench_tooling_compare -- --suite project-check --iterations 1 --warmup-iterations 0 --timeout-ms 60000 --json-output .cache/bench_tooling_compare_project_check_after.json'`\n\nNote: `vp run -w build_node_debug` still fails on this macOS Nix shell while linking `-liconv`; that is separate from this TS bridge perf change.