### PR TITLE
fix: resolve implemented types from class declarations

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -118,7 +118,16 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
         .filter((type): type is CorsaType => type !== undefined);
     },
     getImplementedTypesOfType(type) {
-      return sessionForContext(context).session.getBaseTypes(type);
+      const session = sessionForContext(context).session;
+      const symbol = type.symbol ? session.getSymbol(type.symbol) : undefined;
+      const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
+      const declarationNode = declaration ? session.getNode(declaration) : undefined;
+      const sourceText = declarationNode
+        ? sourceTextForPath(context, declarationNode.fileName)
+        : undefined;
+      return declarationNode && sourceText
+        ? implementedTypesFromSourceText(declarationNode, sourceText, this)
+        : [];
     },
     getTypeArguments(type) {
       return sessionForContext(context).session.getTypeArguments(type);
@@ -174,14 +183,20 @@ function sourceTextFor(
   context: ContextWithParserOptions,
   node: Node | CorsaNode | CorsaType | CorsaSymbol | CorsaSignature,
 ): string | undefined {
-  const fileName = filenameFor(context, node);
+  return sourceTextForPath(context, filenameFor(context, node));
+}
+
+function sourceTextForPath(
+  context: ContextWithParserOptions,
+  fileName: string,
+): string | undefined {
   const normalizedFileName = fileName.toLowerCase();
   const normalizedContextFilename = context.filename.toLowerCase();
   return normalizedFileName === normalizedContextFilename ||
     normalizedFileName.endsWith(normalizedContextFilename) ||
     normalizedContextFilename.endsWith(normalizedFileName)
     ? context.sourceCode.text
-    : undefined;
+    : sessionForContext(context).session.getSourceTextForPath(fileName);
 }
 
 function typeOfNewExpression(node: Node, checker: CorsaTypeCheckerShape): CorsaType | undefined {
@@ -258,39 +273,50 @@ function implementedTypesFromCorsaNode(
   }
   const sourceText = sourceTextFor(context, node);
   if (sourceText) {
-    const classText = sourceText.slice(node.pos, node.end);
-    const bodyOpen = classText.indexOf("{");
-    const headerText = bodyOpen >= 0 ? classText.slice(0, bodyOpen) : classText;
-    const implementsIndex = headerText.indexOf("implements");
-    if (implementsIndex >= 0) {
-      const clauseText = headerText.slice(implementsIndex + "implements".length);
-      const implemented = splitTopLevelRanges(clauseText, ",")
-        .map((range) => {
-          const raw = clauseText.slice(range.start, range.end);
-          const leading = raw.search(/\S/);
-          if (leading < 0) {
-            return undefined;
-          }
-          const trailing = raw.match(/\s*$/)?.[0].length ?? 0;
-          const pos = node.pos + implementsIndex + "implements".length + range.start + leading;
-          const end = node.pos + implementsIndex + "implements".length + range.end - trailing;
-          const lookupNode: CorsaNode = {
-            fileName: node.fileName,
-            pos,
-            end,
-            range: [pos, end] as const,
-          };
-          const symbol = checker.getSymbolAtLocation(lookupNode);
-          return symbol
-            ? (checker.getDeclaredTypeOfSymbol(symbol) ?? checker.getTypeOfSymbol(symbol))
-            : checker.getTypeAtLocation(lookupNode);
-        })
-        .filter((type): type is CorsaType => type !== undefined);
-      return implemented;
-    }
+    return implementedTypesFromSourceText(node, sourceText, checker);
   }
   const type = checker.getTypeAtLocation(node);
   return type ? checker.getImplementedTypesOfType(type) : [];
+}
+
+function implementedTypesFromSourceText(
+  node: CorsaNode,
+  sourceText: string,
+  checker: CorsaTypeCheckerShape,
+): readonly CorsaType[] {
+  if (node.pos < 0 || node.end > sourceText.length || node.pos >= node.end) {
+    return [];
+  }
+  const classText = sourceText.slice(node.pos, node.end);
+  const bodyOpen = classText.indexOf("{");
+  const headerText = bodyOpen >= 0 ? classText.slice(0, bodyOpen) : classText;
+  const implementsIndex = headerText.indexOf("implements");
+  if (implementsIndex < 0) {
+    return [];
+  }
+  const clauseText = headerText.slice(implementsIndex + "implements".length);
+  return splitTopLevelRanges(clauseText, ",")
+    .map((range) => {
+      const raw = clauseText.slice(range.start, range.end);
+      const leading = raw.search(/\S/);
+      if (leading < 0) {
+        return undefined;
+      }
+      const trailing = raw.match(/\s*$/)?.[0].length ?? 0;
+      const pos = node.pos + implementsIndex + "implements".length + range.start + leading;
+      const end = node.pos + implementsIndex + "implements".length + range.end - trailing;
+      const lookupNode: CorsaNode = {
+        fileName: node.fileName,
+        pos,
+        end,
+        range: [pos, end] as const,
+      };
+      const symbol = checker.getSymbolAtLocation(lookupNode);
+      return symbol
+        ? (checker.getDeclaredTypeOfSymbol(symbol) ?? checker.getTypeOfSymbol(symbol))
+        : checker.getTypeAtLocation(lookupNode);
+    })
+    .filter((type): type is CorsaType => type !== undefined);
 }
 
 function splitTopLevelRanges(

--- a/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
@@ -77,6 +77,76 @@ describe("corsa oxlint implemented types", () => {
     expect(seen.PlainClass).toEqual([]);
   });
 
+  integrationCase("returns implemented interfaces from class types", () => {
+    const seen: Record<string, readonly string[] | undefined> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "implemented-types-of-type",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise implemented types resolved from a class type",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          ClassDeclaration(node: any) {
+            if (node.id?.name !== "ChildClass") {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node);
+            seen.byNode = checker.getImplementedTypes(node).map((implemented) =>
+              checker.typeToString(implemented),
+            );
+            seen.byType = type
+              ? checker.getImplementedTypesOfType(type).map((implemented) =>
+                  checker.typeToString(implemented),
+                )
+              : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("implemented-types-of-type", rule as any, {
+      valid: [
+        {
+          code: [
+            "interface IChild {",
+            "  x: string;",
+            "}",
+            "class Parent {}",
+            "class ChildClass extends Parent implements IChild {",
+            "  x = '';",
+            "}",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.byNode).toEqual(["IChild"]);
+    expect(seen.byType).toEqual(["IChild"]);
+  });
+
   integrationCase(
     "resolves implemented types from a declaration node recovered from type metadata",
     () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -174,6 +174,10 @@ export class CorsaProjectSession {
     return this.#nodesById.get(node) ?? this.rememberNode(node);
   }
 
+  getSourceTextForPath(path: string): string | undefined {
+    return this.sourceTextForPath(path);
+  }
+
   getTypeOfSymbol(symbol: CorsaSymbol): CorsaType | undefined {
     const type = this.rememberType(this.tryGetSymbolType(symbol, "getTypeOfSymbol"));
     this.rememberTypeSource(type, symbol.valueDeclaration);


### PR DESCRIPTION
## Summary
- resolve `getImplementedTypesOfType` from the declaration's `implements` clause instead of `getBaseTypes`
- read declaration source text through the session so the same logic works for visited and recovered nodes
- add a regression test that includes an `extends` clause to catch the old base-class result

## Validation
- `corepack pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts`
