### PR TITLE
fix(corsa-oxlint): handle new expressions and array base types

### DIFF
--- a/src/bindings/nodejs/typescript_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/checker.ts
@@ -39,6 +39,9 @@ export function createProgram(
 export function createTypeChecker(context: ContextWithParserOptions): TsgoTypeCheckerShape {
   return {
     getTypeAtLocation(node) {
+      if ((node as { readonly type?: string }).type === "NewExpression") {
+        return typeOfNewExpression(node as Node, this);
+      }
       const lookupNode = nodeForTypeLookup(node);
       return sessionForContext(context).session.getTypeAtPosition(
         filenameFor(context, lookupNode),
@@ -179,6 +182,21 @@ function sourceTextFor(
     normalizedContextFilename.endsWith(normalizedFileName)
     ? context.sourceCode.text
     : undefined;
+}
+
+function typeOfNewExpression(node: Node, checker: TsgoTypeCheckerShape): TsgoType | undefined {
+  const callee = childNode(node, "callee");
+  if (!callee) {
+    return undefined;
+  }
+  const calleeType = checker.getTypeAtLocation(callee);
+  if (!calleeType) {
+    return undefined;
+  }
+  const constructSignature = checker.getSignaturesOfType(calleeType, 1)[0];
+  return constructSignature
+    ? (checker.getReturnTypeOfSignature(constructSignature) ?? calleeType)
+    : calleeType;
 }
 
 function nodeForTypeLookup(node: Node | TsgoNode): Node | TsgoNode {

--- a/src/bindings/nodejs/typescript_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/session.ts
@@ -255,6 +255,9 @@ export class TsgoProjectSession {
   }
 
   getBaseTypes(type: TsgoType): readonly TsgoType[] {
+    if (isArrayOrTupleLikeType(this, type)) {
+      return [];
+    }
     return this.rememberTypes(
       this.client().callJson("getBaseTypes", {
         snapshot: this.#snapshot,
@@ -752,6 +755,17 @@ export class TsgoProjectSession {
     }
     return this.#supportsOverlayChanges;
   }
+}
+
+function isArrayOrTupleLikeType(session: TsgoProjectSession, type: TsgoType): boolean {
+  const texts =
+    Array.isArray(type.texts) && type.texts.length > 0
+      ? type.texts
+      : [session.typeToString(type)];
+  return texts.some((text) => {
+    const normalized = text.trimStart();
+    return normalized.startsWith("readonly [") || normalized.startsWith("[") || normalized.endsWith("[]");
+  });
 }
 
 function findConstructorParameterOpen(text: string): number {

--- a/src/bindings/nodejs/typescript_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/typescript_oxlint/ts/type_location.test.ts
@@ -112,10 +112,12 @@ describe("corsa oxlint type locations", () => {
             if (node.callee?.name !== "Construct") {
               return;
             }
+            const onNode = checker.getTypeAtLocation(node);
             const type = checker.getTypeAtLocation(node.callee);
             if (!type) {
               return;
             }
+            seen.newExpressionType = onNode ? checker.typeToString(onNode) : undefined;
             const signature = checker.getSignaturesOfType(type, 1)[0];
             seen.parameterNames = signature?.parameters.map((id) => checker.getSymbolById(id)?.name);
             const symbol = type.symbol ? checker.getSymbol(type.symbol) : undefined;
@@ -242,6 +244,7 @@ describe("corsa oxlint type locations", () => {
     });
 
     expect(seen.parameterNames).toEqual(["scope", "id"]);
+    expect(seen.newExpressionType).toBe("Construct");
     expect(seen.typeSymbolName).toBe("Construct");
     expect(seen.declarationText).toContain("class Construct");
   });
@@ -252,6 +255,7 @@ describe("corsa oxlint type locations", () => {
       {
         args: readonly string[];
         parts: readonly string[];
+        baseTypes: readonly string[];
         target?: string;
         isUnion: boolean;
         isIntersection: boolean;
@@ -285,11 +289,13 @@ describe("corsa oxlint type locations", () => {
             if (!type) {
               return;
             }
+            const baseTypes = checker.getBaseTypes(type).map((part) => checker.typeToString(part));
             const target = checker.getTargetOfType(type);
             seen[keyName] = {
               args: checker
                 .getTypeArguments(type)
                 .map((argument) => checker.typeToString(argument)),
+              baseTypes,
               parts: checker.getTypesOfType(type).map((part) => checker.typeToString(part)),
               target: target ? checker.typeToString(target) : undefined,
               isUnion: checker.isUnionType(type),
@@ -308,6 +314,7 @@ describe("corsa oxlint type locations", () => {
             "class Foo { value = 1; }",
             "interface Bag {",
             "  arr: Foo[];",
+            "  tup: [Foo, number];",
             "  union: Foo | string;",
             "  intersection: Foo & { x: number };",
             "  mapped: Readonly<Foo>;",
@@ -329,6 +336,8 @@ describe("corsa oxlint type locations", () => {
     });
 
     expect(seen.arr.args).toEqual(["Foo"]);
+    expect(seen.arr.baseTypes).toEqual([]);
+    expect(seen.tup.baseTypes).toEqual([]);
     expect(seen.union.isUnion).toBe(true);
     expect(seen.union.parts).toEqual(expect.arrayContaining(["Foo", "string"]));
     expect(seen.intersection.isIntersection).toBe(true);


### PR DESCRIPTION
Closes #153
Closes #154
Closes #155
Closes #156
Closes #157

## Summary
- Resolve `NewExpression` to its instance type instead of `any`.
- Return `[]` from `getBaseTypes()` for array and tuple types instead of calling into tsgo and panicking.
- Keep the existing implemented-types recovery behavior covered by the current branch.

## Verification
- `corepack pnpm exec vitest run src/bindings/nodejs/typescript_oxlint/ts/type_location.test.ts src/bindings/nodejs/typescript_oxlint/ts/implemented_types.test.ts`
- `corepack pnpm exec vitest run src/bindings/nodejs/typescript_oxlint/ts/**/*.test.ts`