### PR TITLE
fix: guard getBaseTypes against native panic

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -268,13 +268,20 @@ export class CorsaProjectSession {
     if (isArrayOrTupleLikeType(this, type)) {
       return [];
     }
-    return this.rememberTypes(
-      this.client().callJson("getBaseTypes", {
-        snapshot: this.#snapshot,
-        project: this.projectId(),
-        type: type.id,
-      }) ?? [],
-    );
+    try {
+      return this.rememberTypes(
+        this.client().callJson("getBaseTypes", {
+          snapshot: this.#snapshot,
+          project: this.projectId(),
+          type: type.id,
+        }) ?? [],
+      );
+    } catch (error) {
+      if (isProtocolPanicError(error)) {
+        return [];
+      }
+      throw error;
+    }
   }
 
   getTypeArguments(type: CorsaType): readonly CorsaType[] {
@@ -800,6 +807,11 @@ function overlayTextFor(fileName: string, sourceText?: string): string | undefin
   } catch {
     return sourceText;
   }
+}
+
+function isProtocolPanicError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("protocol error: panic:") || message.includes("panic: runtime error");
 }
 
 function statMtimeMs(fileName: string): number {

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -313,10 +313,14 @@ describe("corsa oxlint type locations", () => {
       valid: [
         {
           code: [
+            "interface Wrapper<T> {",
+            "  value: T;",
+            "}",
             "class Foo { value = 1; }",
             "interface Bag {",
             "  arr: Foo[];",
             "  tup: [Foo, number];",
+            "  wrapped: Wrapper<string>;",
             "  union: Foo | string;",
             "  intersection: Foo & { x: number };",
             "  mapped: Readonly<Foo>;",
@@ -340,6 +344,7 @@ describe("corsa oxlint type locations", () => {
     expect(seen.arr.args).toEqual(["Foo"]);
     expect(seen.arr.baseTypes).toEqual([]);
     expect(seen.tup.baseTypes).toEqual([]);
+    expect(seen.wrapped.baseTypes).toEqual([]);
     expect(seen.union.isUnion).toBe(true);
     expect(seen.union.parts).toEqual(expect.arrayContaining(["Foo", "string"]));
     expect(seen.intersection.isIntersection).toBe(true);


### PR DESCRIPTION
## Summary
- catch the native `getBaseTypes` panic that occurs for user-defined generic interface references
- keep the fast path for array/tuple types and normal successful responses
- add a regression that calls `getBaseTypes` on `Wrapper<string>` and expects `[]`

## Validation
- `corepack pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts`
- `corepack pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts`
