### PR TITLE
fix: export ESTree from the root entry

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { ESTree as RootESTree } from "./index";
 
 import * as astUtilsEntry from "./ast_utils";
 import * as main from "./index";
@@ -24,6 +25,10 @@ describe("api surface", () => {
     );
     expect(main.TSESTree.AST_TOKEN_TYPES.Block).toBe("Block");
     expect(tsestreeEntry.AST_NODE_TYPES.Identifier).toBe("Identifier");
+  });
+
+  it("re-exports ESTree types from the root entry", () => {
+    expectTypeOf<RootESTree.NewExpression>().toMatchTypeOf<{ type: "NewExpression" }>();
   });
 
   it("re-exports typescript-eslint-style utility namespaces", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/index.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/index.ts
@@ -1,4 +1,5 @@
 export { AST_NODE_TYPES, AST_TOKEN_TYPES, TSESTree } from "./compat";
+export type { ESTree } from "@oxlint/plugins";
 export * as ASTUtils from "./ast_utils";
 export * as JSONSchema from "./json_schema";
 export * as OxlintCompat from "./oxlint_compat";


### PR DESCRIPTION
Closes #163

- Re-exported `ESTree` from the package root so consumers can import a stable namespace for inferred visitor callback types.
- Added a compile-time API surface check for the root `ESTree` export.
