### PR TITLE
ci: fix declaration emit test config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,7 @@ jobs:
             -o .cache/bindings/cpp_smoke.o
 
   quality:
-    name: Quality (${{ matrix.os }})
+    name: Quality
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
@@ -311,13 +311,6 @@ jobs:
       - public-facade
       - non-node-bindings
     if: ${{ always() && github.event_name != 'pull_request' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
     steps:
       - name: Verify focused quality checks
         env:

--- a/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
@@ -1,12 +1,5 @@
 import { execFileSync } from "node:child_process";
-import {
-  mkdtempSync,
-  readdirSync,
-  readFileSync,
-  realpathSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
 
 import { describe, expect, expectTypeOf, it } from "vitest";
@@ -48,10 +41,12 @@ describe("api surface", () => {
   });
 
   it("emits declarations for inferred visitor callback node types", () => {
-    const workspace = realpathSync(mkdtempSync("/tmp/corsa-oxlint-declaration-"));
+    const declarationsRoot = resolve(workspaceRoot, ".cache");
+    mkdirSync(declarationsRoot, { recursive: true });
+    const workspace = mkdtempSync(resolve(declarationsRoot, "corsa-oxlint-declaration-"));
     const importPath = moduleSpecifierFor(
       workspace,
-      realpathSync(resolve(workspaceRoot, "src/bindings/nodejs/corsa_oxlint/ts/index.ts")),
+      resolve(workspaceRoot, "src/bindings/nodejs/corsa_oxlint/ts/index.ts"),
     );
     writeFileSync(
       resolve(workspace, "rule.ts"),
@@ -97,29 +92,40 @@ describe("api surface", () => {
         "",
       ].join("\n"),
     );
+    writeFileSync(
+      resolve(workspace, "tsconfig.json"),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            declaration: true,
+            emitDeclarationOnly: true,
+            outDir: resolve(workspace, "out"),
+            rootDir: workspaceRoot,
+            moduleResolution: "bundler",
+            module: "esnext",
+            target: "esnext",
+            strict: true,
+            skipLibCheck: true,
+            types: ["node"],
+            typeRoots: [resolve(workspaceRoot, "node_modules/@types")],
+            baseUrl: workspaceRoot,
+            paths: {
+              "@corsa-bind/napi": ["src/bindings/nodejs/corsa_node/ts/index.ts"],
+            },
+            ignoreDeprecations: "6.0",
+          },
+          files: [resolve(workspace, "rule.ts")],
+        },
+        null,
+        2,
+      ),
+    );
 
     try {
       try {
         execFileSync(
           resolve(workspaceRoot, "node_modules/.bin/tsc"),
-          [
-            "--ignoreConfig",
-            "--declaration",
-            "--emitDeclarationOnly",
-            "--outDir",
-            resolve(workspace, "out"),
-            "--moduleResolution",
-            "bundler",
-            "--module",
-            "esnext",
-            "--target",
-            "esnext",
-            "--strict",
-            "--skipLibCheck",
-            "--types",
-            "node",
-            resolve(workspace, "rule.ts"),
-          ],
+          ["-p", resolve(workspace, "tsconfig.json")],
           {
             cwd: workspaceRoot,
             stdio: "pipe",


### PR DESCRIPTION
## Summary

- Move the declaration emit regression fixture under the repo `.cache` directory and compile it through a fixture tsconfig.
- Point `@corsa-bind/napi` at the source wrapper during the declaration emit regression so generated package declarations do not hide source-only API types.
- Collapse the redundant `Quality` matrix into one Ubuntu job.

## Validation

- `./node_modules/.bin/vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts`
- `./node_modules/.bin/vp check src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts`
- `CI=true ./node_modules/.bin/vp run -w test`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml ok"'`