### PR TITLE
perf: add bare oxlint tooling benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ The repo ships two benchmark layers:
 
 - Native Rust benchmark: `vp run -w bench_native`
 - Native profiling benchmark: `vp run -w bench_native_profile`
+- Tooling comparison benchmark: `vp run -w bench_tooling_compare`
 - Node binding benchmark: `vp run -w bench_ts`
 - `corsa oxlint` checker benchmark: `vp test bench --config ./vite.config.ts bench/src/corsa_oxlint.bench.ts`
 - `corsa oxlint` native-rule benchmark: `vp test bench --config ./vite.config.ts bench/src/corsa_oxlint_rules.bench.ts`

--- a/docs/benchmarking_guide.md
+++ b/docs/benchmarking_guide.md
@@ -213,14 +213,16 @@ Flow:
 
 1. Load datasets through the real pinned Corsa.
 2. Build temporary overlay `tsconfig` files.
-3. Run `tsc`, Corsa CLI, `typescript-eslint`, `corsa-oxlint`, and `tsgolint` as child processes for `project_check`.
+3. Run `tsc`, Corsa CLI, `typescript-eslint`, `corsa-oxlint`, bare `oxlint`, and `tsgolint` as child processes for `project_check`.
 4. Run a live `corsa` msgpack session for `editor_workflow`.
 5. Emit timing tables and JSON.
 
 Important design choices:
 
-- `typescript-eslint`, `corsa-oxlint`, and `tsgolint` are allowed to exit with code `1` because lint findings are expected and should not invalidate timing
-- the three lint lanes use the overlapping type-aware rule set currently exported from `corsa-oxlint/rules`
+- the default tooling dataset is the pinned upstream `native-preview` package, which currently completes a clean Corsa CLI project check
+- `typescript-eslint`, `corsa-oxlint`, bare `oxlint`, and `tsgolint` are allowed to exit with code `1` because lint findings are expected and should not invalidate timing
+- `typescript-eslint`, `corsa-oxlint`, and `tsgolint` use the overlapping type-aware rule set currently exported from `corsa-oxlint/rules`
+- bare `oxlint` intentionally runs without the Corsa JS plugin or type-aware `tsgolint` bridge, so it is a raw Oxlint process baseline rather than the same rule workload
 - child processes run with timeouts
 - child stdout and stderr are suppressed during timing so the measurement focuses on the actual workload
 
@@ -282,7 +284,9 @@ For tooling benchmarks, install the exact comparison dependencies first:
 vp run -w bench_tooling_setup
 ```
 
-That keeps `typescript`, `eslint`, and `typescript-eslint` pinned for the comparison runner.
+That keeps `typescript`, `eslint`, `typescript-eslint`, and `oxlint-tsgolint`
+pinned for the comparison runner. Bare `oxlint` comes from the pinned
+`corsa-oxlint` package dependency.
 
 ## Never Forget Snapshot and Client Cleanup
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -30,7 +30,7 @@ For the reasoning behind these benchmark layers, implementation notes, and exten
 
 The tooling benchmark is the `bench_tooling_compare` binary. It tracks two workloads:
 
-- `project_check`: `tsc`, Corsa CLI, `typescript-eslint`, `corsa-oxlint`, and `tsgolint` on the same dataset
+- `project_check`: `tsc`, Corsa CLI, `typescript-eslint`, `corsa-oxlint`, bare `oxlint`, and `tsgolint` on the same dataset
 - `editor_workflow`: `corsa` msgpack cold and warm orchestration over a representative multi-query API flow
 
 Before running it for the first time, install the comparison dependencies:
@@ -48,10 +48,17 @@ cargo run --release -p corsa --bin bench_tooling_compare -- \
   --json-output .cache/bench_tooling_compare.json
 ```
 
+By default the tooling runner uses the pinned upstream `native-preview`
+package, because it is the largest bundled dataset that currently completes a
+clean Corsa CLI project check. Use `--dataset PATH` to add more projects when
+you want exploratory numbers and are prepared to handle diagnostics.
+
 `project_check` is the apples-to-apples CLI comparison.
 The lint lanes use the overlapping type-aware rules currently published by
 `corsa-oxlint/rules`, so `typescript-eslint`, `corsa-oxlint`, and `tsgolint`
 are timed against the same rule workload.
+The `oxlint-bare` lane intentionally runs plain Oxlint without the Corsa plugin
+or type-aware bridge, giving a raw process baseline for the requested comparison.
 `editor_workflow` is intentionally a different workload: it asks whether session reuse and orchestration can beat rerunning a full Corsa CLI `--noEmit` project check.
 
 The runner creates temporary overlay `tsconfig` files for CLI parity, enforces per-process timeouts, and always kills plus reaps spawned children before returning.

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+const clients: FakeClient[] = [];
+
+class FakeClient {
+  readonly initialize = vi.fn();
+  readonly parseConfigFile = vi.fn(() => ({ options: {}, fileNames: [] }));
+  readonly updateSnapshot = vi.fn(() => ({
+    snapshot: `snapshot-${this.updateSnapshot.mock.calls.length}`,
+    projects: [{ id: "project-1" }],
+  }));
+  readonly getTypeAtPosition = vi.fn(() => ({
+    id: "type-1",
+    flags: 0,
+    texts: ["string"],
+  }));
+  readonly releaseHandle = vi.fn();
+  readonly close = vi.fn();
+
+  readonly callJson = vi.fn((method: string) => {
+    if (method === "describeCapabilities") {
+      return { overlay: { updateSnapshotOverlayChanges: false } };
+    }
+    if (method === "getDefaultProjectForFile") {
+      return { id: "project-1" };
+    }
+    return undefined;
+  });
+}
+
+vi.mock("@corsa-bind/napi", () => ({
+  CorsaApiClient: {
+    spawn: vi.fn(() => {
+      const client = new FakeClient();
+      clients.push(client);
+      return client;
+    }),
+  },
+}));
+
+const { CorsaProjectSession } = await import("./session");
+
+describe("CorsaProjectSession", () => {
+  it("reuses the current snapshot when visiting a new unchanged file", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    session.getTypeAtPosition("/tmp/one.ts", 0);
+    session.getTypeAtPosition("/tmp/two.ts", 0);
+
+    expect(clients[0]?.updateSnapshot).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -694,13 +694,14 @@ export class CorsaProjectSession {
     const cached = this.#files.get(fileName);
     const mtimeMs = statMtimeMs(fileName);
     const overlayText = this.supportedOverlayText(fileName, sourceText, mtimeMs, cached);
+    const mtimeChanged = cached !== undefined && mtimeMs !== cached.mtimeMs;
     const textChanged = overlayText !== cached?.sourceText;
     const prepared = {
       mtimeMs,
       lintSourceText: sourceText,
       sourceText: overlayText,
     };
-    const stale = !this.#snapshot || mtimeMs !== cached?.mtimeMs || textChanged || expired;
+    const stale = !this.#snapshot || mtimeChanged || textChanged || expired;
     if (!stale) {
       return prepared;
     }

--- a/src/bindings/rust/corsa/src/bin/bench_tooling_compare/args.rs
+++ b/src/bindings/rust/corsa/src/bin/bench_tooling_compare/args.rs
@@ -160,12 +160,7 @@ fn default_corsa_path(root_dir: &std::path::Path) -> PathBuf {
 
 fn default_datasets(root_dir: &std::path::Path) -> SmallVec<[PathBuf; 4]> {
     let base = root_dir.join("ref/corsa-upstream");
-    let candidates = [
-        base.join("_packages/ast/tsconfig.json"),
-        base.join("_packages/native-preview/tsconfig.json"),
-        base.join("_packages/api/tsconfig.json"),
-        base.join("_extension/tsconfig.json"),
-    ];
+    let candidates = [base.join("_packages/native-preview/tsconfig.json")];
     let mut datasets = SmallVec::<[PathBuf; 4]>::new();
     for path in candidates {
         if path.exists() {

--- a/src/bindings/rust/corsa/src/bin/bench_tooling_compare/main.rs
+++ b/src/bindings/rust/corsa/src/bin/bench_tooling_compare/main.rs
@@ -76,6 +76,14 @@ async fn run(cli: args::Cli) -> corsa::Result<()> {
         println!("{line}");
     }
     println!();
+    println!("project_check requested opponent comparison");
+    println!(
+        "dataset\ttool\topponent\ttool_median_ms\topponent_median_ms\ttool_vs_opponent_x\twinner"
+    );
+    for line in report::project_check_requested_opponent_lines(&results) {
+        println!("{line}");
+    }
+    println!();
     println!("editor_workflow vs corsa CLI project_check baseline (not equivalent work)");
     println!("dataset\ttool\tmedian_ms\tcorsa_project_check_median_ms\tvs_corsa_x");
     for line in report::workflow_vs_corsa_lines(&results) {

--- a/src/bindings/rust/corsa/src/bin/bench_tooling_compare/report.rs
+++ b/src/bindings/rust/corsa/src/bin/bench_tooling_compare/report.rs
@@ -52,6 +52,7 @@ pub fn write(path: &Path, cli: &Cli, datasets: &[DatasetCase], rows: &[ToolRow])
             "datasets": datasets,
             "rows": rows_json,
             "projectCheckVsCorsa": project_check_vs_corsa_json(rows),
+            "projectCheckRequestedOpponentComparison": project_check_requested_opponent_json(rows),
             "workflowVsCorsaCli": workflow_vs_corsa_json(rows),
         }))?,
     )?;
@@ -90,6 +91,24 @@ pub fn workflow_vs_corsa_lines(rows: &[ToolRow]) -> Vec<String> {
         .collect()
 }
 
+pub fn project_check_requested_opponent_lines(rows: &[ToolRow]) -> Vec<String> {
+    project_check_requested_opponents(rows)
+        .into_iter()
+        .map(|comparison| {
+            format!(
+                "{}\t{}\t{}\t{:.3}\t{:.3}\t{:.2}\t{}",
+                comparison.dataset,
+                comparison.tool,
+                comparison.opponent_tool,
+                comparison.tool_median_ms,
+                comparison.opponent_median_ms,
+                comparison.tool_vs_opponent_x,
+                comparison.winner
+            )
+        })
+        .collect()
+}
+
 fn project_check_vs_corsa_json(rows: &[ToolRow]) -> Vec<serde_json::Value> {
     project_check_vs_corsa(rows)
         .into_iter()
@@ -101,6 +120,23 @@ fn project_check_vs_corsa_json(rows: &[ToolRow]) -> Vec<serde_json::Value> {
                 "baselineTool": comparison.baseline_tool,
                 "baselineMedianMs": comparison.baseline_median_ms,
                 "vsBaselineX": comparison.vs_baseline_x,
+            })
+        })
+        .collect()
+}
+
+fn project_check_requested_opponent_json(rows: &[ToolRow]) -> Vec<serde_json::Value> {
+    project_check_requested_opponents(rows)
+        .into_iter()
+        .map(|comparison| {
+            json!({
+                "dataset": comparison.dataset,
+                "tool": comparison.tool,
+                "opponentTool": comparison.opponent_tool,
+                "toolMedianMs": comparison.tool_median_ms,
+                "opponentMedianMs": comparison.opponent_median_ms,
+                "toolVsOpponentX": comparison.tool_vs_opponent_x,
+                "winner": comparison.winner,
             })
         })
         .collect()
@@ -131,6 +167,16 @@ struct Comparison<'a> {
     vs_baseline_x: f64,
 }
 
+struct RequestedOpponentComparison<'a> {
+    dataset: &'a str,
+    tool: &'a str,
+    opponent_tool: &'a str,
+    tool_median_ms: f64,
+    opponent_median_ms: f64,
+    tool_vs_opponent_x: f64,
+    winner: &'a str,
+}
+
 fn project_check_vs_corsa(rows: &[ToolRow]) -> Vec<Comparison<'_>> {
     let mut items = Vec::new();
     for row in rows
@@ -154,6 +200,38 @@ fn project_check_vs_corsa(rows: &[ToolRow]) -> Vec<Comparison<'_>> {
         });
     }
     sort_comparisons(&mut items);
+    items
+}
+
+fn project_check_requested_opponents(rows: &[ToolRow]) -> Vec<RequestedOpponentComparison<'_>> {
+    let mut items = Vec::new();
+    for row in rows.iter().filter(|row| {
+        row.workload.as_str() == "project_check" && is_requested_opponent(row.tool.as_str())
+    }) {
+        let Some(corsa) = rows.iter().find(|candidate| {
+            candidate.workload.as_str() == "project_check"
+                && candidate.dataset == row.dataset
+                && candidate.tool.as_str() == "corsa"
+        }) else {
+            continue;
+        };
+        let tool_median_ms = corsa.stats.median_ms();
+        let opponent_median_ms = row.stats.median_ms();
+        items.push(RequestedOpponentComparison {
+            dataset: row.dataset.as_str(),
+            tool: corsa.tool.as_str(),
+            opponent_tool: row.tool.as_str(),
+            tool_median_ms,
+            opponent_median_ms,
+            tool_vs_opponent_x: opponent_median_ms / tool_median_ms,
+            winner: if tool_median_ms <= opponent_median_ms {
+                corsa.tool.as_str()
+            } else {
+                row.tool.as_str()
+            },
+        });
+    }
+    sort_requested_opponent_comparisons(&mut items);
     items
 }
 
@@ -183,10 +261,23 @@ fn workflow_vs_corsa(rows: &[ToolRow]) -> Vec<Comparison<'_>> {
     items
 }
 
+fn is_requested_opponent(tool: &str) -> bool {
+    matches!(tool, "typescript-eslint" | "tsgolint" | "oxlint-bare")
+}
+
 fn sort_comparisons(items: &mut [Comparison<'_>]) {
     items.sort_by(|left, right| {
         left.dataset
             .cmp(right.dataset)
             .then_with(|| left.tool.cmp(right.tool))
+    });
+}
+
+fn sort_requested_opponent_comparisons(items: &mut [RequestedOpponentComparison<'_>]) {
+    items.sort_by(|left, right| {
+        left.dataset
+            .cmp(right.dataset)
+            .then_with(|| left.tool.cmp(right.tool))
+            .then_with(|| left.opponent_tool.cmp(right.opponent_tool))
     });
 }

--- a/src/bindings/rust/corsa/src/bin/bench_tooling_compare/runner.rs
+++ b/src/bindings/rust/corsa/src/bin/bench_tooling_compare/runner.rs
@@ -85,8 +85,8 @@ async fn run_project_check_suite(
     dataset: &DatasetCase,
     support: &ToolSupport,
     overlay: &OverlayConfig,
-) -> Result<SmallVec<[ToolRow; 8]>> {
-    let mut rows = SmallVec::<[ToolRow; 8]>::new();
+) -> Result<SmallVec<[ToolRow; 16]>> {
+    let mut rows = SmallVec::<[ToolRow; 16]>::new();
     let timeout = Duration::from_millis(cli.timeout_ms);
     if let Some(stats) = measure_row(cli.allow_partial_failures, "project_check:tsc", || {
         measure_with_warmup(cli.warmup_iterations, cli.iterations, || async {
@@ -135,6 +135,20 @@ async fn run_project_check_suite(
     .await?
     {
         rows.push(row("project_check", dataset, "corsa-oxlint", stats));
+    }
+    if let Some(stats) = measure_row(
+        cli.allow_partial_failures,
+        "project_check:oxlint-bare",
+        || {
+            measure_with_warmup(cli.warmup_iterations, cli.iterations, || async {
+                let mut command = oxlint_bare_command(dataset, support);
+                run_command(&mut command, timeout, &[0, 1], "oxlint-bare")
+            })
+        },
+    )
+    .await?
+    {
+        rows.push(row("project_check", dataset, "oxlint-bare", stats));
     }
     if let Some(stats) = measure_row(cli.allow_partial_failures, "project_check:tsgolint", || {
         measure_with_warmup(cli.warmup_iterations, cli.iterations, || async {
@@ -263,6 +277,19 @@ fn corsa_oxlint_command(
         .env("CORSA_RS_BENCH_TSCONFIG", &overlay.path)
         .env("CORSA_RS_BENCH_EXECUTABLE", &cli.corsa_path)
         .env("CORSA_RS_BENCH_ROOT", &support.workspace_root);
+    for file in &dataset.source_files {
+        command.arg(file.as_str());
+    }
+    command
+}
+
+fn oxlint_bare_command(dataset: &DatasetCase, support: &ToolSupport) -> Command {
+    let mut command = Command::new(support.node_command.as_str());
+    command
+        .current_dir(&support.workspace_root)
+        .arg(&support.oxlint_script)
+        .arg("--disable-nested-config")
+        .arg("--silent");
     for file in &dataset.source_files {
         command.arg(file.as_str());
     }


### PR DESCRIPTION
## Summary

- add a bare `oxlint` lane to `bench_tooling_compare`
- add a requested-opponent comparison summary for `typescript-eslint`, `tsgolint`, and bare `oxlint`
- fix `corsa-oxlint` session refresh so visiting a new unchanged file does not rebuild the snapshot
- document the tooling benchmark comparison model and default dataset

## Validation

- `vp run -w bench_tooling_compare`
- `vp lint`
- `cargo test -p corsa --bin bench_tooling_compare`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/session.test.ts`
- `cargo fmt --all --check`
- `git diff --check`

## Benchmark Result

`vp run -w bench_tooling_compare` on `native-preview`:

| opponent | tool median (`corsa`) | opponent median | result |
| --- | ---: | ---: | --- |
| `oxlint-bare` | 36.223 ms | 49.785 ms | `corsa` 1.37x win |
| `tsgolint` | 36.223 ms | 59.761 ms | `corsa` 1.65x win |
| `typescript-eslint` | 36.223 ms | 1767.779 ms | `corsa` 48.80x win |