### PR TITLE
fix: expose corsa checker shape for eslint fallback

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -150,8 +150,9 @@ describe("corsa oxlint", () => {
       },
     } as never);
 
-    expect(services.program).toBe(program);
+    expect(Object.getPrototypeOf(services.program)).toBe(program);
     expect(services.hasFullTypeInformation).toBe(true);
+    expect(typeof services.program.getTypeChecker().isUnionType).toBe("function");
     expect(services.getTypeAtLocation({ type: "Identifier" } as never)).toEqual({
       kind: "type",
     });
@@ -208,14 +209,115 @@ describe("corsa oxlint", () => {
       },
     } as never);
 
-    expect(services.program).toBe(program);
+    expect(Object.getPrototypeOf(services.program)).toBe(program);
     expect(services.hasFullTypeInformation).toBe(true);
+    expect(typeof services.program.getTypeChecker().isUnionType).toBe("function");
     expect(services.getTypeAtLocation({ type: "Identifier" } as never)).toEqual({
       kind: "type",
     });
     expect(services.getSymbolAtLocation({ type: "Identifier" } as never)).toEqual({
       kind: "symbol",
     });
+  });
+
+  it("exposes the corsa checker shape when using sourceCode parserServices", () => {
+    const unionType = {
+      isUnion() {
+        return true;
+      },
+      types: [{ name: "string" }, { name: "number" }],
+    };
+    const implementedType = { name: "Implemented" };
+    const implementationExpression = { kind: "implementation-expression" };
+    const implementedClause = {
+      getText() {
+        return "implements Implemented";
+      },
+      types: [
+        {
+          expression: implementationExpression,
+        },
+      ],
+    };
+    const classDeclaration = {
+      heritageClauses: [implementedClause],
+    };
+    const classType = {
+      symbol: {
+        declarations: [classDeclaration],
+      },
+    };
+    const classNode = { type: "ClassDeclaration" };
+    const typeArgument = { name: "T" };
+    const checker = {
+      getTypeAtLocation(node: unknown) {
+        return node === implementationExpression ? implementedType : unionType;
+      },
+      getSymbolAtLocation() {
+        return { kind: "symbol" };
+      },
+      getTypeArguments() {
+        return [typeArgument];
+      },
+    };
+    const program = {
+      getTypeChecker() {
+        return checker;
+      },
+    };
+    const tsNode = { kind: "ts-node" };
+    const parserServices = {
+      program,
+      esTreeNodeToTSNodeMap: {
+        get(node: unknown) {
+          if (node === classNode) {
+            return classDeclaration;
+          }
+          return tsNode;
+        },
+        has() {
+          return true;
+        },
+      },
+      tsNodeToESTreeNodeMap: {
+        get(node: unknown) {
+          if (node === classDeclaration) {
+            return classNode;
+          }
+          return { type: "Identifier" };
+        },
+        has() {
+          return true;
+        },
+      },
+    };
+
+    const services = getParserServices({
+      cwd: workspaceRoot,
+      filename: resolve(workspaceRoot, "fixture.ts"),
+      languageOptions: {
+        parserOptions: {},
+      },
+      report() {},
+      settings: {},
+      sourceCode: {
+        text: "type Fixture = string | number;",
+        parserServices: parserServices as never,
+      },
+    } as never);
+    const corsaChecker = services.program.getTypeChecker();
+    const type = services.getTypeAtLocation({ type: "Identifier" } as never);
+
+    expect(type).toBe(unionType);
+    expect(corsaChecker.getTypeAtLocation({ type: "Identifier" } as never)).toBe(unionType);
+    expect(corsaChecker.isUnionType(type as never)).toBe(true);
+    expect(corsaChecker.getTypesOfType(type as never)).toEqual(unionType.types);
+    expect(corsaChecker.getBaseTypes(type as never)).toEqual([]);
+    expect(corsaChecker.getImplementedTypes(classNode as never)).toEqual([implementedType]);
+    expect(corsaChecker.getImplementedTypesOfType(classType as never)).toEqual([implementedType]);
+    expect(corsaChecker.getTypeArguments(type as never)).toEqual([typeArgument]);
+    expect(corsaChecker.getSymbolById("missing")).toBeUndefined();
+    expect(corsaChecker.getNodeById("missing")).toBeUndefined();
   });
 
   it("propagates corsaOxlint settings through RuleTester", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
@@ -3,6 +3,7 @@ import { resolveTypeAwareParserOptions } from "./context";
 import { createNodeMaps } from "./node_map";
 import type {
   ContextWithParserOptions,
+  CorsaTypeCheckerShape,
   ParserServices,
   ParserServicesWithTypeInformation,
 } from "./types";
@@ -72,9 +73,12 @@ export function getParserServices(
 function createEslintParserServices(
   parserServices: ParserServices,
 ): ParserServicesWithTypeInformation {
-  const checker = parserServices.program.getTypeChecker();
+  const checker = createEslintTypeChecker(
+    parserServices.program.getTypeChecker(),
+    parserServices.esTreeNodeToTSNodeMap,
+  );
   return {
-    program: parserServices.program,
+    program: createEslintProgram(parserServices.program, checker),
     esTreeNodeToTSNodeMap: parserServices.esTreeNodeToTSNodeMap,
     tsNodeToESTreeNodeMap: parserServices.tsNodeToESTreeNodeMap,
     hasFullTypeInformation: true,
@@ -87,6 +91,227 @@ function createEslintParserServices(
       return tsNode ? checker.getSymbolAtLocation(tsNode) : undefined;
     },
   };
+}
+
+function createEslintProgram(
+  program: ParserServices["program"],
+  checker: CorsaTypeCheckerShape,
+): ParserServices["program"] {
+  return Object.assign(Object.create(program), {
+    getTypeChecker() {
+      return checker;
+    },
+  });
+}
+
+function createEslintTypeChecker(
+  checker: CorsaTypeCheckerShape,
+  esTreeNodeToTSNodeMap: ParserServices["esTreeNodeToTSNodeMap"],
+): CorsaTypeCheckerShape {
+  const source = checker as unknown as Record<string, unknown>;
+  return {
+    ...checker,
+    getTypeAtLocation(node) {
+      return callChecker(source, "getTypeAtLocation", tsNodeFor(node, esTreeNodeToTSNodeMap));
+    },
+    getContextualType(node) {
+      return (
+        callChecker(source, "getContextualType", tsNodeFor(node, esTreeNodeToTSNodeMap)) ??
+        this.getTypeAtLocation(node)
+      );
+    },
+    getSymbolAtLocation(node) {
+      return callChecker(source, "getSymbolAtLocation", tsNodeFor(node, esTreeNodeToTSNodeMap));
+    },
+    getSymbol(symbol) {
+      return typeof symbol === "object" ? symbol : undefined;
+    },
+    getSymbolById(id) {
+      return typeof id === "object" ? id : undefined;
+    },
+    getNode(node) {
+      return typeof node === "object" ? node : undefined;
+    },
+    getNodeById(id) {
+      return typeof id === "object" ? id : undefined;
+    },
+    getTypeOfSymbol(symbol) {
+      return callChecker(source, "getTypeOfSymbol", symbol);
+    },
+    getDeclaredTypeOfSymbol(symbol) {
+      return callChecker(source, "getDeclaredTypeOfSymbol", symbol);
+    },
+    getTypeOfSymbolAtLocation(symbol, node) {
+      return (
+        callChecker(
+          source,
+          "getTypeOfSymbolAtLocation",
+          symbol,
+          tsNodeFor(node, esTreeNodeToTSNodeMap),
+        ) ??
+        this.getTypeOfSymbol(symbol) ??
+        this.getDeclaredTypeOfSymbol(symbol)
+      );
+    },
+    typeToString(type, enclosingDeclaration, flags) {
+      return (
+        callChecker(
+          source,
+          "typeToString",
+          type,
+          enclosingDeclaration ? tsNodeFor(enclosingDeclaration, esTreeNodeToTSNodeMap) : undefined,
+          flags,
+        ) ?? fallbackTypeText(type)
+      );
+    },
+    getBaseTypeOfLiteralType(type) {
+      return callChecker(source, "getBaseTypeOfLiteralType", type) ?? type;
+    },
+    getPropertiesOfType(type) {
+      return asReadonlyArray(callChecker(source, "getPropertiesOfType", type));
+    },
+    getSignaturesOfType(type, kind) {
+      return asReadonlyArray(callChecker(source, "getSignaturesOfType", type, kind));
+    },
+    getReturnTypeOfSignature(signature) {
+      return callChecker(source, "getReturnTypeOfSignature", signature);
+    },
+    getTypePredicateOfSignature(signature) {
+      return callChecker(source, "getTypePredicateOfSignature", signature);
+    },
+    getBaseTypes(type) {
+      const baseTypes = asReadonlyArray(callChecker(source, "getBaseTypes", type));
+      return baseTypes.length > 0 ? baseTypes : heritageTypes(type, source, "extends");
+    },
+    getImplementedTypes(node) {
+      return heritageTypesFromDeclaration(
+        tsNodeFor(node, esTreeNodeToTSNodeMap),
+        source,
+        "implements",
+      );
+    },
+    getImplementedTypesOfType(type) {
+      return heritageTypes(type, source, "implements");
+    },
+    getTypeArguments(type) {
+      return asReadonlyArray(callChecker(source, "getTypeArguments", type));
+    },
+    getTypesOfType(type) {
+      return asReadonlyArray((type as { readonly types?: unknown }).types);
+    },
+    getTargetOfType(type) {
+      return (type as { readonly target?: unknown }).target as never;
+    },
+    getTypeParametersOfType(type) {
+      return asReadonlyArray((type as { readonly typeParameters?: unknown }).typeParameters);
+    },
+    getOuterTypeParametersOfType(type) {
+      return asReadonlyArray(
+        (type as { readonly outerTypeParameters?: unknown }).outerTypeParameters,
+      );
+    },
+    getLocalTypeParametersOfType(type) {
+      return asReadonlyArray(
+        (type as { readonly localTypeParameters?: unknown }).localTypeParameters,
+      );
+    },
+    getObjectTypeOfType(type) {
+      return (type as { readonly objectType?: unknown }).objectType as never;
+    },
+    getIndexTypeOfType(type) {
+      return (type as { readonly indexType?: unknown }).indexType as never;
+    },
+    getCheckTypeOfType(type) {
+      return (type as { readonly checkType?: unknown }).checkType as never;
+    },
+    getExtendsTypeOfType(type) {
+      return (type as { readonly extendsType?: unknown }).extendsType as never;
+    },
+    getBaseTypeOfType(type) {
+      return (type as { readonly baseType?: unknown }).baseType as never;
+    },
+    getConstraintOfType(type) {
+      return callChecker(source, "getBaseConstraintOfType", type);
+    },
+    isUnionType(type) {
+      const value = type as { readonly isUnion?: unknown };
+      return typeof value.isUnion === "function" ? Boolean(value.isUnion()) : false;
+    },
+    isIntersectionType(type) {
+      const value = type as { readonly isIntersection?: unknown };
+      return typeof value.isIntersection === "function" ? Boolean(value.isIntersection()) : false;
+    },
+  } as CorsaTypeCheckerShape;
+}
+
+function callChecker(
+  checker: Record<string, unknown>,
+  method: string,
+  ...args: readonly unknown[]
+): never | undefined {
+  const candidate = checker[method];
+  return typeof candidate === "function" ? candidate.apply(checker, args) : undefined;
+}
+
+function asReadonlyArray<T>(value: unknown): readonly T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function tsNodeFor(
+  node: unknown,
+  esTreeNodeToTSNodeMap: ParserServices["esTreeNodeToTSNodeMap"],
+): unknown {
+  return hasNode(esTreeNodeToTSNodeMap, node) ? esTreeNodeToTSNodeMap.get(node as never) : node;
+}
+
+function hasNode(
+  esTreeNodeToTSNodeMap: ParserServices["esTreeNodeToTSNodeMap"],
+  node: unknown,
+): boolean {
+  return typeof node === "object" && node !== null && esTreeNodeToTSNodeMap.has(node as never);
+}
+
+function fallbackTypeText(type: unknown): string {
+  const name = (type as { readonly name?: unknown }).name;
+  return typeof name === "string" || typeof name === "number" || typeof name === "boolean"
+    ? String(name)
+    : "";
+}
+
+function heritageTypes(
+  type: unknown,
+  checker: Record<string, unknown>,
+  keyword: "extends" | "implements",
+): readonly never[] {
+  const declarations = asReadonlyArray(
+    (type as { readonly symbol?: { readonly declarations?: unknown } }).symbol?.declarations,
+  );
+  return declarations.flatMap((declaration) =>
+    heritageTypesFromDeclaration(declaration, checker, keyword),
+  );
+}
+
+function heritageTypesFromDeclaration(
+  declaration: unknown,
+  checker: Record<string, unknown>,
+  keyword: "extends" | "implements",
+): readonly never[] {
+  const clauses = asReadonlyArray(
+    (declaration as { readonly heritageClauses?: unknown }).heritageClauses,
+  );
+  return clauses
+    .filter((clause) => heritageClauseText(clause).trimStart().startsWith(keyword))
+    .flatMap((clause) => asReadonlyArray((clause as { readonly types?: unknown }).types))
+    .map((node) => {
+      const expression = (node as { readonly expression?: unknown }).expression ?? node;
+      return callChecker(checker, "getTypeAtLocation", expression);
+    })
+    .filter((type): type is never => type !== undefined);
+}
+
+function heritageClauseText(clause: unknown): string {
+  const getText = (clause as { readonly getText?: unknown }).getText;
+  return typeof getText === "function" ? String(getText.call(clause)) : "";
 }
 
 function resolveEslintParserServices(


### PR DESCRIPTION
Closes #177

## Summary
- wrap ESLint-provided parser services with a Corsa-compatible checker shape
- map ESTree nodes through parser services before delegating to the TypeScript checker
- cover sourceCode.parserServices fallback methods used by Corsa rules

## Validation
- ./node_modules/.bin/vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
- ./node_modules/.bin/vp check src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
- ./node_modules/.bin/vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts