### PR TITLE
feat: support Deno and Bun runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,8 +164,21 @@ jobs:
           cache: true
           run-install: true
 
+      - name: Setup Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.x
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.2.18"
+
       - name: Build workspace
         run: vp run -w build_ci
+
+      - name: Check Deno and Bun runtime compatibility
+        run: vp run -w check_js_runtime_compat
 
   test:
     name: Test (${{ matrix.os }})

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # corsa
 
-Rust bindings, orchestration layers, and Node bindings for `typescript-go` over stdio.
+Rust bindings, orchestration layers, and JS runtime bindings for `typescript-go` over stdio.
 
 > [!WARNING]
 > This repository is still evolving.
@@ -16,7 +16,7 @@ Rust bindings, orchestration layers, and Node bindings for `typescript-go` over 
 
 ## What This Is
 
-`corsa` is a multi-crate workspace for talking to `typescript-go` from Rust and Node.js without patching upstream, with a Rust-backed native FFI layer that exposes `tsgo` API, virtual-document, and `utils` surfaces across C-family and other native languages.
+`corsa` is a multi-crate workspace for talking to `typescript-go` from Rust and JavaScript runtimes without patching upstream, with a Rust-backed native FFI layer that exposes `tsgo` API, virtual-document, and `utils` surfaces across C-family and other native languages.
 
 In practice, that means:
 
@@ -47,7 +47,7 @@ Current focus:
 - Fast-path bias: `CompactString`, `SmallVec`, `bumpalo`, `memchr`, `phf`, `FxHash`
 - JS toolchain: Vite+ (`vp`) with vp-managed Node `24`, pnpm `10`, `oxfmt`, and `oxlint`
 - Repo automation: `scripts/*.ts` executed directly through Node `24` with `--strip-types`
-- Node bindings: `@corsa-bind/napi` (`src/bindings/nodejs/corsa_node`) and `corsa-oxlint` (`src/bindings/nodejs/typescript_oxlint`) (public npm packages that still expect a caller-managed `typescript-go` executable)
+- JS bindings: `@corsa-bind/napi` (`src/bindings/nodejs/corsa_node`) and `corsa-oxlint` (`src/bindings/nodejs/typescript_oxlint`) (public npm packages that still expect a caller-managed `typescript-go` executable)
 - Distributed orchestration: `experimental-distributed` cargo feature
 - TS benchmark project: `bench`
 - Example workspace: `examples`
@@ -134,7 +134,7 @@ vp check
 
 Repository automation scripts now assume Node `24` so they can run TypeScript
 directly through `node --strip-types`. The published npm packages themselves
-still target Node `22+`.
+target Node `22+`, Deno `2.0+`, and Bun `1.2+`.
 
 ## Examples
 

--- a/bench/src/npm_release_utils.test.ts
+++ b/bench/src/npm_release_utils.test.ts
@@ -14,12 +14,47 @@ import {
 const nodeBindingManifest = JSON.parse(
   readFileSync(resolve(process.cwd(), "src/bindings/nodejs/corsa_node/package.json"), "utf8"),
 ) as {
+  engines: Record<string, string>;
+  exports: Record<string, unknown>;
   files: string[];
   name: string;
+  type: string;
   version: string;
 };
 
 describe("npm release utils", () => {
+  it("declares Deno and Bun support for published JS packages", () => {
+    const manifests = [
+      nodeBindingManifest,
+      JSON.parse(
+        readFileSync(
+          resolve(process.cwd(), "src/bindings/nodejs/typescript_oxlint/package.json"),
+          "utf8",
+        ),
+      ) as { engines: Record<string, string>; exports: Record<string, unknown> },
+    ];
+
+    for (const manifest of manifests) {
+      expect(manifest.engines).toMatchObject({
+        node: ">=22",
+        deno: ">=2.0",
+        bun: ">=1.2",
+      });
+
+      for (const entry of Object.values(manifest.exports)) {
+        if (typeof entry === "string") {
+          continue;
+        }
+        expect(entry).toMatchObject({
+          deno: expect.any(String),
+          bun: expect.any(String),
+        });
+      }
+    }
+
+    expect(nodeBindingManifest.type).toBe("commonjs");
+  });
+
   it("includes the configured native binding targets", () => {
     expect(
       getNodeBindingTargets(nodeBindingManifest).map(

--- a/docs/production_readiness.md
+++ b/docs/production_readiness.md
@@ -8,8 +8,8 @@ For the current source-level gap register, see [Production Readiness Audit](./pr
 
 The current production target is:
 
-- local Rust and Node API clients
-- published Node bindings with prebuilt packages for supported targets
+- local Rust and JS API clients
+- published JS bindings for Node.js, Deno, and Bun with prebuilt packages for supported targets
 - LSP stdio integrations
 - local worker orchestration and cache reuse
 
@@ -75,7 +75,7 @@ The main quality workflow is intended to stay green on:
 Real `tsgo` smoke coverage now runs across the supported OS matrix, while the
 heavier benchmark verification remains concentrated in the Ubuntu benchmark job.
 
-Published Node prebuild coverage currently targets:
+Published JS prebuild coverage currently targets:
 
 - `darwin-arm64`
 - `darwin-x64`

--- a/docs/support_policy.md
+++ b/docs/support_policy.md
@@ -8,7 +8,7 @@ use and what remains experimental.
 The supported production surface is currently:
 
 - local Rust API clients
-- published Node bindings for the documented prebuilt targets
+- published JS bindings for the documented prebuilt targets
 - LSP stdio integrations
 - local worker orchestration and cache reuse
 - C ABI, C++ headers, and Go wrappers that pass the non-Node binding CI smoke suite
@@ -34,7 +34,7 @@ receives fixes.
 ## Compatibility Matrix
 
 - Rust: `1.85+`
-- Node.js runtime for published packages: `22+`
+- JavaScript runtimes for published packages: Node.js `22+`, Deno `2.0+`, Bun `1.2+`
 - Node.js tooling for repository scripts and examples: `24+`
 - Go: the version declared by `ref/typescript-go/go.mod`
 - Operating systems: Linux, macOS, and Windows for the supported local surface
@@ -43,6 +43,7 @@ receives fixes.
 CI is expected to exercise:
 
 - workspace quality checks on Linux, macOS, and Windows
+- Deno and Bun runtime smoke coverage for the published JS wrapper on Linux, macOS, and Windows
 - real `tsgo` smoke coverage on Linux, macOS, and Windows
 - C ABI, C++ header, and Go wrapper smoke coverage on Ubuntu
 - benchmark verification on Ubuntu

--- a/examples/runtime_compat.ts
+++ b/examples/runtime_compat.ts
@@ -1,0 +1,50 @@
+import {
+  CorsaVirtualDocument,
+  classifyTypeText,
+  isUnsafeAssignment,
+  splitTypeText,
+  version,
+} from "@corsa-bind/napi";
+
+function assert(condition: unknown, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const versionText = version();
+
+assert(
+  typeof versionText === "string" && versionText.length > 0,
+  "version export should be available",
+);
+assert(classifyTypeText('"value"') === "string", "classifyTypeText should call the native binding");
+assert(
+  isUnsafeAssignment({
+    sourceTypeTexts: ["Set<any>"],
+    targetTypeTexts: ["Set<string>"],
+  }),
+  "isUnsafeAssignment should call the native binding",
+);
+assert(
+  splitTypeText("string | Promise<number>").join(",") === "string,Promise<number>",
+  "splitTypeText should preserve top-level type terms",
+);
+
+const document = CorsaVirtualDocument.untitled(
+  "/runtime-compat.ts",
+  "typescript",
+  "let value = 1;\n",
+);
+document.applyChanges([
+  {
+    range: {
+      start: { line: 0, character: 12 },
+      end: { line: 0, character: 13 },
+    },
+    text: "2",
+  },
+]);
+assert(document.text === "let value = 2;\n", "virtual document edits should work");
+
+console.log(`@corsa-bind/napi runtime compatibility ok (${versionText})`);

--- a/src/bindings/nodejs/corsa_node/README.md
+++ b/src/bindings/nodejs/corsa_node/README.md
@@ -1,7 +1,7 @@
 # @corsa-bind/napi
 
-`@corsa-bind/napi` exposes the `corsa` Rust workspace to Node.js through
-`napi-rs`.
+`@corsa-bind/napi` exposes the `corsa` Rust workspace to Node.js, Deno, and
+Bun through `napi-rs`.
 
 ## Install
 
@@ -12,9 +12,23 @@ npm i @corsa-bind/napi
 The published root package stays JS-only and pulls in the matching native
 binary through platform-specific optional dependencies.
 
+Deno consumers should use npm package resolution with a local `node_modules`
+directory and grant native addon access:
+
+```bash
+deno run --node-modules-dir=auto --allow-ffi --allow-read --allow-env --allow-run ./main.ts
+```
+
+Bun consumers can install and import the npm package directly:
+
+```bash
+bun add @corsa-bind/napi
+bun run ./main.ts
+```
+
 ## What it ships
 
-- native Node.js bindings for the `corsa` API and LSP surface
+- native JS bindings for the `corsa` API and LSP surface
 - an ESM TypeScript wrapper under `dist/`
 - no bundled `typescript-go` executable
 

--- a/src/bindings/nodejs/corsa_node/package.json
+++ b/src/bindings/nodejs/corsa_node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@corsa-bind/napi",
   "version": "0.10.0",
-  "description": "Native Node.js bindings for corsa and typescript-go stdio workflows",
+  "description": "Native JS runtime bindings for corsa and typescript-go stdio workflows",
   "homepage": "https://github.com/ubugeeei/corsa-bind/tree/main/src/bindings/nodejs/corsa_node",
   "bugs": {
     "url": "https://github.com/ubugeeei/corsa-bind/issues"
@@ -18,13 +18,16 @@
     "index.d.ts",
     "index.js"
   ],
+  "type": "commonjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
-      "default": "./dist/index.mjs",
-      "import": "./dist/index.mjs"
+      "deno": "./dist/index.mjs",
+      "bun": "./dist/index.mjs",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
     }
   },
   "publishConfig": {
@@ -43,6 +46,8 @@
     }
   },
   "engines": {
+    "bun": ">=1.2",
+    "deno": ">=2.0",
     "node": ">=22"
   }
 }

--- a/src/bindings/nodejs/typescript_oxlint/package.json
+++ b/src/bindings/nodejs/typescript_oxlint/package.json
@@ -22,50 +22,74 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "deno": "./dist/index.js",
+      "bun": "./dist/index.js",
       "import": "./dist/index.js"
     },
     "./ast-utils": {
       "types": "./dist/ast_utils.d.ts",
+      "deno": "./dist/ast_utils.js",
+      "bun": "./dist/ast_utils.js",
       "import": "./dist/ast_utils.js"
     },
     "./eslint-utils": {
       "types": "./dist/oxlint_utils.d.ts",
+      "deno": "./dist/oxlint_utils.js",
+      "bun": "./dist/oxlint_utils.js",
       "import": "./dist/oxlint_utils.js"
     },
     "./oxlint-utils": {
       "types": "./dist/oxlint_utils.d.ts",
+      "deno": "./dist/oxlint_utils.js",
+      "bun": "./dist/oxlint_utils.js",
       "import": "./dist/oxlint_utils.js"
     },
     "./json-schema": {
       "types": "./dist/json_schema.d.ts",
+      "deno": "./dist/json_schema.js",
+      "bun": "./dist/json_schema.js",
       "import": "./dist/json_schema.js"
     },
     "./utils": {
       "types": "./dist/utils.d.ts",
+      "deno": "./dist/utils.js",
+      "bun": "./dist/utils.js",
       "import": "./dist/utils.js"
     },
     "./rule-tester": {
       "types": "./dist/rule_tester.d.ts",
+      "deno": "./dist/rule_tester.js",
+      "bun": "./dist/rule_tester.js",
       "import": "./dist/rule_tester.js"
     },
     "./rules": {
       "types": "./dist/rules/index.d.ts",
+      "deno": "./dist/rules/index.js",
+      "bun": "./dist/rules/index.js",
       "import": "./dist/rules/index.js"
     },
     "./compat": {
       "types": "./dist/oxlint_compat.d.ts",
+      "deno": "./dist/oxlint_compat.js",
+      "bun": "./dist/oxlint_compat.js",
       "import": "./dist/oxlint_compat.js"
     },
     "./ts-estree": {
       "types": "./dist/ts_estree.d.ts",
+      "deno": "./dist/ts_estree.js",
+      "bun": "./dist/ts_estree.js",
       "import": "./dist/ts_estree.js"
     },
     "./ts-eslint": {
       "types": "./dist/ts_eslint.d.ts",
+      "deno": "./dist/ts_eslint.js",
+      "bun": "./dist/ts_eslint.js",
       "import": "./dist/ts_eslint.js"
     },
     "./ts-utils": {
       "types": "./dist/ts_utils.d.ts",
+      "deno": "./dist/ts_utils.js",
+      "bun": "./dist/ts_utils.js",
       "import": "./dist/ts_utils.js"
     },
     "./package.json": "./package.json"
@@ -79,6 +103,8 @@
     "@typescript-eslint/utils": "8.59.3"
   },
   "engines": {
+    "bun": ">=1.2",
+    "deno": ">=2.0",
     "node": ">=22"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -136,6 +136,21 @@ export default defineConfig({
         cwd: "src/bindings/nodejs/corsa_node/ts",
         dependsOn: ["build_node_debug"],
       },
+      check_js_runtime_compat: {
+        command: noopCommand,
+        dependsOn: ["check_js_runtime_compat_bun", "check_js_runtime_compat_deno"],
+      },
+      check_js_runtime_compat_bun: {
+        command: "bun run ./runtime_compat.ts",
+        cwd: "examples",
+        dependsOn: ["build_wrapper_ci"],
+      },
+      check_js_runtime_compat_deno: {
+        command:
+          "deno run --node-modules-dir=manual --allow-ffi --allow-read --allow-env --allow-run ./runtime_compat.ts",
+        cwd: "examples",
+        dependsOn: ["build_wrapper_ci"],
+      },
       lint_rust: {
         command: "cargo clippy --workspace --all-targets -- -D warnings",
       },


### PR DESCRIPTION
## Summary

- Add Deno and Bun export conditions plus runtime engine metadata for the published JS packages.
- Mark the generated @corsa-bind/napi loader package as CommonJS so Deno can import the ESM wrapper without extra CJS detection flags.
- Add Deno/Bun runtime compatibility smoke coverage to the build workflow and document the Deno/Bun usage requirements.

## Validation

- `vp fmt --check`
- `vp check --no-fmt`
- `vp test run --config ./vite.config.ts bench/src/npm_release_utils.test.ts`
- `mise x deno@2.8.0 -- vp run -w check_js_runtime_compat`