### PR TITLE
fix(docs): configure void deployment

### DIFF
--- a/.void/project.json
+++ b/.void/project.json
@@ -1,0 +1,4 @@
+{
+  "projectId": "proj_p9muqipk8922",
+  "slug": "corsa-bind"
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# corsa
+# corsa-bind
 
 Rust bindings, orchestration layers, and JS runtime bindings for Corsa over stdio.
 
@@ -9,25 +9,27 @@ Rust bindings, orchestration layers, and JS runtime bindings for Corsa over stdi
 > cargo feature and some upstream-facing endpoints remain explicitly experimental.
 
 > [!IMPORTANT]
-> `corsa` is intentionally built around upstream-supported Corsa
+> `corsa-bind` is intentionally built around upstream-supported Corsa
 > workflows. We follow Corsa's recommended stdio/API/LSP integration points,
 > keep `ref/corsa-upstream` as an exact upstream checkout, and preserve a strict
 > `no forks, no patches` policy.
 
 ## What This Is
 
-`corsa` is a multi-crate workspace for talking to Corsa from Rust and JavaScript runtimes without patching upstream, with a Rust-backed native FFI layer that exposes Corsa API, virtual-document, and `utils` surfaces across C-family and other native languages.
+`corsa-bind` is a multi-crate workspace for talking to Corsa from Rust and JavaScript runtimes without patching upstream, with a Rust-backed native FFI layer that exposes Corsa API, virtual-document, and `utils` surfaces across C-family and other native languages.
 
 ## Naming Note
 
-`corsa` is the codename for this effort: the native TypeScript 7 implementation
-line we track here in the `typescript-go` codebase.
+`corsa-bind` is the repository and distribution name for bindings around the
+Corsa effort: the native TypeScript 7 implementation line we track here in the
+`typescript-go` codebase.
 The TypeScript roadmap describes this as the JS-based TypeScript 6 line versus
 the native TypeScript 7 line, and it also uses `Strada` for the original
 TypeScript codename and `Corsa` for this effort:
 [TypeScript Native Port: Versioning Roadmap](https://devblogs.microsoft.com/typescript/typescript-native-port/#versioning-roadmap).
-We use `corsa` here instead of the more generic `tsc` or `tsgo` labels because
-those names are easy to misread in docs, code, and release notes.
+We keep `corsa` for crate, binary, and upstream-facing labels where that matches
+the implementation surface, instead of the more generic `tsc` or `tsgo` labels
+that are easy to misread in docs, code, and release notes.
 
 In practice, that means:
 
@@ -144,12 +146,11 @@ vp run -w build
 vp check
 ```
 
-Build the Ox Content documentation site and deploy the generated static output
-with Void:
+Build the Ox Content documentation site and deploy it with Void:
 
 ```bash
 vp run -w docs_build
-vp run -w docs_deploy
+npx void deploy
 ```
 
 Repository automation scripts now assume Node `24` so they can run TypeScript

--- a/docs/benchmarking_guide.md
+++ b/docs/benchmarking_guide.md
@@ -1,15 +1,15 @@
 # Benchmarking Principles, Concepts, and Tips
 
-This document explains how `corsa` thinks about performance work.
+This document explains how `corsa-bind` thinks about performance work.
 It is intentionally more conceptual than [performance.md](./performance.md), which is the place for commands and measured numbers.
 For CI structure, local reproduction, and troubleshooting, see [ci_guide.md](./ci_guide.md).
 
 ## Why This Exists
 
-`corsa` wraps the Corsa upstream.
+`corsa-bind` wraps the Corsa upstream.
 That creates an important constraint:
 
-- if `corsa` and the Corsa CLI do exactly the same work, `corsa` should usually aim for parity, not miracles
+- if `corsa-bind` and the Corsa CLI do exactly the same work, `corsa-bind` should usually aim for parity, not miracles
 - the realistic place to win is the end-to-end workflow, not the compiler engine itself
 
 That is why this repository keeps benchmark layers separate.
@@ -19,7 +19,7 @@ We want to answer different questions with different tools instead of forcing on
 
 ### 1. No Forks, No Patches, No Fake Wins
 
-`corsa` follows a strict upstream policy:
+`corsa-bind` follows a strict upstream policy:
 
 - use upstream-supported Corsa entry points
 - pin an exact upstream commit

--- a/docs/build/html.ts
+++ b/docs/build/html.ts
@@ -4,6 +4,59 @@ import { fileURLToPath } from "node:url";
 
 import type { CompiledMarkdown, MarkdownPage } from "./types.ts";
 
+const SITE_NAME = "corsa-bind";
+
+const NAV_GROUPS = [
+  {
+    title: "Start",
+    routes: ["index.html", "project_guide/index.html"],
+  },
+  {
+    title: "Run",
+    routes: ["ci_guide/index.html", "performance/index.html", "benchmarking_guide/index.html"],
+  },
+  {
+    title: "Ship",
+    routes: [
+      "production_readiness/index.html",
+      "production_readiness_audit/index.html",
+      "release_guide/index.html",
+      "support_policy/index.html",
+      "supply_chain_policy/index.html",
+      "corsa_upstream_dependency/index.html",
+    ],
+  },
+  {
+    title: "Reference",
+    routes: [
+      "api/index.html",
+      "api/corsa-bind-napi/index.html",
+      "api/corsa-oxlint/index.html",
+      "api/corsa-oxlint-rules/index.html",
+      "api_reference/index.html",
+    ],
+  },
+] as const;
+
+const ROUTE_TITLES = new Map<string, string>([
+  ["index.html", "Overview"],
+  ["project_guide/index.html", "Architecture"],
+  ["ci_guide/index.html", "CI and local checks"],
+  ["performance/index.html", "Performance commands"],
+  ["benchmarking_guide/index.html", "Benchmarking model"],
+  ["production_readiness/index.html", "Production readiness"],
+  ["production_readiness_audit/index.html", "Readiness audit"],
+  ["release_guide/index.html", "Release process"],
+  ["support_policy/index.html", "Support policy"],
+  ["supply_chain_policy/index.html", "Supply chain"],
+  ["corsa_upstream_dependency/index.html", "Upstream pin"],
+  ["api/index.html", "API index"],
+  ["api/corsa-bind-napi/index.html", "@corsa-bind/napi"],
+  ["api/corsa-oxlint/index.html", "corsa-oxlint"],
+  ["api/corsa-oxlint-rules/index.html", "Oxlint rules"],
+  ["api_reference/index.html", "API docs generation"],
+]);
+
 /** Renders a complete static HTML document for one compiled Markdown page. */
 export function renderHtml(
   page: MarkdownPage,
@@ -12,32 +65,84 @@ export function renderHtml(
 ): string {
   const title = compiled.title || titleFromRoute(page.route);
   return `<!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>${escapeHtml(title)} - corsa</title>
+  <title>${escapeHtml(title)} - ${SITE_NAME}</title>
   <style>${themeCss()}</style>
   <style>${siteCss()}</style>
 </head>
 <body>
-  <aside>
-    <a class="brand" href="/index.html">corsa</a>
-    <nav>${renderNav(nav, page.route)}</nav>
-  </aside>
-  <main class="void-md">${rewriteMarkdownLinks(compiled.html)}</main>
+  <div class="layout">
+    <aside class="sidebar">
+      <a class="brand" href="/index.html">
+        <span class="brand-mark">cb</span>
+        <span>
+          <strong>${SITE_NAME}</strong>
+          <small>Docs</small>
+        </span>
+      </a>
+      <nav aria-label="Documentation">${renderNav(nav, page.route)}</nav>
+    </aside>
+    <div class="content-shell">
+      <main class="void-md">${rewriteMarkdownLinks(compiled.html)}</main>
+      ${renderPager(nav, page.route)}
+    </div>
+  </div>
 </body>
 </html>`;
 }
 
 function renderNav(pages: readonly MarkdownPage[], activeRoute: string): string {
-  return pages
-    .map((page) => {
-      const label = titleFromRoute(page.route);
-      const active = page.route === activeRoute ? ' aria-current="page"' : "";
-      return `<a href="/${page.route}"${active}>${escapeHtml(label)}</a>`;
-    })
-    .join("");
+  const byRoute = new Map(pages.map((page) => [page.route, page]));
+  const seen = new Set<string>();
+  const grouped = NAV_GROUPS.map((group) => {
+    const links = group.routes
+      .filter((route) => byRoute.has(route))
+      .map((route) => {
+        seen.add(route);
+        return renderNavLink(route, activeRoute);
+      })
+      .join("");
+    return links ? `<section><h2>${group.title}</h2>${links}</section>` : "";
+  });
+  const other = pages
+    .filter((page) => !seen.has(page.route))
+    .map((page) => renderNavLink(page.route, activeRoute));
+  return [
+    ...grouped,
+    other.length ? `<section><h2>Other</h2>${other.join("")}</section>` : "",
+  ].join("");
+}
+
+function renderNavLink(route: string, activeRoute: string): string {
+  const active = route === activeRoute ? ' aria-current="page"' : "";
+  return `<a href="/${route}"${active}>${escapeHtml(titleFromRoute(route))}</a>`;
+}
+
+function renderPager(pages: readonly MarkdownPage[], activeRoute: string): string {
+  const ordered = orderedPages(pages);
+  const current = ordered.findIndex((page) => page.route === activeRoute);
+  if (current === -1) return "";
+  const previous = ordered[current - 1];
+  const next = ordered[current + 1];
+  if (!previous && !next) return "";
+  return `<footer class="pager" aria-label="Page navigation">${renderPagerLink(previous, "Previous")}${renderPagerLink(next, "Next")}</footer>`;
+}
+
+function renderPagerLink(page: MarkdownPage | undefined, label: string): string {
+  if (!page) return "<span></span>";
+  return `<a href="/${page.route}"><span>${label}</span><strong>${escapeHtml(titleFromRoute(page.route))}</strong></a>`;
+}
+
+function orderedPages(pages: readonly MarkdownPage[]): MarkdownPage[] {
+  const byRoute = new Map(pages.map((page) => [page.route, page]));
+  const orderedRoutes = NAV_GROUPS.flatMap((group) => [...group.routes]);
+  const orderedRouteSet = new Set<string>(orderedRoutes);
+  const ordered = orderedRoutes.flatMap((route) => byRoute.get(route) ?? []);
+  const leftovers = pages.filter((page) => !orderedRouteSet.has(page.route));
+  return [...ordered, ...leftovers];
 }
 
 function rewriteMarkdownLinks(html: string): string {
@@ -48,6 +153,8 @@ function rewriteMarkdownLinks(html: string): string {
 }
 
 function titleFromRoute(route: string): string {
+  const explicit = ROUTE_TITLES.get(route);
+  if (explicit) return explicit;
   const trimmed = route.replace(/\/index\.html$/, "").replace(/^api-?/, "api ");
   const name = trimmed || "overview";
   return name

--- a/docs/build/site.css
+++ b/docs/build/site.css
@@ -1,8 +1,23 @@
+:root {
+  --bg: #f6f7f9;
+  --panel: #ffffff;
+  --text: #1b2430;
+  --muted: #647080;
+  --line: #d9e0e7;
+  --accent-strong: #065f5b;
+  --radius: 8px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
-  color: #1f2937;
-  background: #fbfbf8;
+  color: var(--text);
+  background: var(--bg);
   font-family:
+    Inter,
     ui-sans-serif,
     system-ui,
     -apple-system,
@@ -11,62 +26,223 @@ body {
     sans-serif;
 }
 
-aside {
-  position: fixed;
-  inset: 0 auto 0 0;
-  width: 232px;
-  padding: 24px 18px;
-  overflow: auto;
-  border-right: 1px solid #deded7;
-  background: #f4f6f3;
+.layout {
+  display: grid;
+  grid-template-columns: 284px minmax(0, 1fr);
 }
 
-main {
-  max-width: 920px;
-  margin-left: 268px;
-  padding: 42px 40px 80px;
+.sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  padding: 28px 18px;
+  overflow: auto;
+  border-right: 1px solid var(--line);
+  background: var(--panel);
 }
 
 .brand {
-  display: block;
-  margin-bottom: 24px;
-  color: #111827;
-  font-size: 22px;
-  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 28px;
+  color: var(--text);
   text-decoration: none;
+}
+
+.brand-mark {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border: 1px solid #c5ced8;
+  border-radius: var(--radius);
+  background: #eef2f5;
+  color: var(--accent-strong);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.brand strong {
+  display: block;
+  font-size: 17px;
+}
+
+.brand small {
+  display: block;
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
 }
 
 nav {
   display: grid;
-  gap: 2px;
+  gap: 22px;
+}
+
+nav h2 {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 nav a {
-  padding: 7px 8px;
+  display: block;
+  min-height: 32px;
+  padding: 7px 9px;
   border-radius: 6px;
-  color: #374151;
+  color: #344050;
   font-size: 14px;
-  line-height: 1.3;
+  line-height: 1.25;
   text-decoration: none;
 }
 
-nav a:hover,
-nav a[aria-current="page"] {
-  color: #0f172a;
-  background: #e7ede5;
+nav a:hover {
+  color: var(--accent-strong);
+  background: #edf7f6;
 }
 
-@media (max-width: 760px) {
-  aside {
-    position: static;
-    width: auto;
-    max-height: 260px;
-    border-right: 0;
-    border-bottom: 1px solid #deded7;
+nav a[aria-current="page"] {
+  color: var(--accent-strong);
+  background: #dff1ef;
+  font-weight: 700;
+}
+
+.content-shell {
+  width: min(100%, 1040px);
+  padding: 52px 52px 80px;
+}
+
+.void-md {
+  width: min(100%, 820px);
+  padding: 44px 48px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel);
+  box-shadow: 0 16px 48px rgb(27 36 48 / 7%);
+}
+
+.void-md > h1:first-child {
+  margin-bottom: 12px;
+  color: var(--text);
+  font-size: 40px;
+  line-height: 1.1;
+}
+
+.void-md > h1:first-child + p {
+  color: var(--muted);
+  font-size: 17px;
+}
+
+.void-md h2 {
+  margin-top: 40px;
+  padding-top: 8px;
+}
+
+.void-md a {
+  color: var(--accent-strong);
+  text-underline-offset: 3px;
+}
+
+.void-md pre {
+  border: 1px solid #22313f;
+  border-radius: var(--radius);
+  background: #101820;
+}
+
+.void-md :not(pre) > code {
+  padding: 2px 5px;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: #f0f3f6;
+  color: #1f4d4b;
+  font-size: 0.92em;
+}
+
+.void-md table {
+  display: block;
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+}
+
+.void-md th {
+  background: #f1f5f8;
+}
+
+.void-md th,
+.void-md td {
+  padding: 10px 12px;
+  border-color: var(--line);
+}
+
+.pager {
+  display: grid;
+  width: min(100%, 820px);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.pager a {
+  display: block;
+  min-height: 74px;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--panel);
+  color: var(--text);
+  text-decoration: none;
+}
+
+.pager span {
+  display: block;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.pager strong {
+  display: block;
+  margin-top: 5px;
+  font-size: 15px;
+}
+
+.pager a:last-child {
+  text-align: right;
+}
+
+@media (max-width: 860px) {
+  .layout {
+    display: block;
   }
 
-  main {
-    margin-left: 0;
-    padding: 28px 20px 56px;
+  .sidebar {
+    position: static;
+    height: auto;
+    padding: 20px;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .content-shell {
+    padding: 24px 16px 56px;
+  }
+
+  .void-md {
+    padding: 30px 22px;
+  }
+
+  .void-md > h1:first-child {
+    font-size: 32px;
+  }
+
+  .pager {
+    grid-template-columns: 1fr;
   }
 }

--- a/docs/corsa_upstream_dependency.md
+++ b/docs/corsa_upstream_dependency.md
@@ -4,9 +4,9 @@ Corsa upstream is managed as a pinned git dependency via [corsa_ref.lock.toml](.
 
 Core policy:
 
-- `corsa` follows upstream-supported Corsa integration points.
-- `corsa` does not maintain a fork of Corsa upstream.
-- `corsa` does not patch Corsa upstream.
+- `corsa-bind` follows upstream-supported Corsa integration points.
+- `corsa-bind` does not maintain a fork of Corsa upstream.
+- `corsa-bind` does not patch Corsa upstream.
 - Upstream changes are adopted by updating the pinned commit and adapting our bindings around that exact revision.
 
 Rules:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,20 +1,37 @@
 ---
-title: corsa documentation
-description: Guides and generated API reference for the corsa workspace.
+title: corsa-bind documentation
+description: Guides and generated API reference for the corsa-bind workspace.
 ---
 
-# corsa documentation
+# corsa-bind
 
-This documentation is built with Ox Content from the Markdown files in this
-directory and API reference pages generated from TypeScript documentation
-comments.
+Rust, Node.js, and integration tooling around the upstream Corsa checker.
+Use this site as the map for architecture, local verification, release work,
+and generated API reference pages.
 
-## Start here
+## Choose a path
 
-- [Project guide](./project_guide.md) explains the workspace architecture.
-- [CI guide](./ci_guide.md) explains local and GitHub checks.
-- [Release guide](./release_guide.md) explains publish and verification flows.
-- [API reference](./api/index.md) is generated from the public Node entrypoints.
+- [Architecture](./project_guide.md) explains the workspace shape, upstream
+  policy, and extension points.
+- [CI and local checks](./ci_guide.md) is the shortest path for reproducing
+  GitHub checks on a local machine.
+- [Performance commands](./performance.md) lists benchmark entrypoints and the
+  artifacts they write.
+- [Release process](./release_guide.md) covers package publishing and release
+  verification.
+- [API index](./api/index.md) links to generated reference pages for the public
+  Node entrypoints.
+
+## Operational reference
+
+- [Production readiness](./production_readiness.md) lists supported runtime
+  controls and release gates.
+- [Support policy](./support_policy.md) defines supported platforms, bindings,
+  and experimental scope.
+- [Supply chain](./supply_chain_policy.md) records dependency and publishing
+  policy.
+- [Upstream pin](./corsa_upstream_dependency.md) explains how the checked-in
+  Corsa upstream revision is synced and verified.
 
 ## Build and deploy
 
@@ -24,8 +41,9 @@ Build the static documentation site locally:
 vp run -w docs_build
 ```
 
-Deploy the generated `dist/docs` directory with Void:
+Deploy with Void. The root `void.json` points Void at the docs build and
+`dist/docs` output directory, so this command can run from the repository root:
 
 ```bash
-vp run -w docs_deploy
+npx void deploy
 ```

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,6 +1,6 @@
 # Performance
 
-`corsa` ships with multiple benchmark layers:
+`corsa-bind` ships with multiple benchmark layers:
 
 - Native real-Corsa benchmark: `vp run -w bench_native`
 - Native deep benchmark: `vp run -w bench_native_deep`

--- a/docs/production_readiness.md
+++ b/docs/production_readiness.md
@@ -1,6 +1,6 @@
 # Production Readiness Guide
 
-This document is the short operational checklist for running `corsa` in production-style environments.
+This document is the short operational checklist for running `corsa-bind` in production-style environments.
 
 For the current source-level gap register, see [Production Readiness Audit](./production_readiness_audit.md).
 

--- a/docs/project_guide.md
+++ b/docs/project_guide.md
@@ -1,6 +1,6 @@
 # Project Architecture, Strategy, and Implementation Tips
 
-This document is the high-level map for `corsa`.
+This document is the high-level map for `corsa-bind`.
 It explains what the repository is trying to achieve, which constraints shape the design, how the crates fit together, and what patterns are worth following when extending the project.
 
 If you want measured numbers, go to [performance.md](./performance.md).
@@ -9,7 +9,7 @@ If you want CI and local reproduction details, go to [ci_guide.md](./ci_guide.md
 
 ## Why This Project Exists
 
-`corsa` exists to make Corsa usable from Rust and Node.js in production-style workflows without maintaining a fork of upstream.
+`corsa-bind` exists to make Corsa usable from Rust and Node.js in production-style workflows without maintaining a fork of upstream.
 
 In practical terms, the repository is trying to provide:
 

--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -1,6 +1,6 @@
 # Release Guide
 
-This document is the operational release guide for `corsa`.
+This document is the operational release guide for `corsa-bind`.
 
 ## Distribution Decisions
 

--- a/docs/supply_chain_policy.md
+++ b/docs/supply_chain_policy.md
@@ -1,7 +1,7 @@
 # Supply Chain Policy
 
 This document defines the minimum dependency and release-hardening policy for
-`corsa`.
+`corsa-bind`.
 
 ## Rust Dependency Gates
 

--- a/docs/support_policy.md
+++ b/docs/support_policy.md
@@ -1,6 +1,6 @@
 # Support Policy
 
-This document defines what `corsa` treats as supported for production-style
+This document defines what `corsa-bind` treats as supported for production-style
 use and what remains experimental.
 
 ## Supported Surface

--- a/scripts/vite/tasks/docs_tasks.ts
+++ b/scripts/vite/tasks/docs_tasks.ts
@@ -7,8 +7,6 @@ export const docsTasks = {
   },
   docs_deploy: {
     cache: false,
-    command:
-      "npx --yes --package void@0.8.11 --package @void/md@0.8.11 void deploy --dir dist/docs --skip-build",
-    dependsOn: ["docs_build"],
+    command: "npx --yes --package void@0.8.11 void deploy",
   },
 } satisfies RunTasks;

--- a/void.json
+++ b/void.json
@@ -1,0 +1,7 @@
+{
+  "inference": {
+    "appType": "static",
+    "build": "vp run -w docs_build",
+    "outputDir": "dist/docs"
+  }
+}


### PR DESCRIPTION
## Summary

- Add root Void configuration so `npx void deploy` runs the docs build and deploys `dist/docs` instead of looking for a root `index.html`.
- Link the repository to the existing Void project slug `corsa-bind`.
- Rework docs branding, navigation groups, pager flow, and light styling so the site presents as `corsa-bind` with clearer document paths.
- Keep implementation files under 250 lines.

## Root cause

Void inferred a root Vite SPA build because the repository did not provide `void.json`, so deploy ran `vp build` and failed with `Cannot resolve entry module index.html`.

## Validation

- `corepack pnpm exec vp check`
- `corepack pnpm exec vp run -w docs_build`
- `git diff --check`
- Local browser preview for desktop and mobile overflow
- `npx --yes void@0.8.11 deploy --debug` succeeded for `https://corsa-bind.void.app`