### PR TITLE
fix(corsa-oxlint): restore API surface CI

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,10 @@ importers:
       oxlint:
         specifier: 1.66.0
         version: 1.66.0(oxlint-tsgolint@0.22.1)
+    devDependencies:
+      '@typescript-eslint/utils':
+        specifier: 8.59.3
+        version: 8.59.3(eslint@10.4.0)(typescript@6.0.3)
 
 packages:
 
@@ -69,6 +73,56 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.6.0':
+    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.1':
+    resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
@@ -1135,11 +1189,54 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@typescript-eslint/project-service@8.59.3':
+    resolution: {integrity: sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.59.3':
+    resolution: {integrity: sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.3':
+    resolution: {integrity: sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.59.3':
+    resolution: {integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.3':
+    resolution: {integrity: sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.59.3':
+    resolution: {integrity: sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.3':
+    resolution: {integrity: sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitest/expect@4.1.6':
     resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
@@ -1316,6 +1413,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1323,8 +1433,16 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1352,6 +1470,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1360,6 +1482,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1382,8 +1507,54 @@ packages:
   es-toolkit@1.46.1:
     resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.4.0:
+    resolution: {integrity: sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1391,6 +1562,15 @@ packages:
 
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -1410,21 +1590,75 @@ packages:
       picomatch:
         optional: true
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
   json-with-bigint@3.5.8:
     resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1500,8 +1734,16 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -1519,8 +1761,15 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
 
   oxfmt@0.48.0:
     resolution: {integrity: sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g==}
@@ -1551,6 +1800,22 @@ packages:
       oxlint-tsgolint:
         optional: true
 
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -1573,6 +1838,14 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   rolldown@1.0.1:
     resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1585,6 +1858,14 @@ packages:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1630,11 +1911,21 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   typanion@3.14.0:
     resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -1646,6 +1937,9 @@ packages:
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   vite-plus@0.1.21:
     resolution: {integrity: sha512-7MLc9abMelE8g5/vj/xEY8joWT9PLnN/XjX3FhwOliB75WOX3YADcMEFrufmvnl+D4UhrMNZQa2k3A5CSuFJhw==}
@@ -1736,10 +2030,19 @@ packages:
       jsdom:
         optional: true
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
 
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
@@ -1752,6 +2055,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
 snapshots:
 
@@ -1770,6 +2077,52 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.0)':
+    dependencies:
+      eslint: 10.4.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.6.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.1':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@inquirer/ansi@2.0.5': {}
 
@@ -2486,11 +2839,66 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
+
+  '@typescript-eslint/project-service@8.59.3(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.3
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.59.3':
+    dependencies:
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/visitor-keys': 8.59.3
+
+  '@typescript-eslint/tsconfig-utils@8.59.3(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/types@8.59.3': {}
+
+  '@typescript-eslint/typescript-estree@8.59.3(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.3(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/visitor-keys': 8.59.3
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.0
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.59.3(eslint@10.4.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0)
+      '@typescript-eslint/scope-manager': 8.59.3
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@6.0.3)
+      eslint: 10.4.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.59.3':
+    dependencies:
+      '@typescript-eslint/types': 8.59.3
+      eslint-visitor-keys: 5.0.1
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -2608,11 +3016,30 @@ snapshots:
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.21':
     optional: true
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
 
+  balanced-match@4.0.4: {}
+
   before-after-hook@4.0.0: {}
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   chai@6.2.2: {}
 
@@ -2630,9 +3057,17 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  deep-is@0.1.4: {}
 
   detect-libc@2.1.2: {}
 
@@ -2644,13 +3079,85 @@ snapshots:
 
   es-toolkit@1.46.1: {}
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.4.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.6.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
+  esutils@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   fast-content-type-parse@3.0.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -2666,18 +3173,65 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
+
   fsevents@2.3.3:
     optional: true
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
 
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
+  ignore@5.3.2: {}
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  isexe@2.0.0: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
   json-with-bigint@3.5.8: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -2728,9 +3282,17 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
 
   mrmime@2.0.1: {}
 
@@ -2740,7 +3302,18 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  natural-compare@1.4.0: {}
+
   obug@2.1.1: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
 
   oxfmt@0.48.0:
     dependencies:
@@ -2821,6 +3394,18 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.66.0
       oxlint-tsgolint: 0.22.1
 
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -2838,6 +3423,10 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  punycode@2.3.1: {}
 
   rolldown@1.0.1:
     dependencies:
@@ -2863,6 +3452,12 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   semver@7.8.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
 
@@ -2895,16 +3490,28 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
   tslib@2.8.1:
     optional: true
 
   typanion@3.14.0: {}
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
 
   typescript@6.0.3: {}
 
   undici-types@7.24.6: {}
 
   universal-user-agent@7.0.3: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   vite-plus@0.1.21(@types/node@25.9.1)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.1)):
     dependencies:
@@ -2992,9 +3599,17 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  word-wrap@1.2.5: {}
+
   ws@8.20.1: {}
+
+  yocto-queue@0.1.0: {}

--- a/src/bindings/nodejs/typescript_oxlint/package.json
+++ b/src/bindings/nodejs/typescript_oxlint/package.json
@@ -75,6 +75,9 @@
     "@oxlint/plugins": "1.66.0",
     "oxlint": "1.66.0"
   },
+  "devDependencies": {
+    "@typescript-eslint/utils": "8.59.3"
+  },
   "engines": {
     "node": ">=22"
   }

--- a/src/bindings/nodejs/typescript_oxlint/ts/api_surface.test.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/api_surface.test.ts
@@ -51,8 +51,7 @@ describe("api surface", () => {
   });
 
   it("tracks the pinned typescript-eslint utility namespace keys", async () => {
-    const upstream =
-      await import("../../../../../bench/cli_compare/node_modules/@typescript-eslint/utils/dist/index.js");
+    const upstream = await importUpstreamUtils();
 
     expectMissingKeys("root", main, upstream, ["__esModule", "default", "module.exports"]);
     expectMissingKeys("AST_NODE_TYPES", main.AST_NODE_TYPES, upstream.AST_NODE_TYPES);
@@ -90,8 +89,7 @@ describe("api surface", () => {
   });
 
   it("supports scope-free ASTUtils static evaluation helpers", async () => {
-    const upstream =
-      await import("../../../../../bench/cli_compare/node_modules/@typescript-eslint/utils/dist/index.js");
+    const upstream = await importUpstreamUtils();
     const member = {
       type: "MemberExpression",
       computed: false,
@@ -124,41 +122,42 @@ describe("api surface", () => {
     expect(astUtilsEntry.getStringIfConstant(template)).toBe(
       upstream.ASTUtils.getStringIfConstant(template),
     );
-    expect(astUtilsEntry.getStaticValue(binary)).toEqual(
-      upstream.ASTUtils.getStaticValue(binary),
-    );
+    expect(astUtilsEntry.getStaticValue(binary)).toEqual(upstream.ASTUtils.getStaticValue(binary));
     expect(
       astUtilsEntry.getStringIfConstant({
         type: "Literal",
         value: null,
         regex: { pattern: "a+", flags: "u" },
       }),
-    ).toBe(upstream.ASTUtils.getStringIfConstant({
-      type: "Literal",
-      value: null,
-      regex: { pattern: "a+", flags: "u" },
-    }));
+    ).toBe(
+      upstream.ASTUtils.getStringIfConstant({
+        type: "Literal",
+        value: null,
+        regex: { pattern: "a+", flags: "u" },
+      }),
+    );
     expect(
       astUtilsEntry.getPropertyName({
         type: "PropertyDefinition",
         computed: false,
         key: { type: "PrivateIdentifier", name: "value" },
       }),
-    ).toBe(upstream.ASTUtils.getPropertyName({
-      type: "PropertyDefinition",
-      computed: false,
-      key: { type: "PrivateIdentifier", name: "value" },
-    }));
+    ).toBe(
+      upstream.ASTUtils.getPropertyName({
+        type: "PropertyDefinition",
+        computed: false,
+        key: { type: "PrivateIdentifier", name: "value" },
+      }),
+    );
   });
 
   it("matches scope and function ASTUtils helpers for lightweight inputs", async () => {
-    const upstream =
-      await import("../../../../../bench/cli_compare/node_modules/@typescript-eslint/utils/dist/index.js");
-    const innerVariable = { name: "value" };
+    const upstream = await importUpstreamUtils();
+    const innerVariable = variable(idNode("value"));
     const outerScope = {
       block: { range: [0, 100] },
       childScopes: [] as unknown[],
-      set: new Map<string, unknown>([["outer", { name: "outer" }]]),
+      set: new Map<string, unknown>([["outer", variable(idNode("outer"))]]),
       upper: null,
     };
     const innerScope = {
@@ -168,12 +167,12 @@ describe("api surface", () => {
       upper: outerScope,
     };
     outerScope.childScopes = [innerScope];
-    const identifier = { type: "Identifier", name: "value", range: [10, 15] };
+    const identifier = { type: "Identifier", name: "value", range: [10, 15] as const };
 
-    expect(astUtilsEntry.getInnermostScope(outerScope, identifier)).toBe(
+    expect(astUtilsEntry.getInnermostScope(outerScope as never, identifier)).toBe(
       upstream.ASTUtils.getInnermostScope(outerScope, identifier),
     );
-    expect(astUtilsEntry.findVariable(outerScope, identifier)).toBe(
+    expect(astUtilsEntry.findVariable(outerScope as never, identifier)).toBe(
       upstream.ASTUtils.findVariable(outerScope, identifier),
     );
 
@@ -207,8 +206,7 @@ describe("api surface", () => {
   });
 
   it("matches PatternMatcher and side-effect helper behavior", async () => {
-    const upstream =
-      await import("../../../../../bench/cli_compare/node_modules/@typescript-eslint/utils/dist/index.js");
+    const upstream = await importUpstreamUtils();
     const input = "foo \\foo foo";
     const localMatcher = new astUtilsEntry.PatternMatcher(/foo/g);
     const upstreamMatcher = new upstream.ASTUtils.PatternMatcher(/foo/g);
@@ -266,8 +264,7 @@ describe("api surface", () => {
   });
 
   it("matches ReferenceTracker for global, CommonJS, and ESM references", async () => {
-    const upstream =
-      await import("../../../../../bench/cli_compare/node_modules/@typescript-eslint/utils/dist/index.js");
+    const upstream = await importUpstreamUtils();
 
     const globalScope = programScope();
     const mathId = idNode("Math");
@@ -340,7 +337,7 @@ describe("api surface", () => {
 
     const localEsmTrace = {
       fs: {
-        [astUtilsEntry.ReferenceTracker.ESM]: true,
+        [astUtilsEntry.ReferenceTracker.ESM]: true as const,
         readFile: { [astUtilsEntry.ReferenceTracker.CALL]: "esm call" },
       },
     };
@@ -389,6 +386,10 @@ function expectMissingKeys(
     .filter((key) => !ignoredKeys.has(key))
     .filter((key) => !localKeys.has(key));
   expect(missing, `${label} missing keys`).toEqual([]);
+}
+
+async function importUpstreamUtils(): Promise<any> {
+  return await import("@typescript-eslint/utils");
 }
 
 function programScope() {
@@ -466,12 +467,14 @@ function importNamedDeclaration(source: string, imported: string, local: Record<
   return node;
 }
 
-function summarizeReferences(references: Iterable<{
-  readonly info: unknown;
-  readonly node: { readonly type?: string };
-  readonly path: readonly string[];
-  readonly type: symbol;
-}>) {
+function summarizeReferences(
+  references: Iterable<{
+    readonly info: unknown;
+    readonly node: { readonly type?: string };
+    readonly path: readonly string[];
+    readonly type: symbol;
+  }>,
+) {
   return [...references].map((reference) => ({
     info: reference.info,
     nodeType: reference.node.type,

--- a/src/bindings/nodejs/typescript_oxlint/ts/ast_utils.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/ast_utils.ts
@@ -1,7 +1,11 @@
 type TypedValue = { readonly type?: string };
 type ValueToken = { readonly type?: string; readonly value?: string };
 type Predicate<T> = (value: T | null | undefined) => boolean;
-type AstNode = Record<string, unknown> & { readonly type?: string };
+type AstNode = Record<string, unknown> & {
+  readonly name?: string;
+  readonly range?: readonly [number, number];
+  readonly type?: string;
+};
 type StaticValue = { readonly value: unknown } | null;
 type Position = { readonly line: number; readonly column: number };
 type SourceLocation = { readonly start: Position; readonly end: Position };
@@ -32,13 +36,15 @@ type VariableLike = {
   readonly defs?: readonly unknown[];
   readonly references?: readonly ReferenceLike[];
 };
-type TraceMap<T = unknown> = Record<PropertyKey, TraceMapElement<T> | T | true | undefined>;
-type TraceMapElement<T = unknown> = TraceMap<T> & {
+type TraceMapValue<T> = TraceMapElement<T> | T | true | undefined;
+interface TraceMapElement<T = never> {
+  readonly [key: string]: TraceMapValue<T>;
+  readonly [key: number]: TraceMapValue<T>;
   [ReferenceTracker.READ]?: T;
   [ReferenceTracker.CALL]?: T;
   [ReferenceTracker.CONSTRUCT]?: T;
   [ReferenceTracker.ESM]?: true;
-};
+}
 type FoundReference<T = unknown> = {
   info: T;
   node: AstNode;
@@ -336,8 +342,10 @@ export function getInnermostScope(
 
 export function findVariable(
   initialScope: ScopeLike | null | undefined,
-  nameOrNode: string | ({ readonly name?: string } & { readonly range?: readonly [number, number] }),
-): unknown | null {
+  nameOrNode:
+    | string
+    | ({ readonly name?: string } & { readonly range?: readonly [number, number] }),
+): VariableLike | null {
   if (!initialScope) {
     return null;
   }
@@ -347,9 +355,8 @@ export function findVariable(
     return null;
   }
 
-  let scope: ScopeLike | null = typeof nameOrNode === "string"
-    ? initialScope
-    : getInnermostScope(initialScope, nameOrNode);
+  let scope: ScopeLike | null =
+    typeof nameOrNode === "string" ? initialScope : getInnermostScope(initialScope, nameOrNode);
   while (scope) {
     const variable = scope.set?.get(name);
     if (variable != null) {
@@ -580,8 +587,9 @@ export function getStaticValue(node: AstNode | null | undefined): StaticValue {
 
 export function getStringIfConstant(node: AstNode | null | undefined): string | null {
   if (node?.type === "Literal" && (node as { readonly value?: unknown }).value === null) {
-    const regex = (node as { readonly regex?: { readonly pattern?: string; readonly flags?: string } })
-      .regex;
+    const regex = (
+      node as { readonly regex?: { readonly pattern?: string; readonly flags?: string } }
+    ).regex;
     if (regex?.pattern != null && regex.flags != null) {
       return `/${regex.pattern}/${regex.flags}`;
     }
@@ -718,7 +726,12 @@ export class ReferenceTracker {
     } = {},
   ) {
     this.#globalScope = globalScope;
-    this.#globalObjectNames = options.globalObjectNames ?? ["global", "globalThis", "self", "window"];
+    this.#globalObjectNames = options.globalObjectNames ?? [
+      "global",
+      "globalThis",
+      "self",
+      "window",
+    ];
     this.#mode = options.mode ?? "strict";
   }
 
@@ -769,7 +782,11 @@ export class ReferenceTracker {
     const program = this.#globalScope.block;
     for (const node of arrayField<AstNode>(program ?? {}, "body")) {
       const source = node.source;
-      if (!isRecord(source) || typeof source.value !== "string" || !hasOwn(traceMap, source.value)) {
+      if (
+        !isRecord(source) ||
+        typeof source.value !== "string" ||
+        !hasOwn(traceMap, source.value)
+      ) {
         continue;
       }
       const nextTraceMap = traceElement(traceMap, source.value);
@@ -980,10 +997,14 @@ export class ReferenceTracker {
     path: string[],
     traceMap: TraceMapElement<T>,
   ): IterableIterator<FoundReference<T>> {
-    if (specifierNode.type === "ImportSpecifier" || specifierNode.type === "ImportDefaultSpecifier") {
-      const key = specifierNode.type === "ImportDefaultSpecifier"
-        ? "default"
-        : importNameOf(childNode(specifierNode, "imported"));
+    if (
+      specifierNode.type === "ImportSpecifier" ||
+      specifierNode.type === "ImportDefaultSpecifier"
+    ) {
+      const key =
+        specifierNode.type === "ImportDefaultSpecifier"
+          ? "default"
+          : importNameOf(childNode(specifierNode, "imported"));
       const nextTraceMap = key == null ? null : traceElement(traceMap, key);
       if (!key || !nextTraceMap) {
         return;
@@ -997,9 +1018,8 @@ export class ReferenceTracker {
           info: nextTraceMap[ReferenceTracker.READ] as T,
         };
       }
-      const variable = findVariable(this.#globalScope, childNode(specifierNode, "local") ?? {}) as
-        | VariableLike
-        | null;
+      const local = childNode(specifierNode, "local");
+      const variable = local ? findVariable(this.#globalScope, local) : null;
       if (variable) {
         yield* this.#iterateVariableReferences(variable, nextPath, nextTraceMap, false);
       }
@@ -1007,9 +1027,8 @@ export class ReferenceTracker {
     }
 
     if (specifierNode.type === "ImportNamespaceSpecifier") {
-      const variable = findVariable(this.#globalScope, childNode(specifierNode, "local") ?? {}) as
-        | VariableLike
-        | null;
+      const local = childNode(specifierNode, "local");
+      const variable = local ? findVariable(this.#globalScope, local) : null;
       if (variable) {
         yield* this.#iterateVariableReferences(variable, path, traceMap, false);
       }
@@ -1137,7 +1156,7 @@ function traceElement<T>(
   if (!hasOwn(traceMap, key)) {
     return null;
   }
-  const value = traceMap[key];
+  const value = Reflect.get(traceMap, key) as TraceMapValue<T>;
   return isRecord(value) ? (value as TraceMapElement<T>) : null;
 }
 
@@ -1207,26 +1226,18 @@ function locationOf(node: AstNode): SourceLocation | undefined {
 }
 
 function isSourceLocation(value: unknown): value is SourceLocation {
-  return (
-    isRecord(value) &&
-    isPosition(value.start) &&
-    isPosition(value.end)
-  );
+  return isRecord(value) && isPosition(value.start) && isPosition(value.end);
 }
 
 function isPosition(value: unknown): value is Position {
-  return (
-    isRecord(value) &&
-    typeof value.line === "number" &&
-    typeof value.column === "number"
-  );
+  return isRecord(value) && typeof value.line === "number" && typeof value.column === "number";
 }
 
 function getOpeningParenOfParams(node: AstNode, sourceCode: SourceCodeLike): TokenLike | null {
   const id = childNode(node, "id");
   return id
-    ? sourceCode.getTokenAfter?.(id, isOpeningParenToken) ?? null
-    : sourceCode.getFirstToken?.(node, isOpeningParenToken) ?? null;
+    ? (sourceCode.getTokenAfter?.(id, isOpeningParenToken) ?? null)
+    : (sourceCode.getFirstToken?.(node, isOpeningParenToken) ?? null);
 }
 
 function staticTemplateValue(node: AstNode): StaticValue {
@@ -1476,13 +1487,7 @@ const typeConversionBinaryOps = new Set([
   "in",
 ]);
 const typeConversionUnaryOps = new Set(["-", "+", "!", "~"]);
-const skippedAstChildKeys = new Set([
-  "comments",
-  "loc",
-  "parent",
-  "range",
-  "tokens",
-]);
+const skippedAstChildKeys = new Set(["comments", "loc", "parent", "range", "tokens"]);
 
 function isImplicitTypeConversionSideEffectNode(
   node: AstNode,
@@ -1496,7 +1501,9 @@ function isImplicitTypeConversionSideEffectNode(
     node.type === "BinaryExpression" &&
     typeConversionBinaryOps.has(stringField(node, "operator") ?? "")
   ) {
-    return childNode(node, "left")?.type !== "Literal" || childNode(node, "right")?.type !== "Literal";
+    return (
+      childNode(node, "left")?.type !== "Literal" || childNode(node, "right")?.type !== "Literal"
+    );
   }
 
   if (
@@ -1506,7 +1513,9 @@ function isImplicitTypeConversionSideEffectNode(
       node.type === "PropertyDefinition") &&
     isComputedProperty(node)
   ) {
-    return childNode(node, node.type === "MemberExpression" ? "property" : "key")?.type !== "Literal";
+    return (
+      childNode(node, node.type === "MemberExpression" ? "property" : "key")?.type !== "Literal"
+    );
   }
 
   return (
@@ -1591,7 +1600,7 @@ function replacePatternWithFunction(
 
   for (const match of matcher.execAll(str)) {
     chunks.push(str.slice(index, match.index));
-    chunks.push(String(replace(...match, match.index, match.input)));
+    chunks.push(String(replace(match[0], ...match.slice(1), match.index, match.input)));
     index = match.index + match[0].length;
   }
   chunks.push(str.slice(index));
@@ -1611,16 +1620,4 @@ function keywordWithValue(expected: string) {
 
 function not<T extends readonly unknown[]>(predicate: (...args: T) => boolean) {
   return (...args: T): boolean => !predicate(...args);
-}
-
-function unsupportedAstUtilsFunction(name: string): (...args: unknown[]) => never {
-  return (..._args: unknown[]): never => {
-    throw unsupportedAstUtilsError(name);
-  };
-}
-
-function unsupportedAstUtilsError(name: string): Error {
-  return new Error(
-    `ASTUtils.${name} is not supported by corsa-oxlint because it depends on ESLint SourceCode or scope internals.`,
-  );
 }

--- a/src/bindings/nodejs/typescript_oxlint/ts/native_diagnostics_snapshot.test.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/native_diagnostics_snapshot.test.ts
@@ -315,13 +315,18 @@ const diagnosticCases = [
   {
     ruleName: "prefer-reduce-type-parameter",
     scenario: "reduce initial value asserted as array",
-    node: memberCall(id("values", [0, 6], ["number[]"]), "reduce", [0, 57], [
-      node("ArrowFunctionExpression", [14, 38]),
-      node("TSAsExpression", [42, 56], {
-        fields: { __typeAnnotationText: "number[]" },
-        children: { expression: node("ArrayExpression", [42, 44]) },
-      }),
-    ]),
+    node: memberCall(
+      id("values", [0, 6], ["number[]"]),
+      "reduce",
+      [0, 57],
+      [
+        node("ArrowFunctionExpression", [14, 38]),
+        node("TSAsExpression", [42, 56], {
+          fields: { __typeAnnotationText: "number[]" },
+          children: { expression: node("ArrayExpression", [42, 44]) },
+        }),
+      ],
+    ),
   },
   {
     ruleName: "prefer-regexp-exec",

--- a/src/bindings/nodejs/typescript_oxlint/ts/native_rules.test.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/native_rules.test.ts
@@ -244,9 +244,7 @@ describe("corsa-oxlint native rules", () => {
       "prefer-reduce-type-parameter",
       typescriptOxlintRules["prefer-reduce-type-parameter"] as never,
       {
-        valid: [
-          { code: "const result = [1, 2, 3].reduce<number[]>((acc, value) => acc, []);" },
-        ],
+        valid: [{ code: "const result = [1, 2, 3].reduce<number[]>((acc, value) => acc, []);" }],
         invalid: [
           {
             code: "const result = [1, 2, 3].reduce((acc, value) => acc, [] as number[]);",

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/no_implied_eval.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/no_implied_eval.ts
@@ -22,9 +22,7 @@ function shouldRunNoImpliedEval(node: any): boolean {
     case "CallExpression":
       return (
         node.arguments?.length > 0 &&
-        ["execScript", "setInterval", "setTimeout"].includes(
-          calleeName(node) ?? "",
-        )
+        ["execScript", "setInterval", "setTimeout"].includes(calleeName(node) ?? "")
       );
     case "NewExpression":
       return node.arguments?.length > 0 && isIdentifierNamed(node.callee, "Function");

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/prefer_promise_reject_errors.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/prefer_promise_reject_errors.ts
@@ -19,17 +19,13 @@ function includeRejectTypeMetadata(_node: any, depth: number): boolean {
   return depth === 1 || depth === 2;
 }
 
-function shouldRunPreferPromiseRejectErrors(
-  node: any,
-  context: ContextWithParserOptions,
-): boolean {
+function shouldRunPreferPromiseRejectErrors(node: any, context: ContextWithParserOptions): boolean {
   const callee = stripChainExpression(node.callee) as any;
   if (memberPropertyName(callee) === "reject") {
     return true;
   }
   return (
-    callee?.type === "Identifier" &&
-    isPromiseExecutorRejectCandidate(context, node, callee.name)
+    callee?.type === "Identifier" && isPromiseExecutorRejectCandidate(context, node, callee.name)
   );
 }
 

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/require_array_sort_compare.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/require_array_sort_compare.ts
@@ -16,7 +16,6 @@ export const requireArraySortCompareRule = createRustNativeRule(
 
 function shouldRunRequireArraySortCompare(node: any): boolean {
   return (
-    node.arguments?.length === 0 &&
-    ["sort", "toSorted"].includes(calleePropertyName(node) ?? "")
+    node.arguments?.length === 0 && ["sort", "toSorted"].includes(calleePropertyName(node) ?? "")
   );
 }


### PR DESCRIPTION
## Summary
- replace API surface tests' direct benchmark node_modules import with a pinned workspace dev dependency
- make the ReferenceTracker trace-map and findVariable helper types compatible with TypeScript 6
- apply the JS/TS formatting changes required by main CI

## Validation
- `vp fmt --check`
- `vp check --no-fmt`
- `vp run -w test`

Closes #122