### PR TITLE
fix(corsa-oxlint): expose Corsa handle and type traversal accessors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@napi-rs/cli": "3.6.2",
     "@types/node": "25.9.1",
+    "@typescript-eslint/utils": "8.59.3",
     "typescript": "6.0.3",
     "vite": "8.0.13",
     "vite-plus": "^0.1.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/node':
         specifier: 25.9.1
         version: 25.9.1
+      '@typescript-eslint/utils':
+        specifier: 8.59.3
+        version: 8.59.3(eslint@10.4.0)(typescript@6.0.3)
       typescript:
         specifier: 6.0.3
         version: 6.0.3

--- a/src/bindings/nodejs/typescript_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/checker.ts
@@ -57,6 +57,18 @@ export function createTypeChecker(context: ContextWithParserOptions): TsgoTypeCh
         sourceTextFor(context, lookupNode),
       );
     },
+    getSymbol(symbol) {
+      return sessionForContext(context).session.getSymbol(symbol);
+    },
+    getSymbolById(id) {
+      return sessionForContext(context).session.getSymbol(id);
+    },
+    getNode(node) {
+      return sessionForContext(context).session.getNode(node);
+    },
+    getNodeById(id) {
+      return sessionForContext(context).session.getNode(id);
+    },
     getTypeOfSymbol(symbol) {
       return sessionForContext(context).session.getTypeOfSymbol(symbol);
     },
@@ -102,8 +114,52 @@ export function createTypeChecker(context: ContextWithParserOptions): TsgoTypeCh
     getTypeArguments(type) {
       return sessionForContext(context).session.getTypeArguments(type);
     },
+    getTypesOfType(type) {
+      return sessionForContext(context).session.getTypesOfType(type);
+    },
+    getTargetOfType(type) {
+      return sessionForContext(context).session.getTargetOfType(type);
+    },
+    getTypeParametersOfType(type) {
+      return sessionForContext(context).session.getTypeParametersOfType(type);
+    },
+    getOuterTypeParametersOfType(type) {
+      return sessionForContext(context).session.getOuterTypeParametersOfType(type);
+    },
+    getLocalTypeParametersOfType(type) {
+      return sessionForContext(context).session.getLocalTypeParametersOfType(type);
+    },
+    getObjectTypeOfType(type) {
+      return sessionForContext(context).session.getObjectTypeOfType(type);
+    },
+    getIndexTypeOfType(type) {
+      return sessionForContext(context).session.getIndexTypeOfType(type);
+    },
+    getCheckTypeOfType(type) {
+      return sessionForContext(context).session.getCheckTypeOfType(type);
+    },
+    getExtendsTypeOfType(type) {
+      return sessionForContext(context).session.getExtendsTypeOfType(type);
+    },
+    getBaseTypeOfType(type) {
+      return sessionForContext(context).session.getBaseTypeOfType(type);
+    },
+    getConstraintOfType(type) {
+      return sessionForContext(context).session.getConstraintOfType(type);
+    },
+    isUnionType(type) {
+      return (type.flags & typeFlags.union) !== 0;
+    },
+    isIntersectionType(type) {
+      return (type.flags & typeFlags.intersection) !== 0;
+    },
   };
 }
+
+const typeFlags = {
+  union: 1 << 27,
+  intersection: 1 << 28,
+} as const;
 
 function sourceTextFor(
   context: ContextWithParserOptions,

--- a/src/bindings/nodejs/typescript_oxlint/ts/rule_tester.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rule_tester.ts
@@ -66,27 +66,37 @@ export class RuleTester {
   }
 
   run(ruleName: string, rule: Record<string, unknown>, tests: TestCases): void {
-    const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-"));
-    registerCleanup(workspace);
     const transformed = {
-      valid: tests.valid.map((test) => prepareTestCase(workspace, test, this.#config)),
-      invalid: tests.invalid.map((test) => prepareTestCase(workspace, test, this.#config)),
+      valid: tests.valid.map((test, index) =>
+        prepareTestCase(createWorkspace(), test, this.#config, "valid", index),
+      ),
+      invalid: tests.invalid.map((test, index) =>
+        prepareTestCase(createWorkspace(), test, this.#config, "invalid", index),
+      ),
     };
     this.#inner.run(ruleName, decorateRule(rule as never) as never, transformed as TestCases);
   }
+}
+
+function createWorkspace(): string {
+  const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-"));
+  registerCleanup(workspace);
+  return workspace;
 }
 
 function prepareTestCase(
   workspace: string,
   test: string | TestCase,
   config: TesterConfig | undefined,
+  group: "valid" | "invalid",
+  index: number,
 ): string | TestCase {
   if (typeof test === "string") {
-    const filename = resolve(workspace, "fixture.ts");
+    const filename = resolve(workspace, `${group}-${index}.ts`);
     writeFixture(filename, test);
     return test;
   }
-  const filename = resolve(workspace, test.filename ?? "fixture.ts");
+  const filename = resolve(workspace, test.filename ?? `${group}-${index}.ts`);
   writeFixture(filename, test.code);
   const testerConfig = config as ConfigWithSettings | undefined;
   const baseSettings = testerConfig?.settings?.typescriptOxlint;

--- a/src/bindings/nodejs/typescript_oxlint/ts/rules/native_bridge.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/rules/native_bridge.ts
@@ -10,7 +10,7 @@ import type {
 
 import { createNativeRule } from "./rule_creator";
 import { checkerFor, propertyNamesOfNode, typeAtNode, typeTextsAtNode } from "./type_utils";
-import type { ContextWithParserOptions, TsgoSignature, TsgoType } from "../types";
+import type { ContextWithParserOptions, TsgoNode, TsgoSignature, TsgoType } from "../types";
 
 type RangedNode = {
   readonly type: string;
@@ -377,12 +377,13 @@ function expectedArgumentTypeTextsOfCall(
     return [];
   }
   const signature = signatureForCall(context, node, calleeType);
-  if (!signature || signature.parameters.length === 0) {
+  const parameters = signatureParameters(signature);
+  if (parameters.length === 0) {
     return [];
   }
   const args = Array.isArray(node.arguments) ? node.arguments : [];
   return args.map((_arg: unknown, index: number) => {
-    const parameterId = signature.parameters[Math.min(index, signature.parameters.length - 1)];
+    const parameterId = parameters[Math.min(index, parameters.length - 1)];
     return parameterId ? parameterTypeTexts(context, parameterId) : [];
   });
 }
@@ -447,7 +448,7 @@ function scoreSignatureForArguments(
   signature: TsgoSignature,
   args: readonly any[],
 ): number {
-  const parameterTypes = signature.parameters.map((parameterId) =>
+  const parameterTypes = signatureParameters(signature).map((parameterId) =>
     parameterTypeTexts(context, parameterId),
   );
   let score = -Math.abs(args.length - parameterTypes.length);
@@ -467,15 +468,55 @@ function scoreSignatureForArguments(
   return score;
 }
 
+function signatureParameters(signature: TsgoSignature | undefined): readonly string[] {
+  return Array.isArray(signature?.parameters) ? signature.parameters : [];
+}
+
 function parameterTypeTexts(
   context: ContextWithParserOptions,
   parameterId: string,
 ): readonly string[] {
   const checker = checkerFor(context);
-  const parameterSymbol = { id: parameterId } as any;
+  const parameterSymbol = checker.getSymbol(parameterId) ?? ({ id: parameterId } as any);
+  const declaration =
+    checker.getNode(parameterSymbol.valueDeclaration) ??
+    checker.getNode(parameterSymbol.declarations?.[0]);
   const parameterType =
-    checker.getTypeOfSymbol(parameterSymbol) ?? checker.getDeclaredTypeOfSymbol(parameterSymbol);
-  return parameterType ? renderTypeTexts(context, parameterType) : [];
+    (declaration ? checker.getTypeOfSymbolAtLocation(parameterSymbol, declaration) : undefined) ??
+    checker.getTypeOfSymbol(parameterSymbol) ??
+    checker.getDeclaredTypeOfSymbol(parameterSymbol);
+  const typeTexts = parameterType ? renderTypeTexts(context, parameterType) : [];
+  const fallbackTexts = parameterAnnotationTexts(context, declaration);
+  return typeTexts.length > 0 ? typeTexts : fallbackTexts;
+}
+
+function parameterAnnotationTexts(
+  context: ContextWithParserOptions,
+  declaration: TsgoNode | undefined,
+): readonly string[] {
+  if (!declaration) {
+    return [];
+  }
+  const sourceText = sourceTextForPath(context, declaration.fileName);
+  if (
+    !sourceText ||
+    declaration.pos < 0 ||
+    declaration.end > sourceText.length ||
+    declaration.pos >= declaration.end
+  ) {
+    return [];
+  }
+  const parameterText = sourceText.slice(declaration.pos, declaration.end);
+  const annotationStart = topLevelIndexOf(parameterText, ":");
+  if (annotationStart < 0) {
+    return [];
+  }
+  const annotationText = parameterText.slice(annotationStart + 1);
+  const defaultStart = topLevelIndexOf(annotationText, "=");
+  const typeText = (defaultStart >= 0 ? annotationText.slice(0, defaultStart) : annotationText)
+    .trim()
+    .replace(/\s+$/, "");
+  return typeText ? [typeText] : [];
 }
 
 function typeTextsOverlap(actual: readonly string[], expected: readonly string[]): boolean {

--- a/src/bindings/nodejs/typescript_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/session.ts
@@ -2,7 +2,7 @@ import { readFileSync, statSync } from "node:fs";
 
 import { type ProjectResponse, TsgoApiClient } from "@corsa-bind/napi";
 
-import type { TsgoSignature, TsgoSymbol, TsgoType, TsgoTypePredicate } from "./types";
+import type { TsgoNode, TsgoSignature, TsgoSymbol, TsgoType, TsgoTypePredicate } from "./types";
 import type { ResolvedProjectConfig, ResolvedRuntimeOptions } from "./types";
 
 type FileCache = {
@@ -20,12 +20,56 @@ type PreparedFileState = {
   sourceText?: string;
 };
 
+type SourceSlice = {
+  node: TsgoNode;
+  text: string;
+};
+
+type TypeLookup = {
+  fileName: string;
+  position: number;
+  sourceText?: string;
+};
+
+type ParameterInfo = {
+  name: string;
+  node: TsgoNode;
+};
+
+type TypeArgumentInfo = {
+  pos: number;
+};
+
+const typeFlags = {
+  object: 1 << 20,
+  index: 1 << 21,
+  templateLiteral: 1 << 22,
+  stringMapping: 1 << 23,
+  substitution: 1 << 24,
+  indexedAccess: 1 << 25,
+  conditional: 1 << 26,
+  union: 1 << 27,
+  intersection: 1 << 28,
+} as const;
+
+const objectFlags = {
+  classOrInterface: (1 << 0) | (1 << 1),
+  reference: 1 << 2,
+  mapped: 1 << 5,
+} as const;
+
 export class TsgoProjectSession {
   #client?: TsgoApiClient;
   #config?: { options: unknown; fileNames: string[] };
   #snapshot?: string;
   #projects: ProjectResponse[] = [];
   #files = new Map<string, FileCache>();
+  #symbolsById = new Map<string, TsgoSymbol>();
+  #symbolTypeById = new Map<string, string>();
+  #nodesById = new Map<string, TsgoNode>();
+  #typeLookupById = new Map<string, TypeLookup>();
+  #typeSourceById = new Map<string, SourceSlice>();
+  #typeTextById = new Map<string, string>();
   #lastRefreshMs = 0;
   #supportsOverlayChanges?: boolean;
 
@@ -43,6 +87,8 @@ export class TsgoProjectSession {
     this.#client = undefined;
     this.#supportsOverlayChanges = undefined;
     this.#files.clear();
+    this.clearHandleCaches();
+    this.#typeTextById.clear();
   }
 
   getCompilerOptions(): unknown {
@@ -63,7 +109,11 @@ export class TsgoProjectSession {
           | undefined,
       );
     }
-    return state.typeByPosition.get(position);
+    const type = this.rememberType(state.typeByPosition.get(position));
+    if (type) {
+      this.#typeLookupById.set(type.id, { fileName, position, sourceText });
+    }
+    return type;
   }
 
   getSymbolAtPosition(
@@ -80,85 +130,460 @@ export class TsgoProjectSession {
           | undefined,
       );
     }
-    return state.symbolByPosition.get(position);
+    return this.rememberSymbol(state.symbolByPosition.get(position));
+  }
+
+  getSymbol(symbol: string | TsgoSymbol): TsgoSymbol | undefined {
+    if (typeof symbol !== "string") {
+      return this.rememberSymbol(symbol);
+    }
+    const cached = this.#symbolsById.get(symbol);
+    if (cached) {
+      return cached;
+    }
+    const typeId = this.#symbolTypeById.get(symbol);
+    if (!typeId || !this.#snapshot) {
+      return undefined;
+    }
+    const resolved = this.client().callJson<TsgoSymbol | null>("getSymbolOfType", {
+      snapshot: this.#snapshot,
+      type: typeId,
+    });
+    return resolved?.id === symbol ? this.rememberSymbol(resolved) : undefined;
+  }
+
+  getNode(node: string | TsgoNode): TsgoNode | undefined {
+    if (typeof node !== "string") {
+      return node;
+    }
+    return this.#nodesById.get(node) ?? this.rememberNode(node);
   }
 
   getTypeOfSymbol(symbol: TsgoSymbol): TsgoType | undefined {
-    return this.client().getTypeOfSymbol(this.#snapshot!, this.projectId(), symbol.id) as
-      | TsgoType
-      | undefined;
+    const type = this.rememberType(
+      this.client().getTypeOfSymbol(this.#snapshot!, this.projectId(), symbol.id) as
+        | TsgoType
+        | undefined,
+    );
+    this.rememberTypeSource(type, symbol.valueDeclaration);
+    return type;
   }
 
   getDeclaredTypeOfSymbol(symbol: TsgoSymbol): TsgoType | undefined {
-    return this.client().getDeclaredTypeOfSymbol(this.#snapshot!, this.projectId(), symbol.id) as
-      | TsgoType
-      | undefined;
+    const type = this.rememberType(
+      this.client().getDeclaredTypeOfSymbol(this.#snapshot!, this.projectId(), symbol.id) as
+        | TsgoType
+        | undefined,
+    );
+    this.rememberTypeSource(type, symbol.valueDeclaration);
+    return type;
   }
 
   typeToString(type: TsgoType, flags?: number): string {
-    return this.client().typeToString(this.#snapshot!, this.projectId(), type.id, undefined, flags);
+    try {
+      const text = this.client().typeToString(
+        this.#snapshot!,
+        this.projectId(),
+        type.id,
+        undefined,
+        flags,
+      );
+      if (flags === undefined) {
+        this.#typeTextById.set(type.id, text);
+      }
+      return text;
+    } catch (error) {
+      const cached = flags === undefined ? this.#typeTextById.get(type.id) : undefined;
+      if (cached !== undefined) {
+        return cached;
+      }
+      throw error;
+    }
   }
 
   getBaseTypeOfLiteralType(type: TsgoType): TsgoType | undefined {
-    return this.client().callJson("getBaseTypeOfLiteralType", {
-      snapshot: this.#snapshot,
-      project: this.projectId(),
-      type: type.id,
-    });
+    return this.rememberType(
+      this.client().callJson("getBaseTypeOfLiteralType", {
+        snapshot: this.#snapshot,
+        project: this.projectId(),
+        type: type.id,
+      }),
+    );
   }
 
   getPropertiesOfType(type: TsgoType): readonly TsgoSymbol[] {
-    return (
+    return this.rememberSymbols(
       this.client().callJson("getPropertiesOfType", {
         snapshot: this.#snapshot,
         project: this.projectId(),
         type: type.id,
-      }) ?? []
+      }) ?? [],
     );
   }
 
   getSignaturesOfType(type: TsgoType, kind: number): readonly TsgoSignature[] {
-    return this.client().callJson("getSignaturesOfType", {
-      snapshot: this.#snapshot,
-      project: this.projectId(),
-      type: type.id,
-      kind,
-    });
+    return this.rememberSignatures(
+      this.client().callJson("getSignaturesOfType", {
+        snapshot: this.#snapshot,
+        project: this.projectId(),
+        type: type.id,
+        kind,
+      }) ?? [],
+    );
   }
 
   getReturnTypeOfSignature(signature: TsgoSignature): TsgoType | undefined {
-    return this.client().callJson("getReturnTypeOfSignature", {
-      snapshot: this.#snapshot,
-      project: this.projectId(),
-      signature: signature.id,
-    });
+    return this.rememberType(
+      this.client().callJson("getReturnTypeOfSignature", {
+        snapshot: this.#snapshot,
+        project: this.projectId(),
+        signature: signature.id,
+      }),
+    );
   }
 
   getTypePredicateOfSignature(signature: TsgoSignature): TsgoTypePredicate | undefined {
-    return this.client().callJson("getTypePredicateOfSignature", {
-      snapshot: this.#snapshot,
-      project: this.projectId(),
-      signature: signature.id,
-    });
+    const predicate = this.client().callJson<TsgoTypePredicate | undefined>(
+      "getTypePredicateOfSignature",
+      {
+        snapshot: this.#snapshot,
+        project: this.projectId(),
+        signature: signature.id,
+      },
+    );
+    if (predicate?.type) {
+      this.rememberType(predicate.type);
+    }
+    return predicate;
   }
 
   getBaseTypes(type: TsgoType): readonly TsgoType[] {
-    return (
+    return this.rememberTypes(
       this.client().callJson("getBaseTypes", {
         snapshot: this.#snapshot,
         project: this.projectId(),
         type: type.id,
-      }) ?? []
+      }) ?? [],
     );
   }
 
   getTypeArguments(type: TsgoType): readonly TsgoType[] {
-    return this.client().getTypeArguments(
-      this.#snapshot!,
-      this.projectId(),
-      type.id,
-      type.objectFlags,
-    ) as unknown as readonly TsgoType[];
+    const argumentsFromApi = this.rememberTypes(
+      this.client().getTypeArguments(
+        this.#snapshot!,
+        this.projectId(),
+        type.id,
+        type.objectFlags,
+      ) as unknown as readonly TsgoType[],
+    );
+    return argumentsFromApi.length > 0 ? argumentsFromApi : this.fallbackTypeArguments(type);
+  }
+
+  getTypesOfType(type: TsgoType): readonly TsgoType[] {
+    if (
+      (type.flags & (typeFlags.union | typeFlags.intersection | typeFlags.templateLiteral)) ===
+      0
+    ) {
+      return [];
+    }
+    return this.callTypeArray("getTypesOfType", type);
+  }
+
+  getTargetOfType(type: TsgoType): TsgoType | undefined {
+    if (
+      (type.flags & (typeFlags.index | typeFlags.stringMapping)) === 0 &&
+      ((type.objectFlags ?? 0) & (objectFlags.reference | objectFlags.mapped)) === 0
+    ) {
+      return undefined;
+    }
+    const target = this.callType("getTargetOfType", type);
+    this.cacheTypeText(target);
+    return target;
+  }
+
+  getTypeParametersOfType(type: TsgoType): readonly TsgoType[] {
+    const flags = type.objectFlags ?? 0;
+    if ((type.flags & typeFlags.object) === 0 || (flags & objectFlags.classOrInterface) === 0) {
+      return [];
+    }
+    return this.callTypeArray("getTypeParametersOfType", type);
+  }
+
+  getOuterTypeParametersOfType(type: TsgoType): readonly TsgoType[] {
+    const flags = type.objectFlags ?? 0;
+    if ((type.flags & typeFlags.object) === 0 || (flags & objectFlags.classOrInterface) === 0) {
+      return [];
+    }
+    return this.callTypeArray("getOuterTypeParametersOfType", type);
+  }
+
+  getLocalTypeParametersOfType(type: TsgoType): readonly TsgoType[] {
+    const flags = type.objectFlags ?? 0;
+    if ((type.flags & typeFlags.object) === 0 || (flags & objectFlags.classOrInterface) === 0) {
+      return [];
+    }
+    return this.callTypeArray("getLocalTypeParametersOfType", type);
+  }
+
+  getObjectTypeOfType(type: TsgoType): TsgoType | undefined {
+    return (type.flags & typeFlags.indexedAccess) !== 0
+      ? this.callType("getObjectTypeOfType", type)
+      : undefined;
+  }
+
+  getIndexTypeOfType(type: TsgoType): TsgoType | undefined {
+    return (type.flags & typeFlags.indexedAccess) !== 0
+      ? this.callType("getIndexTypeOfType", type)
+      : undefined;
+  }
+
+  getCheckTypeOfType(type: TsgoType): TsgoType | undefined {
+    return (type.flags & typeFlags.conditional) !== 0
+      ? this.callType("getCheckTypeOfType", type)
+      : undefined;
+  }
+
+  getExtendsTypeOfType(type: TsgoType): TsgoType | undefined {
+    return (type.flags & typeFlags.conditional) !== 0
+      ? this.callType("getExtendsTypeOfType", type)
+      : undefined;
+  }
+
+  getBaseTypeOfType(type: TsgoType): TsgoType | undefined {
+    return (type.flags & typeFlags.substitution) !== 0
+      ? this.callType("getBaseTypeOfType", type)
+      : undefined;
+  }
+
+  getConstraintOfType(type: TsgoType): TsgoType | undefined {
+    return (type.flags & typeFlags.substitution) !== 0
+      ? this.callType("getConstraintOfType", type)
+      : undefined;
+  }
+
+  private callType(method: string, type: TsgoType): TsgoType | undefined {
+    return this.rememberType(
+      this.client().callJson<TsgoType | null>(method, {
+        snapshot: this.#snapshot,
+        type: type.id,
+      }) ?? undefined,
+    );
+  }
+
+  private callTypeArray(method: string, type: TsgoType): readonly TsgoType[] {
+    return this.rememberTypes(
+      this.client().callJson<readonly TsgoType[] | null>(method, {
+        snapshot: this.#snapshot,
+        type: type.id,
+      }) ?? [],
+    );
+  }
+
+  private fallbackTypeArguments(type: TsgoType): readonly TsgoType[] {
+    const source = this.sourceSliceForType(type);
+    if (!source) {
+      return [];
+    }
+    return typeArgumentInfosForSource(source)
+      .map((argument) => {
+        const symbol = this.getSymbolAtPosition(
+          source.node.fileName,
+          argument.pos,
+          this.sourceTextForPath(source.node.fileName),
+        );
+        return symbol
+          ? (this.getDeclaredTypeOfSymbol(symbol) ?? this.getTypeOfSymbol(symbol))
+          : undefined;
+      })
+      .filter((argument): argument is TsgoType => argument !== undefined);
+  }
+
+  private sourceSliceForType(type: TsgoType): SourceSlice | undefined {
+    const cached = this.#typeSourceById.get(type.id);
+    if (cached) {
+      return cached;
+    }
+    const lookup = this.#typeLookupById.get(type.id);
+    if (lookup) {
+      const symbol = this.getSymbolAtPosition(lookup.fileName, lookup.position, lookup.sourceText);
+      this.rememberTypeSource(type, symbol?.valueDeclaration);
+      const fromLookup = this.#typeSourceById.get(type.id);
+      if (fromLookup) {
+        return fromLookup;
+      }
+    }
+    if (type.symbol) {
+      const symbol = this.getSymbol(type.symbol);
+      this.rememberTypeSource(type, symbol?.valueDeclaration);
+    }
+    return this.#typeSourceById.get(type.id);
+  }
+
+  private rememberType<T extends TsgoType | undefined>(type: T): T {
+    if (type?.symbol) {
+      this.#symbolTypeById.set(type.symbol, type.id);
+    }
+    if (type?.texts?.[0]) {
+      this.#typeTextById.set(type.id, type.texts[0]);
+    }
+    return type;
+  }
+
+  private rememberTypes<T extends readonly TsgoType[]>(types: T): T {
+    for (const type of types) {
+      this.rememberType(type);
+    }
+    return types;
+  }
+
+  private rememberTypeSource(type: TsgoType | undefined, handle: string | undefined): void {
+    if (!type || !handle || this.#typeSourceById.has(type.id)) {
+      return;
+    }
+    const source = this.sourceSliceForHandle(handle);
+    if (source) {
+      this.#typeSourceById.set(type.id, source);
+    }
+  }
+
+  private cacheTypeText(type: TsgoType | undefined): void {
+    if (!type || this.#typeTextById.has(type.id)) {
+      return;
+    }
+    try {
+      this.#typeTextById.set(
+        type.id,
+        this.client().typeToString(this.#snapshot!, this.projectId(), type.id),
+      );
+    } catch {
+      // Some upstream handles are only renderable before a later relation query.
+    }
+  }
+
+  private rememberSymbol<T extends TsgoSymbol | undefined>(symbol: T): T {
+    if (!symbol) {
+      return symbol;
+    }
+    this.#symbolsById.set(symbol.id, symbol);
+    for (const declaration of symbol.declarations ?? []) {
+      this.rememberNode(declaration);
+    }
+    if (symbol.valueDeclaration) {
+      this.rememberNode(symbol.valueDeclaration);
+    }
+    return symbol;
+  }
+
+  private rememberSymbols<T extends readonly TsgoSymbol[]>(symbols: T): T {
+    for (const symbol of symbols) {
+      this.rememberSymbol(symbol);
+    }
+    return symbols;
+  }
+
+  private rememberSignatures<T extends readonly TsgoSignature[]>(signatures: T): T {
+    for (const signature of signatures) {
+      this.rememberSignature(signature);
+    }
+    return signatures;
+  }
+
+  private rememberSignature(signature: TsgoSignature): TsgoSignature {
+    if (signature.declaration) {
+      this.rememberNode(signature.declaration);
+    }
+    const parameters = signature.declaration
+      ? this.parameterInfosForDeclaration(signature.declaration)
+      : [];
+    signature.parameters.forEach((id, index) => {
+      this.rememberSyntheticSymbol(id, parameters[index]);
+    });
+    if (signature.thisParameter) {
+      this.rememberSyntheticSymbol(signature.thisParameter, undefined, "this");
+    }
+    return signature;
+  }
+
+  private rememberSyntheticSymbol(
+    id: string,
+    parameter?: ParameterInfo,
+    fallbackName = "",
+  ): TsgoSymbol {
+    const cached = this.#symbolsById.get(id);
+    if (cached && (cached.name || !parameter?.name)) {
+      return cached;
+    }
+    const declaration = parameter?.node.id;
+    const symbol: TsgoSymbol = {
+      id,
+      name: parameter?.name ?? fallbackName,
+      flags: cached?.flags ?? 0,
+      checkFlags: cached?.checkFlags ?? 0,
+      declarations: declaration ? [declaration] : (cached?.declarations ?? []),
+      valueDeclaration: declaration ?? cached?.valueDeclaration,
+    };
+    this.#symbolsById.set(id, symbol);
+    if (declaration) {
+      this.#nodesById.set(declaration, parameter.node);
+    }
+    return symbol;
+  }
+
+  private rememberNode(handle: string): TsgoNode | undefined {
+    const parsed = parseNodeHandle(handle);
+    if (!parsed) {
+      return undefined;
+    }
+    this.#nodesById.set(handle, parsed);
+    return parsed;
+  }
+
+  private clearHandleCaches(): void {
+    this.#symbolsById.clear();
+    this.#symbolTypeById.clear();
+    this.#nodesById.clear();
+    this.#typeLookupById.clear();
+    this.#typeSourceById.clear();
+  }
+
+  private parameterInfosForDeclaration(handle: string): readonly ParameterInfo[] {
+    const source = this.sourceSliceForHandle(handle);
+    if (!source) {
+      return [];
+    }
+    const open = source.text.indexOf("(");
+    if (open < 0) {
+      return [];
+    }
+    const close = matchingCloseParen(source.text, open);
+    if (close < 0) {
+      return [];
+    }
+    const parametersText = source.text.slice(open + 1, close);
+    return splitTopLevelRanges(parametersText, ",")
+      .map((range) => parameterInfoForText(source.node, parametersText, range, open + 1))
+      .filter((parameter): parameter is ParameterInfo => parameter !== undefined);
+  }
+
+  private sourceSliceForHandle(handle: string): SourceSlice | undefined {
+    const node = this.getNode(handle);
+    if (!node) {
+      return undefined;
+    }
+    const sourceText = this.sourceTextForPath(node.fileName);
+    if (!sourceText || node.pos < 0 || node.end > sourceText.length || node.pos >= node.end) {
+      return undefined;
+    }
+    return { node, text: sourceText.slice(node.pos, node.end) };
+  }
+
+  private sourceTextForPath(path: string): string | undefined {
+    for (const [fileName, cached] of this.#files) {
+      if (fileName === path || fileName.endsWith(path)) {
+        return cached.lintSourceText ?? cached.sourceText ?? readFileOrUndefined(fileName);
+      }
+    }
+    return readFileOrUndefined(path) ?? readFileOrUndefined(`${this.runtime.cwd}/${path}`);
   }
 
   private client(): TsgoApiClient {
@@ -234,6 +659,7 @@ export class TsgoProjectSession {
     this.#projects = response.projects;
     this.#lastRefreshMs = now;
     this.#files.clear();
+    this.clearHandleCaches();
     if (previous && previous !== this.#snapshot) {
       this.client().releaseHandle(previous);
     }
@@ -339,4 +765,264 @@ function languageIdFor(fileName: string): string {
     return "javascript";
   }
   return "typescript";
+}
+
+function parseNodeHandle(value: string): TsgoNode | undefined {
+  const [posText, endText, _kindText, ...pathParts] = value.split(".");
+  const pos = Number(posText);
+  const end = Number(endText);
+  const fileName = pathParts.join(".");
+  if (!Number.isFinite(pos) || !Number.isFinite(end) || !fileName) {
+    return undefined;
+  }
+  return { id: value, fileName, pos, end, range: [pos, end] };
+}
+
+function parameterInfoForText(
+  declarationNode: TsgoNode,
+  parametersText: string,
+  range: { readonly start: number; readonly end: number },
+  parametersStart: number,
+): ParameterInfo | undefined {
+  const raw = parametersText.slice(range.start, range.end);
+  const leading = raw.search(/\S/);
+  if (leading < 0) {
+    return undefined;
+  }
+  const trailing = raw.match(/\s*$/)?.[0].length ?? 0;
+  const text = raw.slice(leading, raw.length - trailing);
+  const name = parameterNameForText(text);
+  if (!name) {
+    return undefined;
+  }
+  const pos = declarationNode.pos + parametersStart + range.start + leading;
+  const end = declarationNode.pos + parametersStart + range.end - trailing;
+  const id = `${pos}.${end}.0.${declarationNode.fileName}`;
+  return {
+    name,
+    node: {
+      id,
+      fileName: declarationNode.fileName,
+      pos,
+      end,
+      range: [pos, end],
+    },
+  };
+}
+
+function parameterNameForText(text: string): string | undefined {
+  let candidate = text.trim().replace(/^\.\.\.\s*/, "");
+  let changed = true;
+  while (changed) {
+    const previous = candidate;
+    candidate = candidate.replace(
+      /^(?:public|private|protected|readonly|override|static|abstract|declare)\s+/,
+      "",
+    );
+    changed = candidate !== previous;
+  }
+  const separator = firstTopLevelIndexOfAny(candidate, [":", "="]);
+  let left = (separator >= 0 ? candidate.slice(0, separator) : candidate).trim();
+  if (left.endsWith("?")) {
+    left = left.slice(0, -1).trim();
+  }
+  if (left.startsWith("{") || left.startsWith("[")) {
+    return left;
+  }
+  return left.split(/\s+/).at(-1);
+}
+
+function typeArgumentInfosForSource(source: SourceSlice): readonly TypeArgumentInfo[] {
+  const annotationMarker = firstTopLevelIndexOfAny(source.text, [":", "="]);
+  const typeStart = annotationMarker >= 0 ? annotationMarker + 1 : 0;
+  const openInType = firstTopLevelOpeningAngle(source.text.slice(typeStart));
+  if (openInType < 0) {
+    return [];
+  }
+  const open = typeStart + openInType;
+  const close = matchingCloseAngle(source.text, open);
+  if (close < 0) {
+    return [];
+  }
+  const argumentsText = source.text.slice(open + 1, close);
+  return splitTopLevelRanges(argumentsText, ",")
+    .map((range) => {
+      const raw = argumentsText.slice(range.start, range.end);
+      const leading = raw.search(/\S/);
+      if (leading < 0) {
+        return undefined;
+      }
+      return {
+        pos: source.node.pos + open + 1 + range.start + leading,
+      };
+    })
+    .filter((argument): argument is TypeArgumentInfo => argument !== undefined);
+}
+
+function matchingCloseParen(text: string, open: number): number {
+  let depth = 0;
+  const scanner = createScanner();
+  for (let index = open; index < text.length; index += 1) {
+    const char = text[index];
+    if (scanner.inQuote(char)) {
+      continue;
+    }
+    if (char === "(") {
+      depth += 1;
+    } else if (char === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return -1;
+}
+
+function matchingCloseAngle(text: string, open: number): number {
+  let depth = 0;
+  const scanner = createScanner();
+  for (let index = open; index < text.length; index += 1) {
+    const char = text[index];
+    if (scanner.inQuote(char)) {
+      continue;
+    }
+    if (char === "<") {
+      depth += 1;
+    } else if (char === ">") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return -1;
+}
+
+function splitTopLevelRanges(
+  text: string,
+  delimiter: string,
+): readonly { readonly start: number; readonly end: number }[] {
+  const ranges: { start: number; end: number }[] = [];
+  const scanner = createScanner();
+  let start = 0;
+  let angleDepth = 0;
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (scanner.inQuote(char)) {
+      continue;
+    }
+    if (char === "<") angleDepth += 1;
+    else if (char === ">") angleDepth = Math.max(0, angleDepth - 1);
+    else if (char === "(") parenDepth += 1;
+    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
+    else if (char === "[") bracketDepth += 1;
+    else if (char === "]") bracketDepth = Math.max(0, bracketDepth - 1);
+    else if (char === "{") braceDepth += 1;
+    else if (char === "}") braceDepth = Math.max(0, braceDepth - 1);
+    else if (
+      char === delimiter &&
+      angleDepth === 0 &&
+      parenDepth === 0 &&
+      bracketDepth === 0 &&
+      braceDepth === 0
+    ) {
+      ranges.push({ start, end: index });
+      start = index + 1;
+    }
+  }
+  ranges.push({ start, end: text.length });
+  return ranges;
+}
+
+function firstTopLevelIndexOfAny(text: string, needles: readonly string[]): number {
+  const scanner = createScanner();
+  let angleDepth = 0;
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (scanner.inQuote(char)) {
+      continue;
+    }
+    if (char === "<") angleDepth += 1;
+    else if (char === ">") angleDepth = Math.max(0, angleDepth - 1);
+    else if (char === "(") parenDepth += 1;
+    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
+    else if (char === "[") bracketDepth += 1;
+    else if (char === "]") bracketDepth = Math.max(0, bracketDepth - 1);
+    else if (char === "{") braceDepth += 1;
+    else if (char === "}") braceDepth = Math.max(0, braceDepth - 1);
+    else if (
+      needles.includes(char) &&
+      angleDepth === 0 &&
+      parenDepth === 0 &&
+      bracketDepth === 0 &&
+      braceDepth === 0
+    ) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function firstTopLevelOpeningAngle(text: string): number {
+  const scanner = createScanner();
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (scanner.inQuote(char)) {
+      continue;
+    }
+    if (char === "(") parenDepth += 1;
+    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
+    else if (char === "[") bracketDepth += 1;
+    else if (char === "]") bracketDepth = Math.max(0, bracketDepth - 1);
+    else if (char === "{") braceDepth += 1;
+    else if (char === "}") braceDepth = Math.max(0, braceDepth - 1);
+    else if (char === "<" && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function createScanner(): {
+  inQuote(char: string): boolean;
+} {
+  let quote: string | undefined;
+  let escaped = false;
+  return {
+    inQuote(char) {
+      if (quote) {
+        if (escaped) {
+          escaped = false;
+        } else if (char === "\\") {
+          escaped = true;
+        } else if (char === quote) {
+          quote = undefined;
+        }
+        return true;
+      }
+      if (char === '"' || char === "'" || char === "`") {
+        quote = char;
+        return true;
+      }
+      return false;
+    },
+  };
+}
+
+function readFileOrUndefined(path: string): string | undefined {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return undefined;
+  }
 }

--- a/src/bindings/nodejs/typescript_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/session.ts
@@ -160,21 +160,13 @@ export class TsgoProjectSession {
   }
 
   getTypeOfSymbol(symbol: TsgoSymbol): TsgoType | undefined {
-    const type = this.rememberType(
-      this.client().getTypeOfSymbol(this.#snapshot!, this.projectId(), symbol.id) as
-        | TsgoType
-        | undefined,
-    );
+    const type = this.rememberType(this.tryGetSymbolType(symbol, "getTypeOfSymbol"));
     this.rememberTypeSource(type, symbol.valueDeclaration);
     return type;
   }
 
   getDeclaredTypeOfSymbol(symbol: TsgoSymbol): TsgoType | undefined {
-    const type = this.rememberType(
-      this.client().getDeclaredTypeOfSymbol(this.#snapshot!, this.projectId(), symbol.id) as
-        | TsgoType
-        | undefined,
-    );
+    const type = this.rememberType(this.tryGetSymbolType(symbol, "getDeclaredTypeOfSymbol"));
     this.rememberTypeSource(type, symbol.valueDeclaration);
     return type;
   }
@@ -379,6 +371,19 @@ export class TsgoProjectSession {
     );
   }
 
+  private tryGetSymbolType(
+    symbol: TsgoSymbol,
+    method: "getTypeOfSymbol" | "getDeclaredTypeOfSymbol",
+  ): TsgoType | undefined {
+    try {
+      return this.client()[method](this.#snapshot!, this.projectId(), symbol.id) as
+        | TsgoType
+        | undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   private fallbackTypeArguments(type: TsgoType): readonly TsgoType[] {
     const source = this.sourceSliceForType(type);
     if (!source) {
@@ -495,7 +500,8 @@ export class TsgoProjectSession {
     const parameters = signature.declaration
       ? this.parameterInfosForDeclaration(signature.declaration)
       : [];
-    signature.parameters.forEach((id, index) => {
+    const parameterIds = Array.isArray(signature.parameters) ? signature.parameters : [];
+    parameterIds.forEach((id, index) => {
       this.rememberSyntheticSymbol(id, parameters[index]);
     });
     if (signature.thisParameter) {

--- a/src/bindings/nodejs/typescript_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/type_location.test.ts
@@ -87,6 +87,171 @@ describe("corsa-oxlint type locations", () => {
     expect(seen.classFromNode).toBe(seen.classFromId);
   });
 
+  integrationCase("resolves symbol and node handles exposed by signatures and types", () => {
+    const seen: Record<string, unknown> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "symbol-handle-resolution",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise symbol and node handle resolution",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          NewExpression(node: any) {
+            if (node.callee?.name !== "Foo") {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node.callee);
+            if (!type) {
+              return;
+            }
+            const signature = checker.getSignaturesOfType(type, 1)[0];
+            seen.parameterNames = signature?.parameters.map((id) => checker.getSymbol(id)?.name);
+            const symbol = type.symbol ? checker.getSymbol(type.symbol) : undefined;
+            seen.typeSymbolName = symbol?.name;
+            const declarationNode = symbol?.valueDeclaration
+              ? checker.getNode(symbol.valueDeclaration)
+              : undefined;
+            seen.declarationText = declarationNode
+              ? context.sourceCode.text.slice(declarationNode.pos, declarationNode.end)
+              : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("symbol-handle-resolution", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Foo {",
+            "  constructor(a: string, b: number) {}",
+            "}",
+            'const foo = new Foo("x", 1);',
+          ].join("\n"),
+          settings: {
+            typescriptOxlint: {
+              parserOptions: {
+                tsgo: {
+                  executable: realTsgoBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.parameterNames).toEqual(["a", "b"]);
+    expect(seen.typeSymbolName).toBe("Foo");
+    expect(seen.declarationText).toContain("class Foo");
+  });
+
+  integrationCase("exposes constituent and mapped type traversal helpers", () => {
+    const seen: Record<
+      string,
+      {
+        args: readonly string[];
+        parts: readonly string[];
+        target?: string;
+        isUnion: boolean;
+        isIntersection: boolean;
+      }
+    > = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "type-relation-accessors",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise type relation accessors",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          TSPropertySignature(node: any) {
+            const keyName = node.key?.name;
+            if (!keyName) {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node);
+            if (!type) {
+              return;
+            }
+            const target = checker.getTargetOfType(type);
+            seen[keyName] = {
+              args: checker
+                .getTypeArguments(type)
+                .map((argument) => checker.typeToString(argument)),
+              parts: checker.getTypesOfType(type).map((part) => checker.typeToString(part)),
+              target: target ? checker.typeToString(target) : undefined,
+              isUnion: checker.isUnionType(type),
+              isIntersection: checker.isIntersectionType(type),
+            };
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("type-relation-accessors", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Foo { value = 1; }",
+            "interface Bag {",
+            "  arr: Foo[];",
+            "  union: Foo | string;",
+            "  intersection: Foo & { x: number };",
+            "  mapped: Readonly<Foo>;",
+            "}",
+          ].join("\n"),
+          settings: {
+            typescriptOxlint: {
+              parserOptions: {
+                tsgo: {
+                  executable: realTsgoBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.arr.args).toEqual(["Foo"]);
+    expect(seen.union.isUnion).toBe(true);
+    expect(seen.union.parts).toEqual(expect.arrayContaining(["Foo", "string"]));
+    expect(seen.intersection.isIntersection).toBe(true);
+    expect(seen.intersection.parts).toEqual(expect.arrayContaining(["Foo", "{ x: number; }"]));
+    expect(seen.mapped.args).toEqual(["Foo"]);
+    expect(seen.mapped.target).toBe("Readonly<T>");
+  });
+
   it("sends linted source text overlay changes when it differs from disk", () => {
     const workspace = mkdtempSync(resolve(tmpdir(), "corsa-oxlint-overlay-"));
     const srcDir = resolve(workspace, "src");

--- a/src/bindings/nodejs/typescript_oxlint/ts/types.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/types.ts
@@ -46,6 +46,7 @@ export interface ResolvedProjectConfig {
 }
 
 export interface TsgoNode {
+  readonly id?: string;
   readonly fileName: string;
   readonly pos: number;
   readonly end: number;
@@ -97,6 +98,10 @@ export interface TsgoTypeCheckerShape {
   getTypeAtLocation(node: Node | TsgoNode): TsgoType | undefined;
   getContextualType(node: Node | TsgoNode): TsgoType | undefined;
   getSymbolAtLocation(node: Node | TsgoNode): TsgoSymbol | undefined;
+  getSymbol(symbol: string | TsgoSymbol): TsgoSymbol | undefined;
+  getSymbolById(id: string): TsgoSymbol | undefined;
+  getNode(node: string | TsgoNode): TsgoNode | undefined;
+  getNodeById(id: string): TsgoNode | undefined;
   getTypeOfSymbol(symbol: TsgoSymbol): TsgoType | undefined;
   getDeclaredTypeOfSymbol(symbol: TsgoSymbol): TsgoType | undefined;
   getTypeOfSymbolAtLocation(symbol: TsgoSymbol, node: Node | TsgoNode): TsgoType | undefined;
@@ -109,6 +114,19 @@ export interface TsgoTypeCheckerShape {
   getBaseTypes(type: TsgoType): readonly TsgoType[];
   getImplementedTypes(node: Node | TsgoNode): readonly TsgoType[];
   getTypeArguments(type: TsgoType): readonly TsgoType[];
+  getTypesOfType(type: TsgoType): readonly TsgoType[];
+  getTargetOfType(type: TsgoType): TsgoType | undefined;
+  getTypeParametersOfType(type: TsgoType): readonly TsgoType[];
+  getOuterTypeParametersOfType(type: TsgoType): readonly TsgoType[];
+  getLocalTypeParametersOfType(type: TsgoType): readonly TsgoType[];
+  getObjectTypeOfType(type: TsgoType): TsgoType | undefined;
+  getIndexTypeOfType(type: TsgoType): TsgoType | undefined;
+  getCheckTypeOfType(type: TsgoType): TsgoType | undefined;
+  getExtendsTypeOfType(type: TsgoType): TsgoType | undefined;
+  getBaseTypeOfType(type: TsgoType): TsgoType | undefined;
+  getConstraintOfType(type: TsgoType): TsgoType | undefined;
+  isUnionType(type: TsgoType): boolean;
+  isIntersectionType(type: TsgoType): boolean;
 }
 
 export interface ParserServices {


### PR DESCRIPTION
## Summary

- Adds `checker.getSymbol()` / `getSymbolById()` and `checker.getNode()` / `getNodeById()` so opaque Corsa symbol and node handles can be resolved from corsa-oxlint rules.
- Hydrates signature parameter symbol handles from declaration source when Corsa only returns parameter IDs, and exposes safe union/intersection/mapped type traversal helpers.
- Fixes type-aware `RuleTester` case isolation and root test dependency resolution so the full local JS test suite passes.

Closes #149.
Closes #151.

## Validation

- `vp test`
- `vp fmt --check package.json pnpm-lock.yaml src/bindings/nodejs/typescript_oxlint/ts/rule_tester.ts src/bindings/nodejs/typescript_oxlint/ts/rules/native_bridge.ts src/bindings/nodejs/typescript_oxlint/ts/session.ts`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/typescript_oxlint/ts/type_location.test.ts`
- `vp run -w build_typescript_oxlint`