### PR TITLE
fix: make inferred visitor node types nameable

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
@@ -1,3 +1,14 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { relative, resolve } from "node:path";
+
 import { describe, expect, expectTypeOf, it } from "vitest";
 import type { ESTree as RootESTree } from "./index";
 
@@ -9,6 +20,8 @@ import * as rules from "./rules";
 import * as tsEslintEntry from "./ts_eslint";
 import * as tsestreeEntry from "./ts_estree";
 import * as tsUtilsEntry from "./ts_utils";
+
+const workspaceRoot = resolve(import.meta.dirname, "../../../../..");
 
 describe("api surface", () => {
   it("re-exports the compatibility entrypoint", () => {
@@ -32,6 +45,95 @@ describe("api surface", () => {
     expectTypeOf<RootESTree["BindingIdentifier"]["typeAnnotation"]>().toEqualTypeOf<
       RootESTree["TSTypeAnnotation"] | null | undefined
     >();
+  });
+
+  it("emits declarations for inferred visitor callback node types", () => {
+    const workspace = realpathSync(mkdtempSync("/tmp/corsa-oxlint-declaration-"));
+    const importPath = moduleSpecifierFor(
+      workspace,
+      realpathSync(resolve(workspaceRoot, "src/bindings/nodejs/corsa_oxlint/ts/index.ts")),
+    );
+    writeFileSync(
+      resolve(workspace, "rule.ts"),
+      [
+        `import { RuleCreator, definePlugin, defineRule } from "${importPath}";`,
+        "",
+        "export const r = defineRule({",
+        '  meta: { type: "problem", messages: {}, schema: [] },',
+        "  create() {",
+        "    return {",
+        "      NewExpression(node) {",
+        "        void node;",
+        "      },",
+        "    };",
+        "  },",
+        "});",
+        "",
+        "export const p = definePlugin({",
+        "  rules: {",
+        "    demo: {",
+        '      meta: { type: "problem", messages: {}, schema: [] },',
+        "      create() {",
+        "        return {",
+        "          NewExpression(node) {",
+        "            void node;",
+        "          },",
+        "        };",
+        "      },",
+        "    },",
+        "  },",
+        "});",
+        "",
+        "export const created = RuleCreator.withoutDocs({",
+        '  meta: { type: "problem", messages: {}, schema: [] },',
+        "  create() {",
+        "    return {",
+        "      NewExpression(node) {",
+        "        void node;",
+        "      },",
+        "    };",
+        "  },",
+        "});",
+        "",
+      ].join("\n"),
+    );
+
+    try {
+      try {
+        execFileSync(
+          resolve(workspaceRoot, "node_modules/.bin/tsc"),
+          [
+            "--ignoreConfig",
+            "--declaration",
+            "--emitDeclarationOnly",
+            "--outDir",
+            resolve(workspace, "out"),
+            "--moduleResolution",
+            "bundler",
+            "--module",
+            "esnext",
+            "--target",
+            "esnext",
+            "--strict",
+            "--skipLibCheck",
+            "--types",
+            "node",
+            resolve(workspace, "rule.ts"),
+          ],
+          {
+            cwd: workspaceRoot,
+            stdio: "pipe",
+          },
+        );
+      } catch (error) {
+        throw new Error(`tsc declaration emit failed:\n${commandOutput(error)}`);
+      }
+
+      const declarationPath = findFile(resolve(workspace, "out"), "rule.d.ts");
+      expect(readFileSync(declarationPath, "utf8")).not.toContain("NewExpression");
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
   });
 
   it("re-exports typescript-eslint-style utility namespaces", () => {
@@ -473,6 +575,31 @@ function importNamedDeclaration(source: string, imported: string, local: Record<
   Object.assign(specifier, { parent: node });
   Object.assign(node.source, { parent: node });
   return node;
+}
+
+function moduleSpecifierFor(fromDirectory: string, toFile: string): string {
+  const specifier = relative(fromDirectory, toFile).replace(/\\/g, "/").replace(/\.ts$/, "");
+  return specifier.startsWith(".") ? specifier : `./${specifier}`;
+}
+
+function commandOutput(error: unknown): string {
+  const output = error as { readonly stderr?: Buffer; readonly stdout?: Buffer };
+  return [output.stdout?.toString(), output.stderr?.toString()].filter(Boolean).join("\n");
+}
+
+function findFile(directory: string, name: string): string {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      const found = findFile(entryPath, name);
+      if (found) {
+        return found;
+      }
+    } else if (entry.name === name) {
+      return entryPath;
+    }
+  }
+  return "";
 }
 
 function summarizeReferences(

--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -73,7 +73,8 @@ describe("corsa oxlint", () => {
       },
     } as any);
 
-    rule.create({
+    expect(rule.create).toBeDefined();
+    rule.create!({
       cwd: workspaceRoot,
       filename: resolve(workspaceRoot, "fixture.ts"),
       languageOptions: {

--- a/src/bindings/nodejs/corsa_oxlint/ts/index.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/index.ts
@@ -9,6 +9,7 @@ export * as Utils from "./utils";
 
 export { ESLintUtils, OxlintUtils, RuleCreator } from "./oxlint_utils";
 export { compatPlugin, definePlugin, defineRule } from "./plugin";
+export type { Plugin, Rule } from "./plugin";
 export { getParserServices } from "./parser_services";
 export { RuleTester } from "./rule_tester";
 export { TSESLint } from "./ts_eslint";

--- a/src/bindings/nodejs/corsa_oxlint/ts/oxlint_utils.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/oxlint_utils.ts
@@ -1,7 +1,8 @@
-import type { Rule, RuleMeta, Visitor } from "@oxlint/plugins";
+import type { RuleMeta, Visitor } from "@oxlint/plugins";
 
 import { getParserServices } from "./parser_services";
 import { decorateRule } from "./plugin";
+import type { Rule } from "./plugin";
 import type { ContextWithParserOptions } from "./types";
 
 export type RuleCreatorRule<
@@ -16,10 +17,7 @@ export type RuleCreatorRule<
   readonly create: (context: ContextWithParserOptions) => Visitor;
 };
 
-export type RuleCreatorCreatedRule<TRule extends RuleCreatorRule> = Omit<
-  TRule,
-  "defaultOptions" | "meta"
-> & {
+export type RuleCreatorCreatedRule<TRule extends RuleCreatorRule> = Rule & {
   readonly defaultOptions: TRule extends { readonly defaultOptions: infer TOptions }
     ? TOptions
     : readonly [];
@@ -28,8 +26,7 @@ export type RuleCreatorCreatedRule<TRule extends RuleCreatorRule> = Omit<
       readonly url: string;
     };
   };
-} & Rule &
-  Record<string, unknown>;
+};
 
 export type RuleCreatorFactory = <TRule extends RuleCreatorRule>(
   rule: TRule,
@@ -68,12 +65,11 @@ export const NullThrowsReasons = Object.freeze({
 export const RuleCreator = Object.assign(OxlintUtils.RuleCreator, {
   withoutDocs<TRule extends Omit<RuleCreatorRule, "name">>(
     rule: TRule,
-  ): Omit<TRule, "defaultOptions"> &
-    Rule & {
-      readonly defaultOptions: TRule extends { readonly defaultOptions: infer TOptions }
-        ? TOptions
-        : readonly [];
-    } {
+  ): Rule & {
+    readonly defaultOptions: TRule extends { readonly defaultOptions: infer TOptions }
+      ? TOptions
+      : readonly [];
+  } {
     return decorateRule({
       ...rule,
       defaultOptions: rule.defaultOptions ?? [],

--- a/src/bindings/nodejs/corsa_oxlint/ts/plugin.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/plugin.ts
@@ -9,8 +9,11 @@ import { resolveTypeAwareParserOptions } from "./context";
 import { getParserServices } from "./parser_services";
 import type { ContextWithParserOptions, ParserServices } from "./types";
 
-type PluginShape = OxlintPlugin;
-type RuleShape = OxlintRule;
+export type Plugin = Omit<OxlintPlugin, "rules"> & {
+  readonly rules: Record<string, Rule>;
+} & Record<string, unknown>;
+export type Rule = OxlintRule & Record<string, unknown>;
+
 const defineOxlintPlugin = oxlintPluginApi.definePlugin;
 const defineOxlintRule = oxlintPluginApi.defineRule;
 const baseCompatPlugin = Reflect.get(
@@ -18,7 +21,7 @@ const baseCompatPlugin = Reflect.get(
   ["es", "lintCompatPlugin"].join(""),
 ) as typeof oxlintPluginApi.definePlugin;
 
-export function definePlugin<Plugin extends PluginShape>(plugin: Plugin): Plugin {
+export function definePlugin(plugin: Plugin): Plugin {
   return defineOxlintPlugin({
     ...plugin,
     rules: wrapRules(plugin.rules ?? {}),
@@ -39,15 +42,15 @@ export function definePlugin<Plugin extends PluginShape>(plugin: Plugin): Plugin
  * });
  * ```
  */
-export function defineRule<Rule extends RuleShape>(rule: Rule): Rule {
+export function defineRule(rule: Rule): Rule {
   return defineOxlintRule(decorateRule(rule) as OxlintRule) as Rule;
 }
 
-export function compatPlugin<Plugin extends PluginShape>(plugin: Plugin): Plugin {
+export function compatPlugin(plugin: Plugin): Plugin {
   return baseCompatPlugin(definePlugin(plugin)) as Plugin;
 }
 
-export function decorateRule<Rule extends RuleShape>(rule: Rule): Rule {
+export function decorateRule(rule: Rule): Rule {
   if (rule.create) {
     return {
       ...rule,
@@ -67,7 +70,7 @@ export function decorateRule<Rule extends RuleShape>(rule: Rule): Rule {
   return rule;
 }
 
-function wrapRules(rules: Record<string, RuleShape>): Record<string, RuleShape> {
+function wrapRules(rules: Record<string, Rule>): Record<string, Rule> {
   return Object.fromEntries(
     Object.entries(rules).map(([name, rule]) => [name, decorateRule(rule)]),
   );


### PR DESCRIPTION
Closes #182

## Summary
- expose nameable Rule and Plugin types from corsa-oxlint
- make defineRule/definePlugin/RuleCreator return public rule shapes instead of leaking inferred visitor callback node types
- add a declaration emit regression covering unannotated NewExpression visitors

## Validation
- ./node_modules/.bin/vp check
- ./node_modules/.bin/vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts
- ./node_modules/.bin/vp pack