### PR TITLE
test: run declaration emit tsc through node

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
@@ -16,6 +16,7 @@ import * as tsUtilsEntry from "./ts_utils";
 
 const workspaceRoot = resolve(import.meta.dirname, "../../../../..");
 const declarationEmitTimeoutMs = 20_000;
+const typescriptCompilerBin = resolve(workspaceRoot, "node_modules/typescript/bin/tsc");
 
 describe("api surface", () => {
   it("re-exports the compatibility entrypoint", () => {
@@ -127,8 +128,8 @@ describe("api surface", () => {
       try {
         try {
           execFileSync(
-            resolve(workspaceRoot, "node_modules/.bin/tsc"),
-            ["-p", resolve(workspace, "tsconfig.json")],
+            process.execPath,
+            [typescriptCompilerBin, "-p", resolve(workspace, "tsconfig.json")],
             {
               cwd: workspaceRoot,
               stdio: "pipe",


### PR DESCRIPTION
## Summary
- run the declaration emit regression through `process.execPath` and TypeScript's JS entrypoint instead of `node_modules/.bin/tsc`
- avoid Windows `.CMD` resolution issues when the test uses `execFileSync` without a shell

## Verification
- `./node_modules/.bin/vp run build_node_debug`
- `./node_modules/.bin/vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts -t "emits declarations for inferred visitor callback node types"`
- `./node_modules/.bin/vp check src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts`
- `git diff --check`