### PR TITLE
fix: accept corsa settings in rule tester config

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -368,6 +368,50 @@ describe("corsa oxlint", () => {
     });
   });
 
+  it("accepts corsaOxlint settings on the RuleTester constructor config", () => {
+    let seen: Record<string, unknown> | undefined;
+    const tester = new RuleTester({
+      settings: {
+        corsaOxlint: {
+          parserOptions: {
+            corsa: {
+              executable: realCorsaBinary,
+            },
+          },
+        },
+      },
+    });
+    tester.run(
+      "settings-config-roundtrip",
+      {
+        meta: {
+          messages: {
+            demo: "demo",
+          },
+          schema: [],
+        },
+        create(context: any) {
+          seen = {
+            languageExecutable: context.languageOptions?.parserOptions?.corsa?.executable,
+            parserExecutable: context.parserOptions?.corsa?.executable,
+            settingsExecutable: context.settings?.corsaOxlint?.parserOptions?.corsa?.executable,
+          };
+          return {};
+        },
+      } as any,
+      {
+        valid: [{ code: "const value = 1;" }],
+        invalid: [],
+      },
+    );
+
+    expect(seen).toEqual({
+      languageExecutable: realCorsaBinary,
+      parserExecutable: realCorsaBinary,
+      settingsExecutable: realCorsaBinary,
+    });
+  });
+
   const integrationCase = existsSync(realCorsaBinary) ? it : it.skip;
 
   integrationCase("runs a type-aware custom rule through oxlint RuleTester", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/index.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/index.ts
@@ -12,6 +12,7 @@ export { compatPlugin, definePlugin, defineRule } from "./plugin";
 export type { Plugin, Rule } from "./plugin";
 export { getParserServices } from "./parser_services";
 export { RuleTester } from "./rule_tester";
+export type { RuleTesterConfig } from "./rule_tester";
 export { TSESLint } from "./ts_eslint";
 export * as rules from "./rules/index";
 export { oxlintCompat } from "./oxlint_compat";

--- a/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
@@ -12,10 +12,10 @@ type TesterConfig = import("oxlint/plugins-dev").RuleTester.Config;
 type TestCase = import("oxlint/plugins-dev").RuleTester.ValidTestCase &
   Partial<import("oxlint/plugins-dev").RuleTester.InvalidTestCase>;
 type TestCases = import("oxlint/plugins-dev").RuleTester.TestCases;
-type ConfigWithSettings = TesterConfig & {
-  settings?: {
-    corsaOxlint?: CorsaOxlintSettings;
-    [key: string]: unknown;
+export type RuleTesterConfig = TesterConfig & {
+  readonly settings?: {
+    readonly corsaOxlint?: CorsaOxlintSettings;
+    readonly [key: string]: unknown;
   };
 };
 
@@ -58,9 +58,9 @@ export class RuleTester {
   }
 
   readonly #inner: OxlintRuleTester;
-  readonly #config?: TesterConfig;
+  readonly #config?: RuleTesterConfig;
 
-  constructor(config?: TesterConfig) {
+  constructor(config?: RuleTesterConfig) {
     this.#config = config;
     this.#inner = new OxlintRuleTester(config);
   }
@@ -87,7 +87,7 @@ function createWorkspace(): string {
 function prepareTestCase(
   workspace: string,
   test: string | TestCase,
-  config: TesterConfig | undefined,
+  config: RuleTesterConfig | undefined,
   group: "valid" | "invalid",
   index: number,
 ): string | TestCase {
@@ -98,7 +98,7 @@ function prepareTestCase(
   }
   const filename = resolve(workspace, test.filename ?? `${group}-${index}.ts`);
   writeFixture(filename, test.code);
-  const testerConfig = config as ConfigWithSettings | undefined;
+  const testerConfig = config;
   const baseSettings = testerConfig?.settings?.corsaOxlint;
   const caseSettings = (
     test.settings as {

--- a/src/bindings/nodejs/corsa_oxlint/ts/ts_eslint.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/ts_eslint.ts
@@ -1,6 +1,7 @@
 import { RuleTester } from "./rule_tester";
 
 export { RuleTester } from "./rule_tester";
+export type { RuleTesterConfig } from "./rule_tester";
 
 export const ESLint = unsupportedTSESLintClass("ESLint");
 export const FlatESLint = unsupportedTSESLintClass("FlatESLint");


### PR DESCRIPTION
## Summary
- add a public RuleTesterConfig type that includes settings.corsaOxlint
- use that config type for the RuleTester constructor and fixture preparation
- cover constructor-level corsaOxlint settings in the RuleTester regression tests

Closes #185

## Validation
- ./node_modules/.bin/vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
- ./node_modules/.bin/vp check src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts src/bindings/nodejs/corsa_oxlint/ts/index.ts src/bindings/nodejs/corsa_oxlint/ts/ts_eslint.ts
- git diff --check