### PR TITLE
ci: use github hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   js-format:
     name: JS/TS Format
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -41,7 +41,7 @@ jobs:
 
   js-lint-types:
     name: JS/TS Lint and Types
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -62,7 +62,7 @@ jobs:
 
   rust-format:
     name: Rust Format
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -81,7 +81,7 @@ jobs:
 
   rust-lint:
     name: Rust Lint
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(github.event_name == 'pull_request' && '["blacksmith-2vcpu-ubuntu-2404"]' || '["blacksmith-2vcpu-ubuntu-2404","blacksmith-6vcpu-macos-15","blacksmith-2vcpu-windows-2025"]') }}
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest","macos-15","windows-latest"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -153,9 +153,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-2vcpu-ubuntu-2404
-          - blacksmith-6vcpu-macos-15
-          - blacksmith-2vcpu-windows-2025
+          - ubuntu-latest
+          - macos-15
+          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -180,7 +180,7 @@ jobs:
 
   public-facade:
     name: Public Facade
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -203,7 +203,7 @@ jobs:
 
   non-node-bindings:
     name: Non-Node Bindings
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -256,7 +256,7 @@ jobs:
 
   quality:
     name: Quality
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
       - js-format
@@ -308,9 +308,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - blacksmith-2vcpu-ubuntu-2404
-          - blacksmith-6vcpu-macos-15
-          - blacksmith-2vcpu-windows-2025
+          - ubuntu-latest
+          - macos-15
+          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -352,7 +352,7 @@ jobs:
 
   bench-corsa-ref:
     name: Corsa Ref Bench
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     if: ${{ github.event_name != 'pull_request' }}
     steps:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -30,7 +30,7 @@ jobs:
   github-release:
     if: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'push' && startsWith(github.event.workflow_run.head_branch, 'v') && github.event.workflow_run.conclusion == 'success') || (github.event_name == 'workflow_dispatch' && inputs.confirm == 'github-release') }}
     name: Create GitHub Release
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: release
     steps:

--- a/.github/workflows/pr-performance.yml
+++ b/.github/workflows/pr-performance.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   benchmark:
     name: Benchmark ${{ matrix.ref-role }} TypeScript ${{ matrix.typescript.channel }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     continue-on-error: ${{ matrix.ref-role == 'base' }}
     strategy:
@@ -182,7 +182,7 @@ jobs:
 
   comment:
     name: Comment benchmark result
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: benchmark
     steps:
       - name: Checkout

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -37,7 +37,7 @@ jobs:
   release-gates:
     if: ${{ (github.event_name == 'push' && github.ref_type == 'tag') || (github.event_name == 'workflow_dispatch' && inputs.confirm == 'publish-npm' && inputs.tag != '') }}
     name: Release Gates
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -103,7 +103,7 @@ jobs:
     name: Resolve native binding targets
     needs:
       - release-gates
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -206,7 +206,7 @@ jobs:
     needs:
       - release-gates
       - build-native-bindings
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: release
     permissions:

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -33,7 +33,7 @@ jobs:
   release-gates:
     if: ${{ (github.event_name == 'push' || inputs.confirm == 'publish-rust') && github.ref_type == 'tag' }}
     name: Release Gates
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -98,7 +98,7 @@ jobs:
     name: Publish Rust Crates
     needs:
       - release-gates
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: release
     permissions:

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   release-dry-run:
     name: Release Dry Run
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   scorecard:
     name: OpenSSF Scorecard
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       actions: read

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   cargo-deny:
     name: Cargo Deny
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -36,7 +36,7 @@ jobs:
 
   sbom:
     name: SBOM Generation
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/bench/src/npm_release_utils.test.ts
+++ b/bench/src/npm_release_utils.test.ts
@@ -106,7 +106,7 @@ describe("npm release utils", () => {
     expect(getNodeBindingBuildMatrix(nodeBindingManifest)).toEqual([
       {
         crossCompile: false,
-        os: "blacksmith-2vcpu-windows-2025",
+        os: "windows-latest",
         target: "x86_64-pc-windows-msvc",
         useNapiCross: false,
       },
@@ -118,37 +118,37 @@ describe("npm release utils", () => {
       },
       {
         crossCompile: false,
-        os: "blacksmith-2vcpu-ubuntu-2404",
+        os: "ubuntu-latest",
         target: "x86_64-unknown-linux-gnu",
         useNapiCross: true,
       },
       {
         crossCompile: false,
-        os: "blacksmith-6vcpu-macos-15",
+        os: "macos-15",
         target: "aarch64-apple-darwin",
         useNapiCross: false,
       },
       {
         crossCompile: false,
-        os: "blacksmith-2vcpu-windows-2025",
+        os: "windows-latest",
         target: "aarch64-pc-windows-msvc",
         useNapiCross: false,
       },
       {
         crossCompile: true,
-        os: "blacksmith-2vcpu-ubuntu-2404",
+        os: "ubuntu-latest",
         target: "x86_64-unknown-linux-musl",
         useNapiCross: false,
       },
       {
         crossCompile: false,
-        os: "blacksmith-2vcpu-ubuntu-2404",
+        os: "ubuntu-latest",
         target: "aarch64-unknown-linux-gnu",
         useNapiCross: true,
       },
       {
         crossCompile: true,
-        os: "blacksmith-2vcpu-ubuntu-2404",
+        os: "ubuntu-latest",
         target: "aarch64-unknown-linux-musl",
         useNapiCross: false,
       },

--- a/scripts/npm_release_utils.ts
+++ b/scripts/npm_release_utils.ts
@@ -135,12 +135,12 @@ interface NodeBindingBuildTargetConfig {
 const nodeBindingBuildTargetConfig: Record<string, NodeBindingBuildTargetConfig> = {
   "x86_64-pc-windows-msvc": {
     crossCompile: false,
-    os: "blacksmith-2vcpu-windows-2025",
+    os: "windows-latest",
     useNapiCross: false,
   },
   "aarch64-pc-windows-msvc": {
     crossCompile: false,
-    os: "blacksmith-2vcpu-windows-2025",
+    os: "windows-latest",
     useNapiCross: false,
   },
   "x86_64-apple-darwin": {
@@ -150,27 +150,27 @@ const nodeBindingBuildTargetConfig: Record<string, NodeBindingBuildTargetConfig>
   },
   "aarch64-apple-darwin": {
     crossCompile: false,
-    os: "blacksmith-6vcpu-macos-15",
+    os: "macos-15",
     useNapiCross: false,
   },
   "x86_64-unknown-linux-gnu": {
     crossCompile: false,
-    os: "blacksmith-2vcpu-ubuntu-2404",
+    os: "ubuntu-latest",
     useNapiCross: true,
   },
   "aarch64-unknown-linux-gnu": {
     crossCompile: false,
-    os: "blacksmith-2vcpu-ubuntu-2404",
+    os: "ubuntu-latest",
     useNapiCross: true,
   },
   "x86_64-unknown-linux-musl": {
     crossCompile: true,
-    os: "blacksmith-2vcpu-ubuntu-2404",
+    os: "ubuntu-latest",
     useNapiCross: false,
   },
   "aarch64-unknown-linux-musl": {
     crossCompile: true,
-    os: "blacksmith-2vcpu-ubuntu-2404",
+    os: "ubuntu-latest",
     useNapiCross: false,
   },
 };


### PR DESCRIPTION
## Summary

- Replace Blacksmith runner labels in GitHub Actions workflows with GitHub-hosted runner labels.
- Update the npm native binding build matrix generator and its test expectations to emit GitHub-hosted runners.

## Validation

- `./node_modules/.bin/vitest run --config ./vite.config.ts bench/src/npm_release_utils.test.ts bench/src/publish_workflows.test.ts`
- `node --strip-types ./scripts/print_napi_build_matrix.ts`
- `./node_modules/.bin/vp fmt --check`