### PR TITLE
ci: use blacksmith runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,30 +19,15 @@ env:
 
 jobs:
   js-format:
-    name: JS/TS Format (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: JS/TS Format
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     if: ${{ github.event_name != 'pull_request' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          components: rustfmt, clippy
-
-      - name: Restore Cargo cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
@@ -55,17 +40,10 @@ jobs:
         run: vp fmt --check
 
   js-lint-types:
-    name: JS/TS Lint and Types (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: JS/TS Lint and Types
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     if: ${{ github.event_name != 'pull_request' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -83,17 +61,10 @@ jobs:
         run: vp check --no-fmt
 
   rust-format:
-    name: Rust Format (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Rust Format
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     if: ${{ github.event_name != 'pull_request' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -109,17 +80,10 @@ jobs:
         run: cargo fmt --all --check
 
   rust-lint:
-    name: Rust Lint (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Rust Lint
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     if: ${{ github.event_name != 'pull_request' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -144,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest","macos-latest","windows-latest"]') }}
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["blacksmith-4vcpu-ubuntu-2404"]' || '["blacksmith-4vcpu-ubuntu-2404","blacksmith-6vcpu-macos-15","blacksmith-4vcpu-windows-2025"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -189,9 +153,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - blacksmith-4vcpu-ubuntu-2404
+          - blacksmith-6vcpu-macos-15
+          - blacksmith-4vcpu-windows-2025
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -215,17 +179,10 @@ jobs:
         run: vp run -w test
 
   public-facade:
-    name: Public Facade (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Public Facade
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     if: ${{ github.event_name != 'pull_request' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -246,7 +203,7 @@ jobs:
 
   non-node-bindings:
     name: Non-Node Bindings
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -299,7 +256,7 @@ jobs:
 
   quality:
     name: Quality
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 5
     needs:
       - js-format
@@ -351,9 +308,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - blacksmith-4vcpu-ubuntu-2404
+          - blacksmith-6vcpu-macos-15
+          - blacksmith-4vcpu-windows-2025
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -395,7 +352,7 @@ jobs:
 
   bench-corsa-ref:
     name: Corsa Ref Bench
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 60
     if: ${{ github.event_name != 'pull_request' }}
     steps:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -30,7 +30,7 @@ jobs:
   github-release:
     if: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'push' && startsWith(github.event.workflow_run.head_branch, 'v') && github.event.workflow_run.conclusion == 'success') || (github.event_name == 'workflow_dispatch' && inputs.confirm == 'github-release') }}
     name: Create GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 60
     environment: release
     steps:

--- a/.github/workflows/pr-performance.yml
+++ b/.github/workflows/pr-performance.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   benchmark:
     name: Benchmark ${{ matrix.ref-role }} TypeScript ${{ matrix.typescript.channel }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 90
     continue-on-error: ${{ matrix.ref-role == 'base' }}
     strategy:
@@ -182,7 +182,7 @@ jobs:
 
   comment:
     name: Comment benchmark result
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: benchmark
     steps:
       - name: Checkout

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -37,7 +37,7 @@ jobs:
   release-gates:
     if: ${{ (github.event_name == 'push' && github.ref_type == 'tag') || (github.event_name == 'workflow_dispatch' && inputs.confirm == 'publish-npm' && inputs.tag != '') }}
     name: Release Gates
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -103,7 +103,7 @@ jobs:
     name: Resolve native binding targets
     needs:
       - release-gates
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -206,7 +206,7 @@ jobs:
     needs:
       - release-gates
       - build-native-bindings
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
     environment: release
     permissions:

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -33,7 +33,7 @@ jobs:
   release-gates:
     if: ${{ (github.event_name == 'push' || inputs.confirm == 'publish-rust') && github.ref_type == 'tag' }}
     name: Release Gates
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -98,7 +98,7 @@ jobs:
     name: Publish Rust Crates
     needs:
       - release-gates
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     environment: release
     permissions:

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   release-dry-run:
     name: Release Dry Run
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   scorecard:
     name: OpenSSF Scorecard
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     permissions:
       actions: read

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   cargo-deny:
     name: Cargo Deny
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -36,7 +36,7 @@ jobs:
 
   sbom:
     name: SBOM Generation
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Corsa upstream snapshot at the time of writing:
 - Lock file: [`corsa_ref.lock.toml`](./corsa_ref.lock.toml), which is the
   source of truth for the exact upstream ref and tree.
 
+## Sponsors
+
+CI/CD runners for this project are supported by
+[Blacksmith](https://www.blacksmith.sh/).
+
 ## Workspace Layout
 
 - `corsa_core`: shared errors, process handles, and fast-path primitives

--- a/bench/src/npm_release_utils.test.ts
+++ b/bench/src/npm_release_utils.test.ts
@@ -106,7 +106,7 @@ describe("npm release utils", () => {
     expect(getNodeBindingBuildMatrix(nodeBindingManifest)).toEqual([
       {
         crossCompile: false,
-        os: "windows-latest",
+        os: "blacksmith-4vcpu-windows-2025",
         target: "x86_64-pc-windows-msvc",
         useNapiCross: false,
       },
@@ -118,37 +118,37 @@ describe("npm release utils", () => {
       },
       {
         crossCompile: false,
-        os: "ubuntu-latest",
+        os: "blacksmith-4vcpu-ubuntu-2404",
         target: "x86_64-unknown-linux-gnu",
         useNapiCross: true,
       },
       {
         crossCompile: false,
-        os: "macos-15",
+        os: "blacksmith-6vcpu-macos-15",
         target: "aarch64-apple-darwin",
         useNapiCross: false,
       },
       {
         crossCompile: false,
-        os: "windows-latest",
+        os: "blacksmith-4vcpu-windows-2025",
         target: "aarch64-pc-windows-msvc",
         useNapiCross: false,
       },
       {
         crossCompile: true,
-        os: "ubuntu-latest",
+        os: "blacksmith-4vcpu-ubuntu-2404",
         target: "x86_64-unknown-linux-musl",
         useNapiCross: false,
       },
       {
         crossCompile: false,
-        os: "ubuntu-latest",
+        os: "blacksmith-4vcpu-ubuntu-2404",
         target: "aarch64-unknown-linux-gnu",
         useNapiCross: true,
       },
       {
         crossCompile: true,
-        os: "ubuntu-latest",
+        os: "blacksmith-4vcpu-ubuntu-2404",
         target: "aarch64-unknown-linux-musl",
         useNapiCross: false,
       },

--- a/scripts/npm_release_utils.ts
+++ b/scripts/npm_release_utils.ts
@@ -135,12 +135,12 @@ interface NodeBindingBuildTargetConfig {
 const nodeBindingBuildTargetConfig: Record<string, NodeBindingBuildTargetConfig> = {
   "x86_64-pc-windows-msvc": {
     crossCompile: false,
-    os: "windows-latest",
+    os: "blacksmith-4vcpu-windows-2025",
     useNapiCross: false,
   },
   "aarch64-pc-windows-msvc": {
     crossCompile: false,
-    os: "windows-latest",
+    os: "blacksmith-4vcpu-windows-2025",
     useNapiCross: false,
   },
   "x86_64-apple-darwin": {
@@ -150,27 +150,27 @@ const nodeBindingBuildTargetConfig: Record<string, NodeBindingBuildTargetConfig>
   },
   "aarch64-apple-darwin": {
     crossCompile: false,
-    os: "macos-15",
+    os: "blacksmith-6vcpu-macos-15",
     useNapiCross: false,
   },
   "x86_64-unknown-linux-gnu": {
     crossCompile: false,
-    os: "ubuntu-latest",
+    os: "blacksmith-4vcpu-ubuntu-2404",
     useNapiCross: true,
   },
   "aarch64-unknown-linux-gnu": {
     crossCompile: false,
-    os: "ubuntu-latest",
+    os: "blacksmith-4vcpu-ubuntu-2404",
     useNapiCross: true,
   },
   "x86_64-unknown-linux-musl": {
     crossCompile: true,
-    os: "ubuntu-latest",
+    os: "blacksmith-4vcpu-ubuntu-2404",
     useNapiCross: false,
   },
   "aarch64-unknown-linux-musl": {
     crossCompile: true,
-    os: "ubuntu-latest",
+    os: "blacksmith-4vcpu-ubuntu-2404",
     useNapiCross: false,
   },
 };


### PR DESCRIPTION
## Summary
- move CI/CD GitHub Actions jobs to Blacksmith runner labels, using the official 2 vCPU Ubuntu/Windows mappings and 6 vCPU macOS mapping
- collapse environment-independent CI checks to one Ubuntu runner: JS/TS format, JS/TS lint/types, Rust format, Rust lint, and public-facade validation
- keep matrix coverage only where OS differences matter: build, workspace tests, real Corsa smoke, PR performance axes, and npm native release targets
- keep the macOS Intel native release build on GitHub-hosted `macos-15-intel`
- add Blacksmith to the README Sponsors section

## Validation
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "#{f} ok" }'`
- `./node_modules/.bin/vp test run --config ./vite.config.ts bench/src/npm_release_utils.test.ts bench/src/publish_workflows.test.ts`
- `./node_modules/.bin/vp check scripts/npm_release_utils.ts bench/src/npm_release_utils.test.ts bench/src/publish_workflows.test.ts`
- `rg -n "JS/TS Format \\(\\$\\{\\{ matrix\\.os \\}\\}\\)|JS/TS Lint and Types \\(\\$\\{\\{ matrix\\.os \\}\\}\\)|Rust Format \\(\\$\\{\\{ matrix\\.os \\}\\}\\)|Rust Lint \\(\\$\\{\\{ matrix\\.os \\}\\}\\)|Public Facade \\(\\$\\{\\{ matrix\\.os \\}\\}\\)" .github/workflows/ci.yml; test $? -eq 1`
- `git diff --check`
