### PR TITLE
feat(corsa-oxlint): add native restrict-template-expressions

### DIFF
--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -131,6 +131,7 @@ describe("CorsaApiClient", () => {
       "prefer-string-starts-ends-with",
       "require-array-sort-compare",
       "restrict-plus-operands",
+      "restrict-template-expressions",
       "use-unknown-in-catch-callback-variable",
     ]);
     expect(diagnostics).toHaveLength(1);

--- a/src/bindings/nodejs/typescript_oxlint/ts/native_diagnostics_snapshot.test.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/native_diagnostics_snapshot.test.ts
@@ -113,6 +113,12 @@ describe("native diagnostic snapshots", () => {
           ],
         },
         {
+          "caseName": "restrict-template-expressions: object in template literal",
+          "diagnostics": [
+            "restrict-template-expressions/invalidType@17..29: Invalid type used in template literal expression.",
+          ],
+        },
+        {
           "caseName": "use-unknown-in-catch-callback-variable: catch parameter typed as Error",
           "diagnostics": [
             "use-unknown-in-catch-callback-variable/unexpected@23..35: Catch callback variables should be explicitly typed as unknown.",
@@ -268,6 +274,15 @@ const diagnosticCases = [
       children: {
         left: id("left", [0, 4], ["string"]),
         right: id("right", [7, 12], ["number"]),
+      },
+    }),
+  },
+  {
+    ruleName: "restrict-template-expressions",
+    scenario: "object in template literal",
+    node: node("TemplateLiteral", [0, 32], {
+      childLists: {
+        expressions: [id("value", [17, 29], ["{ value: number }"])],
       },
     }),
   },

--- a/src/bindings/nodejs/typescript_oxlint/ts/native_rules.test.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/native_rules.test.ts
@@ -205,6 +205,17 @@ describe("corsa-oxlint native rules", () => {
     );
   });
 
+  integrationCase("runs restrict-template-expressions through RuleTester", () => {
+    createTester().run(
+      "restrict-template-expressions",
+      typescriptOxlintRules["restrict-template-expressions"] as never,
+      {
+        valid: [{ code: "const label = `${1}-${true}`;" }],
+        invalid: [{ code: "const label = `${{ value: 1 }}`;", errors: 1 }],
+      },
+    );
+  });
+
   integrationCase("runs use-unknown-in-catch-callback-variable through RuleTester", () => {
     createTester().run(
       "use-unknown-in-catch-callback-variable",

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/index.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/index.ts
@@ -18,6 +18,7 @@ import { preferRegexpExecRule } from "./prefer_regexp_exec";
 import { preferStringStartsEndsWithRule } from "./prefer_string_starts_ends_with";
 import { requireArraySortCompareRule } from "./require_array_sort_compare";
 import { restrictPlusOperandsRule } from "./restrict_plus_operands";
+import { restrictTemplateExpressionsRule } from "./restrict_template_expressions";
 import { useUnknownInCatchCallbackVariableRule } from "./use_unknown_in_catch_callback_variable";
 
 export const implementedNativeRuleNames = [
@@ -39,6 +40,7 @@ export const implementedNativeRuleNames = [
   "prefer-string-starts-ends-with",
   "require-array-sort-compare",
   "restrict-plus-operands",
+  "restrict-template-expressions",
   "use-unknown-in-catch-callback-variable",
 ] as const;
 
@@ -77,7 +79,6 @@ export const pendingNativeRuleNames = [
   "promise-function-async",
   "related-getter-setter-pairs",
   "require-await",
-  "restrict-template-expressions",
   "return-await",
   "strict-boolean-expressions",
   "strict-void-return",
@@ -104,6 +105,7 @@ export const typescriptOxlintRules = Object.freeze({
   "prefer-string-starts-ends-with": preferStringStartsEndsWithRule,
   "require-array-sort-compare": requireArraySortCompareRule,
   "restrict-plus-operands": restrictPlusOperandsRule,
+  "restrict-template-expressions": restrictTemplateExpressionsRule,
   "use-unknown-in-catch-callback-variable": useUnknownInCatchCallbackVariableRule,
 });
 

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/native_bridge.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/native_bridge.ts
@@ -293,6 +293,9 @@ function addHostFacts(
   if (current.type === "ExpressionStatement") {
     fields.__nearestFunctionAsync = nearestFunctionAncestor(context, current)?.async === true;
   }
+  if (current.type === "TemplateLiteral") {
+    fields.__taggedTemplate = current.parent?.type === "TaggedTemplateExpression";
+  }
   if (current.type === "CallExpression" && isPromiseExecutorRejectCall(context, current)) {
     fields.__promiseExecutorRejectCall = true;
   }

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/restrict_template_expressions.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/restrict_template_expressions.ts
@@ -1,0 +1,5 @@
+import { createRustNativeRule } from "./native_bridge";
+
+export const restrictTemplateExpressionsRule = createRustNativeRule(
+  "restrict-template-expressions",
+);

--- a/src/core/corsa_core/src/lint/mod.rs
+++ b/src/core/corsa_core/src/lint/mod.rs
@@ -16,7 +16,7 @@ pub use rules::{
     NoUnsafeReturnRule, NoUnsafeUnaryMinusRule, OnlyThrowErrorRule, PreferFindRule,
     PreferIncludesRule, PreferPromiseRejectErrorsRule, PreferRegexpExecRule,
     PreferStringStartsEndsWithRule, RequireArraySortCompareRule, RestrictPlusOperandsRule,
-    UseUnknownInCatchCallbackVariableRule,
+    RestrictTemplateExpressionsRule, UseUnknownInCatchCallbackVariableRule,
 };
 pub use types::{
     LintDiagnostic, LintFix, LintNode, LintSuggestion, RuleMessage, RuleMeta, TextRange,

--- a/src/core/corsa_core/src/lint/registry.rs
+++ b/src/core/corsa_core/src/lint/registry.rs
@@ -4,7 +4,8 @@ use super::{
     NoUnsafeAssignmentRule, NoUnsafeReturnRule, NoUnsafeUnaryMinusRule, OnlyThrowErrorRule,
     PreferFindRule, PreferIncludesRule, PreferPromiseRejectErrorsRule, PreferRegexpExecRule,
     PreferStringStartsEndsWithRule, RequireArraySortCompareRule, RestrictPlusOperandsRule,
-    RuleContext, RuleMeta, RustLintRule, UseUnknownInCatchCallbackVariableRule,
+    RestrictTemplateExpressionsRule, RuleContext, RuleMeta, RustLintRule,
+    UseUnknownInCatchCallbackVariableRule,
 };
 
 /// Collection of Rust-authored lint rules addressable by stable rule name.
@@ -46,6 +47,7 @@ impl LintRuleRegistry {
             .with_rule(PreferStringStartsEndsWithRule)
             .with_rule(RequireArraySortCompareRule)
             .with_rule(RestrictPlusOperandsRule)
+            .with_rule(RestrictTemplateExpressionsRule)
             .with_rule(UseUnknownInCatchCallbackVariableRule)
     }
 

--- a/src/core/corsa_core/src/lint/rules/mod.rs
+++ b/src/core/corsa_core/src/lint/rules/mod.rs
@@ -16,6 +16,7 @@ mod prefer_regexp_exec;
 mod prefer_string_starts_ends_with;
 mod require_array_sort_compare;
 mod restrict_plus_operands;
+mod restrict_template_expressions;
 mod use_unknown_in_catch_callback_variable;
 
 pub use await_thenable::AwaitThenableRule;
@@ -36,4 +37,5 @@ pub use prefer_regexp_exec::PreferRegexpExecRule;
 pub use prefer_string_starts_ends_with::PreferStringStartsEndsWithRule;
 pub use require_array_sort_compare::RequireArraySortCompareRule;
 pub use restrict_plus_operands::RestrictPlusOperandsRule;
+pub use restrict_template_expressions::RestrictTemplateExpressionsRule;
 pub use use_unknown_in_catch_callback_variable::UseUnknownInCatchCallbackVariableRule;

--- a/src/core/corsa_core/src/lint/rules/restrict_template_expressions.rs
+++ b/src/core/corsa_core/src/lint/rules/restrict_template_expressions.rs
@@ -1,0 +1,133 @@
+use super::super::{LintNode, RuleContext, RuleMessage, RustLintRule};
+use crate::lint::helpers::{child_list, rule_option_bool};
+use crate::utils::{
+    TypeTextKind, classify_type_text, is_array_like_type_texts, split_top_level_type_text,
+};
+
+/// Type-aware rule that restricts template literal expression types.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct RestrictTemplateExpressionsRule;
+
+const MESSAGES: &[RuleMessage] = &[RuleMessage {
+    id: "invalidType",
+    description: "Invalid type used in template literal expression.",
+}];
+const LISTENERS: &[&str] = &["TemplateLiteral"];
+
+impl RustLintRule for RestrictTemplateExpressionsRule {
+    fn name(&self) -> &'static str {
+        "restrict-template-expressions"
+    }
+
+    fn docs_description(&self) -> &'static str {
+        "Require template literal expressions to be string-compatible."
+    }
+
+    fn messages(&self) -> &'static [RuleMessage] {
+        MESSAGES
+    }
+
+    fn listeners(&self) -> &'static [&'static str] {
+        LISTENERS
+    }
+
+    fn check(&self, ctx: &mut RuleContext<'_>, node: &LintNode) {
+        if node.kind != "TemplateLiteral" || node.field_bool("__taggedTemplate").unwrap_or(false) {
+            return;
+        }
+
+        let options = RestrictTemplateExpressionsOptions::from_node(node);
+        for expression in child_list(node, "expressions") {
+            if !is_allowed_expression(expression, options) {
+                ctx.report("invalidType", expression.range);
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct RestrictTemplateExpressionsOptions {
+    allow_any: bool,
+    allow_array: bool,
+    allow_boolean: bool,
+    allow_never: bool,
+    allow_nullish: bool,
+    allow_number: bool,
+    allow_regexp: bool,
+}
+
+impl RestrictTemplateExpressionsOptions {
+    fn from_node(node: &LintNode) -> Self {
+        Self {
+            allow_any: rule_option_bool(node, "allowAny").unwrap_or(true),
+            allow_array: rule_option_bool(node, "allowArray").unwrap_or(false),
+            allow_boolean: rule_option_bool(node, "allowBoolean").unwrap_or(true),
+            allow_never: rule_option_bool(node, "allowNever").unwrap_or(false),
+            allow_nullish: rule_option_bool(node, "allowNullish").unwrap_or(true),
+            allow_number: rule_option_bool(node, "allowNumber").unwrap_or(true),
+            allow_regexp: rule_option_bool(node, "allowRegExp").unwrap_or(true),
+        }
+    }
+}
+
+fn is_allowed_expression(
+    expression: &LintNode,
+    options: RestrictTemplateExpressionsOptions,
+) -> bool {
+    if matches!(
+        expression.kind.as_str(),
+        "ObjectExpression" | "FunctionExpression" | "ArrowFunctionExpression"
+    ) {
+        return false;
+    }
+    if expression.kind == "ArrayExpression" {
+        return options.allow_array;
+    }
+
+    !expression.type_texts.is_empty()
+        && expression
+            .type_texts
+            .iter()
+            .all(|text| is_allowed_type_text(text, options))
+}
+
+fn is_allowed_type_text(text: &str, options: RestrictTemplateExpressionsOptions) -> bool {
+    split_top_level_type_text(text, '|')
+        .iter()
+        .all(|part| is_allowed_intersection_type_text(part, options))
+}
+
+fn is_allowed_intersection_type_text(
+    text: &str,
+    options: RestrictTemplateExpressionsOptions,
+) -> bool {
+    split_top_level_type_text(text, '&')
+        .iter()
+        .any(|part| is_allowed_atom_type_text(part, options))
+}
+
+fn is_allowed_atom_type_text(text: &str, options: RestrictTemplateExpressionsOptions) -> bool {
+    let text = text.trim();
+    if text.is_empty() {
+        return false;
+    }
+    if options.allow_array && is_array_like_type_texts(&[text]) {
+        return true;
+    }
+
+    match classify_type_text(Some(text)) {
+        TypeTextKind::String => true,
+        TypeTextKind::Any => options.allow_any,
+        TypeTextKind::Boolean => options.allow_boolean,
+        TypeTextKind::Bigint | TypeTextKind::Number => options.allow_number,
+        TypeTextKind::Nullish => options.allow_nullish,
+        TypeTextKind::Regexp => options.allow_regexp,
+        TypeTextKind::Unknown if text == "never" => options.allow_never,
+        TypeTextKind::Other => is_default_allowed_named_type(text),
+        TypeTextKind::Unknown => false,
+    }
+}
+
+fn is_default_allowed_named_type(text: &str) -> bool {
+    matches!(text, "Error" | "URL" | "URLSearchParams") || text.ends_with("Error")
+}

--- a/src/core/corsa_core/src/lint/tests.rs
+++ b/src/core/corsa_core/src/lint/tests.rs
@@ -387,6 +387,75 @@ fn allows_default_string_number_plus() {
 }
 
 #[test]
+fn reports_restricted_template_expression_object() {
+    let diagnostics = registry()
+        .run_rule(
+            "restrict-template-expressions",
+            &template_node(vec![typed_node(
+                "ObjectExpression",
+                TextRange::new(17, 29),
+                "{ value: number }",
+            )]),
+        )
+        .unwrap();
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].rule_name, "restrict-template-expressions");
+    assert_eq!(diagnostics[0].message_id, "invalidType");
+    assert_eq!(diagnostics[0].range, TextRange::new(17, 29));
+}
+
+#[test]
+fn allows_restricted_template_expression_default_primitives() {
+    let diagnostics = registry()
+        .run_rule(
+            "restrict-template-expressions",
+            &template_node(vec![
+                typed_node("Identifier", TextRange::new(9, 14), "number"),
+                typed_node("Identifier", TextRange::new(17, 21), "boolean | null"),
+            ]),
+        )
+        .unwrap();
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn respects_restricted_template_expression_boolean_option() {
+    let mut node = template_node(vec![typed_node(
+        "Identifier",
+        TextRange::new(17, 21),
+        "boolean",
+    )]);
+    node.fields
+        .insert("__ruleOptions".to_owned(), json!([{ "allowBoolean": false }]));
+
+    let diagnostics = registry()
+        .run_rule("restrict-template-expressions", &node)
+        .unwrap();
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message_id, "invalidType");
+}
+
+#[test]
+fn ignores_tagged_template_expressions() {
+    let mut node = template_node(vec![typed_node(
+        "ObjectExpression",
+        TextRange::new(5, 17),
+        "{ value: number }",
+    )]);
+    node.fields
+        .insert("__taggedTemplate".to_owned(), json!(true));
+
+    let diagnostics = registry()
+        .run_rule("restrict-template-expressions", &node)
+        .unwrap();
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
 fn lists_default_rule_meta() {
     let registry = registry();
     assert_eq!(
@@ -410,6 +479,7 @@ fn lists_default_rule_meta() {
             "prefer-string-starts-ends-with",
             "require-array-sort-compare",
             "restrict-plus-operands",
+            "restrict-template-expressions",
             "use-unknown-in-catch-callback-variable"
         ]
     );
@@ -581,6 +651,21 @@ fn binary_plus_node(left_type_text: &str, right_type_text: &str) -> LintNode {
     );
     node.fields.insert("operator".to_owned(), json!("+"));
     node
+}
+
+fn typed_node(kind: &str, range: TextRange, type_text: &str) -> LintNode {
+    let mut node = node(kind, range);
+    node.type_texts = vec![type_text.to_owned()];
+    node
+}
+
+fn template_node(expressions: Vec<LintNode>) -> LintNode {
+    node_with_child_list(
+        "TemplateLiteral",
+        TextRange::new(0, 32),
+        "expressions",
+        expressions,
+    )
 }
 
 fn array_delete_node() -> LintNode {


### PR DESCRIPTION
## Summary

- implement Rust-backed `restrict-template-expressions` using compact template expression type facts
- wire the rule into the corsa-oxlint native rule registry and remove it from the pending list
- add Rust unit coverage, native diagnostic snapshots, metadata checks, and RuleTester integration

Refs #120.

## Validation

- `nix develop -c cargo test -p corsa_core`
- `nix develop -c bash -c 'vp test run --config ./vite.config.ts src/bindings/nodejs/typescript_oxlint/ts/native_diagnostics_snapshot.test.ts src/bindings/nodejs/typescript_oxlint/ts/native_rules.test.ts src/bindings/nodejs/corsa_node/ts/index.test.ts'`
- `nix develop -c bash -c 'vp pack >/tmp/corsa-vp-pack.log'`

Note: for the local macOS N-API rebuild used before the Node test, I had to pass `RUSTFLAGS="-C link-arg=-L${LIBRARY_PATH%:}"` inside the Nix shell so `-liconv` resolves.