### PR TITLE
fix: widen binding identifier type annotations

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { ESTree as OxlintESTree } from "@oxlint/plugins";
 
 import * as astUtilsEntry from "./ast_utils";
 import * as main from "./index";
@@ -24,6 +25,12 @@ describe("api surface", () => {
     );
     expect(main.TSESTree.AST_TOKEN_TYPES.Block).toBe("Block");
     expect(tsestreeEntry.AST_NODE_TYPES.Identifier).toBe("Identifier");
+  });
+
+  it("wires typed parameter identifiers to type annotations", () => {
+    expectTypeOf<OxlintESTree.BindingIdentifier["typeAnnotation"]>().toEqualTypeOf<
+      OxlintESTree.TSTypeAnnotation | null | undefined
+    >();
   });
 
   it("re-exports typescript-eslint-style utility namespaces", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/index.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/index.ts
@@ -1,3 +1,5 @@
+import "./oxlint_plugins";
+
 export { AST_NODE_TYPES, AST_TOKEN_TYPES, TSESTree } from "./compat";
 export * as ASTUtils from "./ast_utils";
 export * as JSONSchema from "./json_schema";

--- a/src/bindings/nodejs/corsa_oxlint/ts/oxlint_plugins.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/oxlint_plugins.ts
@@ -1,0 +1,9 @@
+declare module "@oxlint/plugins" {
+  namespace ESTree {
+    interface BindingIdentifier {
+      typeAnnotation?: TSTypeAnnotation | null;
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
Closes #165

- Added a declaration merge for `@oxlint/plugins` so `BindingIdentifier.typeAnnotation` is typed as `TSTypeAnnotation | null`.
- Added a compile-time check covering the widened annotation shape.
