### PR TITLE
fix: guard benchmark path normalization in PR performance workflow

### DIFF
--- a/.github/workflows/pr-performance.yml
+++ b/.github/workflows/pr-performance.yml
@@ -111,7 +111,9 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ matrix.ref-role }}" = "base" ]; then
-            cp .cache/tsgo .cache/corsa
+            if [ -f .cache/tsgo ]; then
+              cp .cache/tsgo .cache/corsa
+            fi
             ln -sfn typescript_oxlint src/bindings/nodejs/corsa_oxlint
           fi
 


### PR DESCRIPTION
## Summary
- skip copying `.cache/tsgo` when the file is absent in the base benchmark job
- keep the benchmark path normalization step in place for the cases that still produce the tsgo artifact
- avoid the recurrent PR Performance failure that was blocking the issue PRs

## Validation
- `corepack pnpm exec vitest run bench/src/publish_workflows.test.ts`
