### PR TITLE
fix: read ESLint parser services from sourceCode

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -160,6 +160,64 @@ describe("corsa oxlint", () => {
     });
   });
 
+  it("reuses existing parserServices from sourceCode when ESLint provides type information there", () => {
+    const program = {
+      getTypeChecker() {
+        return {
+          getTypeAtLocation() {
+            return { kind: "type" };
+          },
+          getSymbolAtLocation() {
+            return { kind: "symbol" };
+          },
+        };
+      },
+    };
+    const tsNode = { kind: "ts-node" };
+    const parserServices = {
+      program,
+      esTreeNodeToTSNodeMap: {
+        get() {
+          return tsNode;
+        },
+        has() {
+          return true;
+        },
+      },
+      tsNodeToESTreeNodeMap: {
+        get() {
+          return { type: "Identifier" };
+        },
+        has() {
+          return true;
+        },
+      },
+    };
+
+    const services = getParserServices({
+      cwd: workspaceRoot,
+      filename: resolve(workspaceRoot, "fixture.ts"),
+      languageOptions: {
+        parserOptions: {},
+      },
+      report() {},
+      settings: {},
+      sourceCode: {
+        text: "const fixture = 1;",
+        parserServices: parserServices as never,
+      },
+    } as never);
+
+    expect(services.program).toBe(program);
+    expect(services.hasFullTypeInformation).toBe(true);
+    expect(services.getTypeAtLocation({ type: "Identifier" } as never)).toEqual({
+      kind: "type",
+    });
+    expect(services.getSymbolAtLocation({ type: "Identifier" } as never)).toEqual({
+      kind: "symbol",
+    });
+  });
+
   it("propagates corsaOxlint settings through RuleTester", () => {
     let seen: Record<string, unknown> | undefined;
     const tester = new RuleTester();

--- a/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
@@ -27,8 +27,9 @@ export function getParserServices(
     return current;
   }
   const parserOptions = resolveTypeAwareParserOptions(context);
-  if (!parserOptions.corsa && hasEslintParserServices(context.parserServices)) {
-    const services = createEslintParserServices(context);
+  const eslintParserServices = resolveEslintParserServices(context);
+  if (!parserOptions.corsa && eslintParserServices) {
+    const services = createEslintParserServices(eslintParserServices);
     parserServices.set(context, services);
     return services;
   }
@@ -69,9 +70,8 @@ export function getParserServices(
 }
 
 function createEslintParserServices(
-  context: ContextWithParserOptions,
+  parserServices: ParserServices,
 ): ParserServicesWithTypeInformation {
-  const parserServices = context.parserServices!;
   const checker = parserServices.program.getTypeChecker();
   return {
     program: parserServices.program,
@@ -89,8 +89,20 @@ function createEslintParserServices(
   };
 }
 
+function resolveEslintParserServices(
+  context: ContextWithParserOptions,
+): ParserServices | undefined {
+  const candidates = [context.parserServices, context.sourceCode.parserServices] as const;
+  for (const candidate of candidates) {
+    if (hasEslintParserServices(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
 function hasEslintParserServices(
-  value: ContextWithParserOptions["parserServices"],
+  value: unknown,
 ): value is ParserServices {
   return Boolean(
     value &&


### PR DESCRIPTION
## Summary
- fall back to `context.sourceCode.parserServices` when ESLint exposes type information there
- keep the existing `context.parserServices` path working
- add a regression test for the `sourceCode`-backed parser services shape

## Validation
- `corepack pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts`
