### PR TITLE
feat: add native stylistic oxlint plugin

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -14,6 +14,7 @@ Ox Content.
 - `@corsa-bind/napi`
 - `corsa-oxlint`
 - `corsa-oxlint/rules`
+- `corsa-oxlint/stylistic`
 
 The generated reference pages are emitted directly into `dist/docs/api` during
 `vp run -w docs_build`. Source Markdown stays in `docs`, and the generated HTML

--- a/docs/build/api.ts
+++ b/docs/build/api.ts
@@ -8,6 +8,7 @@ const ENTRYPOINTS = [
   ["@corsa-bind/napi", "src/bindings/nodejs/corsa_node/ts/index.ts"],
   ["corsa-oxlint", "src/bindings/nodejs/corsa_oxlint/ts/index.ts"],
   ["corsa-oxlint/rules", "src/bindings/nodejs/corsa_oxlint/ts/rules/index.ts"],
+  ["corsa-oxlint/stylistic", "src/bindings/nodejs/corsa_oxlint/ts/stylistic.ts"],
 ] as const;
 
 /** Builds API reference Markdown from public TypeScript exports and JSDoc. */

--- a/docs/build/html.ts
+++ b/docs/build/html.ts
@@ -33,6 +33,7 @@ const NAV_GROUPS = [
       "api/corsa-bind-napi/index.html",
       "api/corsa-oxlint/index.html",
       "api/corsa-oxlint-rules/index.html",
+      "api/corsa-oxlint-stylistic/index.html",
       "api_reference/index.html",
     ],
   },
@@ -54,6 +55,7 @@ const ROUTE_TITLES = new Map<string, string>([
   ["api/corsa-bind-napi/index.html", "@corsa-bind/napi"],
   ["api/corsa-oxlint/index.html", "corsa-oxlint"],
   ["api/corsa-oxlint-rules/index.html", "Oxlint rules"],
+  ["api/corsa-oxlint-stylistic/index.html", "Stylistic rules"],
   ["api_reference/index.html", "API docs generation"],
 ]);
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -24,6 +24,13 @@ The binding benchmark writes its report to `.cache/bench_bindings.json`.
 
 The native runner is still the main source of truth for transport-level speed because it measures the Rust client directly against the pinned upstream worker.
 
+The `corsa-oxlint/stylistic` entrypoint uses a different performance model from
+type-aware rules: it sends the full source text to Rust once per source/config,
+scans bytes directly, and shares the resulting diagnostics across enabled
+stylistic rules through a JS-side cache. Configure
+`settings.corsaStylistic.rules` when several stylistic rules are active so the
+plugin can keep that single native scan path.
+
 For the reasoning behind these benchmark layers, implementation notes, and extension tips, see [benchmarking_guide.md](./benchmarking_guide.md).
 
 ## Tooling Runner

--- a/examples/README.md
+++ b/examples/README.md
@@ -146,5 +146,6 @@ cargo run -p corsa --features experimental-distributed --example distributed_orc
 - `examples/corsa_oxlint/custom_plugin.ts`: plugin wrapper around the custom rule
 - `examples/corsa_oxlint/custom_rules_config.ts`: flat config using the custom plugin
 - `examples/corsa_oxlint/native_rules_config.ts`: flat config using the built-in native rules
+- `examples/corsa_oxlint/stylistic_config.ts`: flat config using the Rust-backed stylistic plugin through `corsa-oxlint/stylistic`
 - `examples/corsa_oxlint/rule_tester.ts`: executable `RuleTester` example against the real pinned Corsa binary
 - `examples/corsa_oxlint/native_rule_tester.ts`: executable `RuleTester` example for the built-in Rust-backed and TS-native rules

--- a/examples/corsa_oxlint/stylistic_config.ts
+++ b/examples/corsa_oxlint/stylistic_config.ts
@@ -1,0 +1,33 @@
+import { corsaStylisticPlugin } from "corsa-oxlint/stylistic";
+
+const config = [
+  {
+    settings: {
+      corsaStylistic: {
+        rules: {
+          "eol-last": ["always"],
+          "linebreak-style": ["unix"],
+          "no-multiple-empty-lines": [{ max: 1, maxBOF: 0, maxEOF: 1 }],
+          "no-tabs": [{ allowIndentationTabs: false }],
+          "no-trailing-spaces": [{ skipBlankLines: false }],
+          quotes: ["single", { avoidEscape: true }],
+          "unicode-bom": ["never"],
+        },
+      },
+    },
+    plugins: {
+      stylistic: corsaStylisticPlugin,
+    },
+    rules: {
+      "stylistic/eol-last": "error",
+      "stylistic/linebreak-style": "error",
+      "stylistic/no-multiple-empty-lines": "error",
+      "stylistic/no-tabs": "error",
+      "stylistic/no-trailing-spaces": "error",
+      "stylistic/quotes": "error",
+      "stylistic/unicode-bom": "error",
+    },
+  },
+];
+
+export default config;

--- a/examples/smoke.ts
+++ b/examples/smoke.ts
@@ -9,6 +9,7 @@ import customRulesConfig from "./corsa_oxlint/custom_rules_config.ts";
 import { corsaOxlintCustomPlugin } from "./corsa_oxlint/custom_plugin.ts";
 import { noStringPlusNumberRule } from "./corsa_oxlint/custom_rule.ts";
 import nativeRulesConfig from "./corsa_oxlint/native_rules_config.ts";
+import stylisticConfig from "./corsa_oxlint/stylistic_config.ts";
 
 function ruleCount(config: readonly unknown[]): number {
   return config.reduce<number>((count, entry) => {
@@ -31,6 +32,7 @@ const result = {
   mockClient: runMockClientExample(),
   nativeRuleEntries: ruleCount(nativeRulesConfig),
   rawCalls: runRawCallsExample(),
+  stylisticEntries: ruleCount(stylisticConfig),
   unsafeTypeFlow: runUnsafeTypeFlowExample(),
   virtualDocument: runVirtualDocumentExample(),
 };

--- a/scripts/vite/aliases.ts
+++ b/scripts/vite/aliases.ts
@@ -18,6 +18,7 @@ export const aliases = {
   "corsa-oxlint/utils": resolve(corsaOxlintDir, "ts/utils.ts"),
   "corsa-oxlint/rule-tester": resolve(corsaOxlintDir, "ts/rule_tester.ts"),
   "corsa-oxlint/rules": resolve(corsaOxlintDir, "ts/rules/index.ts"),
+  "corsa-oxlint/stylistic": resolve(corsaOxlintDir, "ts/stylistic.ts"),
   "corsa-oxlint/ts-estree": resolve(corsaOxlintDir, "ts/ts_estree.ts"),
   "corsa-oxlint/ts-eslint": resolve(corsaOxlintDir, "ts/ts_eslint.ts"),
   "corsa-oxlint/ts-utils": resolve(corsaOxlintDir, "ts/ts_utils.ts"),

--- a/src/bindings/nodejs/corsa_node/index.d.ts
+++ b/src/bindings/nodejs/corsa_node/index.d.ts
@@ -131,7 +131,11 @@ export declare function isUnsafeReturn(input: any): boolean
 
 export declare function nativeLintRuleMetas(): any
 
+export declare function nativeStylisticRuleMetas(): any
+
 export declare function runNativeLintRule(ruleName: string, node: any): any
+
+export declare function runNativeStylisticLint(sourceText: string, config: any): any
 
 /** Spawns a new client on a libuv worker thread. */
 export declare function spawnCorsaApiClientAsync(options: any): Promise<CorsaApiClient>

--- a/src/bindings/nodejs/corsa_node/src/native_lint.rs
+++ b/src/bindings/nodejs/corsa_node/src/native_lint.rs
@@ -22,3 +22,16 @@ pub fn run_native_lint_rule(rule_name: String, node: Value) -> Result<Value> {
 pub fn native_lint_rule_metas() -> Result<Value> {
     to_value(&corsa::lint::LintRuleRegistry::with_default_type_aware_rules().metas())
 }
+
+#[napi]
+pub fn run_native_stylistic_lint(source_text: String, config: Value) -> Result<Value> {
+    let config = from_value::<corsa::lint::StylisticRunConfig>(config)?;
+    let diagnostics =
+        corsa::lint::run_stylistic_lint(source_text.as_str(), &config).map_err(into_napi_error)?;
+    to_value(&diagnostics)
+}
+
+#[napi]
+pub fn native_stylistic_rule_metas() -> Result<Value> {
+    to_value(&corsa::lint::stylistic_rule_metas())
+}

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -13,8 +13,10 @@ import {
   isErrorLikeTypeTexts,
   isStringArrayLikeTypeTexts,
   isPromiseLikeTypeTexts,
+  nativeStylisticRuleMetas,
   nativeLintRuleMetas,
   runNativeLintRule,
+  runNativeStylisticLint,
   splitTopLevelTypeText,
   splitTypeText,
   isUnsafeAssignment,
@@ -177,6 +179,38 @@ describe("CorsaApiClient", () => {
       ".splice(",
       ", 1)",
     ]);
+  });
+
+  it("runs Rust-authored native stylistic rules", () => {
+    const diagnostics = runNativeStylisticLint('\u{feff}const\tlabel = "value";  \r\n\n\n', {
+      rules: [
+        { name: "unicode-bom", options: ["never"] },
+        { name: "quotes", options: ["single"] },
+        { name: "no-trailing-spaces", options: [] },
+        { name: "no-tabs", options: [] },
+        { name: "linebreak-style", options: ["unix"] },
+        { name: "no-multiple-empty-lines", options: [{ max: 1 }] },
+      ],
+    });
+
+    expect(nativeStylisticRuleMetas().map((meta) => meta.name)).toEqual([
+      "eol-last",
+      "linebreak-style",
+      "no-multiple-empty-lines",
+      "no-tabs",
+      "no-trailing-spaces",
+      "quotes",
+      "unicode-bom",
+    ]);
+    expect(diagnostics.map((diagnostic) => diagnostic.ruleName)).toEqual([
+      "unicode-bom",
+      "quotes",
+      "no-trailing-spaces",
+      "no-tabs",
+      "linebreak-style",
+      "no-multiple-empty-lines",
+    ]);
+    expect(diagnostics[1].suggestions?.[0]?.fixes[0]?.replacementText).toBe("'value'");
   });
 
   it("roundtrips through the mock corsa binary", () => {

--- a/src/bindings/nodejs/corsa_node/ts/index.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.ts
@@ -7,6 +7,7 @@ import type {
   NativeLintDiagnostic,
   NativeLintNode,
   NativeLintRuleMeta,
+  NativeStylisticRunConfig,
   SymbolResponse,
   TypeResponse,
   TypeTextKind,
@@ -158,6 +159,12 @@ export const runNativeLintRule = binding.runNativeLintRule as (
   node: NativeLintNode,
 ) => NativeLintDiagnostic[];
 export const nativeLintRuleMetas = binding.nativeLintRuleMetas as () => NativeLintRuleMeta[];
+export const runNativeStylisticLint = binding.runNativeStylisticLint as (
+  sourceText: string,
+  config: NativeStylisticRunConfig,
+) => NativeLintDiagnostic[];
+export const nativeStylisticRuleMetas =
+  binding.nativeStylisticRuleMetas as () => NativeLintRuleMeta[];
 export const classifyTypeText = binding.classifyTypeText as (text?: string) => TypeTextKind;
 export const splitTopLevelTypeText = binding.splitTopLevelTypeText as (
   text: string,

--- a/src/bindings/nodejs/corsa_node/ts/types.ts
+++ b/src/bindings/nodejs/corsa_node/ts/types.ts
@@ -181,6 +181,15 @@ export interface NativeLintRuleMeta {
   requiresTypeTexts: boolean;
 }
 
+export interface NativeStylisticRuleConfig {
+  name: string;
+  options?: unknown;
+}
+
+export interface NativeStylisticRunConfig {
+  rules: readonly NativeStylisticRuleConfig[];
+}
+
 export type TypeTextKind =
   | "any"
   | "bigint"

--- a/src/bindings/nodejs/corsa_oxlint/README.md
+++ b/src/bindings/nodejs/corsa_oxlint/README.md
@@ -18,6 +18,7 @@ plugins with real type information powered by Corsa.
 - lets custom Oxlint rules query types and symbols from JS or TS
 - ships a `RuleTester` wrapper that injects temp projects and type-aware config
 - ships a growing TS-native ruleset under `corsa-oxlint/rules`
+- ships a source-wide native stylistic ruleset under `corsa-oxlint/stylistic`
 
 The design goal is simple: performance-critical pieces live in Rust, `napi-rs`
 bridges them into Node, and end users still get to author custom plugins and
@@ -121,6 +122,52 @@ unsafe, unnecessary, promise/control-flow, preference/style, and type/export
 families. `pendingNativeRuleNames` is intentionally empty, and
 `native_rules.test.ts` fails if implemented + pending drift away from the
 tracked upstream rule list.
+
+## Stylistic Rules
+
+`corsa-oxlint/stylistic` is a separate path for Rust-backed style rules that do
+not need type information. The rules scan the full source text in native code
+and the JS plugin caches diagnostics per source/config so enabled rules can
+share one N-API call.
+
+```ts
+import { corsaStylisticPlugin } from "corsa-oxlint/stylistic";
+
+export default [
+  {
+    settings: {
+      corsaStylistic: {
+        rules: {
+          "eol-last": ["always"],
+          "linebreak-style": ["unix"],
+          "no-multiple-empty-lines": [{ max: 1, maxBOF: 0, maxEOF: 1 }],
+          "no-tabs": [{ allowIndentationTabs: false }],
+          "no-trailing-spaces": [{ skipBlankLines: false }],
+          quotes: ["single", { avoidEscape: true }],
+          "unicode-bom": ["never"],
+        },
+      },
+    },
+    plugins: {
+      stylistic: corsaStylisticPlugin,
+    },
+    rules: {
+      "stylistic/eol-last": "error",
+      "stylistic/linebreak-style": "error",
+      "stylistic/no-multiple-empty-lines": "error",
+      "stylistic/no-tabs": "error",
+      "stylistic/no-trailing-spaces": "error",
+      "stylistic/quotes": "error",
+      "stylistic/unicode-bom": "error",
+    },
+  },
+];
+```
+
+Rule options can also be supplied directly in `rules`, for example
+`"stylistic/quotes": ["error", "single"]`. For the fastest multi-rule path,
+put the same option payloads in `settings.corsaStylistic.rules`; that lets the
+bridge batch all configured stylistic rules into a single Rust source scan.
 
 ## Rust-Authored Rule Lane
 

--- a/src/bindings/nodejs/corsa_oxlint/package.json
+++ b/src/bindings/nodejs/corsa_oxlint/package.json
@@ -68,6 +68,12 @@
       "bun": "./dist/rules/index.js",
       "import": "./dist/rules/index.js"
     },
+    "./stylistic": {
+      "types": "./dist/stylistic.d.ts",
+      "deno": "./dist/stylistic.js",
+      "bun": "./dist/stylistic.js",
+      "import": "./dist/stylistic.js"
+    },
     "./compat": {
       "types": "./dist/oxlint_compat.d.ts",
       "deno": "./dist/oxlint_compat.js",

--- a/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
@@ -10,6 +10,7 @@ import * as main from "./index";
 import * as eslintUtilsEntry from "./oxlint_utils";
 import * as compatEntry from "./oxlint_compat";
 import * as rules from "./rules";
+import * as stylistic from "./stylistic";
 import * as tsEslintEntry from "./ts_eslint";
 import * as tsestreeEntry from "./ts_estree";
 import * as tsUtilsEntry from "./ts_utils";
@@ -483,6 +484,11 @@ describe("api surface", () => {
   it("re-exports the native rules surface from both entrypoints", () => {
     expect(typeof main.rules.corsaOxlintPlugin).toBe("object");
     expect(rules.implementedNativeRuleNames).toContain("restrict-plus-operands");
+  });
+
+  it("re-exports the native stylistic surface from both entrypoints", () => {
+    expect(typeof main.stylistic.corsaStylisticPlugin).toBe("object");
+    expect(stylistic.implementedStylisticRuleNames).toContain("quotes");
   });
 
   it("re-exports Rust-backed utility helpers from the root entry", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/index.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/index.ts
@@ -15,6 +15,7 @@ export { RuleTester } from "./rule_tester";
 export type { RuleTesterConfig } from "./rule_tester";
 export { TSESLint } from "./ts_eslint";
 export * as rules from "./rules/index";
+export * as stylistic from "./stylistic";
 export { oxlintCompat } from "./oxlint_compat";
 export type ESTree = {
   NewExpression: OxlintESTree.NewExpression;
@@ -29,6 +30,7 @@ export type {
   CorsaProgramShape,
   CorsaRuntimeOptions,
   CorsaOxlintSettings,
+  CorsaStylisticSettings,
   CorsaSignature,
   CorsaSymbol,
   CorsaType,

--- a/src/bindings/nodejs/corsa_oxlint/ts/stylistic.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/stylistic.test.ts
@@ -1,0 +1,85 @@
+import { nativeStylisticRuleMetas, runNativeStylisticLint } from "@corsa-bind/napi";
+import { describe, expect, it } from "vitest";
+
+import { RuleTester } from "./rule_tester";
+import {
+  corsaStylisticPlugin,
+  corsaStylisticRules,
+  implementedStylisticRuleNames,
+} from "./stylistic";
+
+describe("corsa stylistic rules", () => {
+  it("exports a separate stylistic plugin surface", () => {
+    expect(Object.keys(corsaStylisticPlugin.rules ?? {}).sort()).toEqual(
+      [...implementedStylisticRuleNames].sort(),
+    );
+    expect(nativeStylisticRuleMetas().map((meta) => meta.name)).toEqual([
+      "eol-last",
+      "linebreak-style",
+      "no-multiple-empty-lines",
+      "no-tabs",
+      "no-trailing-spaces",
+      "quotes",
+      "unicode-bom",
+    ]);
+  });
+
+  it("runs multiple stylistic rules through one native binding call", () => {
+    const diagnostics = runNativeStylisticLint('\u{feff}const\tlabel = "value";  \r\n\n\n', {
+      rules: [
+        { name: "unicode-bom", options: ["never"] },
+        { name: "quotes", options: ["single"] },
+        { name: "no-trailing-spaces", options: [] },
+        { name: "no-tabs", options: [] },
+        { name: "linebreak-style", options: ["unix"] },
+        { name: "no-multiple-empty-lines", options: [{ max: 1 }] },
+      ],
+    });
+
+    expect(diagnostics.map((diagnostic) => diagnostic.ruleName)).toEqual([
+      "unicode-bom",
+      "quotes",
+      "no-trailing-spaces",
+      "no-tabs",
+      "linebreak-style",
+      "no-multiple-empty-lines",
+    ]);
+    expect(diagnostics[1].suggestions?.[0]?.fixes[0]?.replacementText).toBe("'value'");
+  });
+
+  it("runs quotes through Oxlint RuleTester", () => {
+    new RuleTester().run("quotes", corsaStylisticRules.quotes as never, {
+      valid: [{ code: "const label = 'value';", options: ["single"] }],
+      invalid: [
+        {
+          code: 'const label = "value";',
+          options: ["single"],
+          errors: [{ messageId: "wrongQuote" }],
+        },
+      ],
+    });
+  });
+
+  it("shares configured stylistic settings across enabled rules", () => {
+    const tester = new RuleTester({
+      settings: {
+        corsaStylistic: {
+          rules: {
+            quotes: ["single"],
+            "no-trailing-spaces": [],
+          },
+        },
+      },
+    });
+
+    tester.run("no-trailing-spaces", corsaStylisticRules["no-trailing-spaces"] as never, {
+      valid: [{ code: "const label = 'value';\n" }],
+      invalid: [
+        {
+          code: "const label = 'value';  \n",
+          errors: [{ messageId: "trailingSpace" }],
+        },
+      ],
+    });
+  });
+});

--- a/src/bindings/nodejs/corsa_oxlint/ts/stylistic.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/stylistic.ts
@@ -1,0 +1,229 @@
+import {
+  nativeStylisticRuleMetas,
+  runNativeStylisticLint,
+  type NativeLintDiagnostic,
+  type NativeLintRange,
+  type NativeLintRuleMeta,
+  type NativeStylisticRuleConfig,
+} from "@corsa-bind/napi";
+
+import { definePlugin, defineRule } from "./plugin";
+import type { ContextWithParserOptions } from "./types";
+
+type ProgramNode = {
+  readonly type: string;
+  readonly range?: readonly [number, number];
+};
+
+export type CorsaStylisticRuleName =
+  | "eol-last"
+  | "linebreak-style"
+  | "no-multiple-empty-lines"
+  | "no-tabs"
+  | "no-trailing-spaces"
+  | "quotes"
+  | "unicode-bom";
+
+export type CorsaStylisticRuleOptions = readonly unknown[];
+
+export interface CorsaStylisticSettings {
+  /**
+   * Rule options used by the native batch runner.
+   *
+   * Keep this in sync with enabled Oxlint rules when several stylistic rules
+   * are active; the JS bridge can then perform one native scan and share the
+   * diagnostics across individual rule reports.
+   */
+  readonly rules?: Partial<Record<CorsaStylisticRuleName, CorsaStylisticRuleOptions>>;
+}
+
+const stylisticMetas = nativeStylisticRuleMetas();
+const stylisticMetasByName = new Map(stylisticMetas.map((meta) => [meta.name, meta]));
+const diagnosticsCache = new WeakMap<object, Map<string, readonly NativeLintDiagnostic[]>>();
+
+/**
+ * Native stylistic rule names exported by `corsa-oxlint/stylistic`.
+ */
+export const implementedStylisticRuleNames = [
+  "eol-last",
+  "linebreak-style",
+  "no-multiple-empty-lines",
+  "no-tabs",
+  "no-trailing-spaces",
+  "quotes",
+  "unicode-bom",
+] as const satisfies readonly CorsaStylisticRuleName[];
+
+/**
+ * Oxlint-compatible stylistic rules backed by the Rust source scanner.
+ */
+export const corsaStylisticRules = Object.freeze(
+  Object.fromEntries(
+    implementedStylisticRuleNames.map((ruleName) => [ruleName, createStylisticRule(ruleName)]),
+  ),
+) as Readonly<Record<CorsaStylisticRuleName, ReturnType<typeof createStylisticRule>>>;
+
+/**
+ * Oxlint plugin exposing Corsa's Rust-backed stylistic rules.
+ *
+ * Register it under any namespace, then enable rules such as
+ * `stylistic/quotes` or `stylistic/no-trailing-spaces`.
+ */
+export const corsaStylisticPlugin = definePlugin({
+  meta: { name: "oxlint-plugin-corsa-stylistic" },
+  rules: corsaStylisticRules,
+});
+
+function createStylisticRule(ruleName: CorsaStylisticRuleName) {
+  const meta = stylisticRuleMeta(ruleName);
+  return defineRule({
+    defaultOptions: [],
+    meta: {
+      type: "layout",
+      docs: {
+        description: meta.docsDescription,
+        requiresTypeChecking: false,
+        url: `https://github.com/ubugeeei/corsa-bind/tree/main/src/bindings/nodejs/corsa_oxlint/ts/stylistic.ts`,
+      },
+      fixable: "whitespace",
+      hasSuggestions: meta.hasSuggestions,
+      messages: meta.messages,
+      schema: { type: "array" },
+    },
+    create(context: ContextWithParserOptions) {
+      return {
+        Program(node: ProgramNode) {
+          reportStylisticDiagnostics(
+            context,
+            node,
+            diagnosticsForRule(context, ruleName).filter(
+              (diagnostic) => diagnostic.ruleName === ruleName,
+            ),
+          );
+        },
+      };
+    },
+  });
+}
+
+function diagnosticsForRule(
+  context: ContextWithParserOptions,
+  ruleName: CorsaStylisticRuleName,
+): readonly NativeLintDiagnostic[] {
+  const sourceCode = context.sourceCode as unknown as object;
+  const sourceText = sourceTextForContext(context);
+  const config = stylisticRunConfig(context, ruleName);
+  const key = JSON.stringify(config);
+  let sourceCache = diagnosticsCache.get(sourceCode);
+  if (!sourceCache) {
+    sourceCache = new Map();
+    diagnosticsCache.set(sourceCode, sourceCache);
+  }
+
+  const cached = sourceCache.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const diagnostics = runNativeStylisticLint(sourceText, { rules: config });
+  sourceCache.set(key, diagnostics);
+  return diagnostics;
+}
+
+function stylisticRunConfig(
+  context: ContextWithParserOptions,
+  currentRuleName: CorsaStylisticRuleName,
+): readonly NativeStylisticRuleConfig[] {
+  const settingsRules = context.settings?.corsaStylistic?.rules;
+  const rules = new Map<CorsaStylisticRuleName, CorsaStylisticRuleOptions>();
+
+  if (settingsRules) {
+    for (const [name, options] of Object.entries(settingsRules)) {
+      assertKnownStylisticRuleName(name);
+      rules.set(name, normalizeOptions(options));
+    }
+  }
+
+  const currentOptions = currentRuleOptions(context);
+  if (!rules.has(currentRuleName) || currentOptions.length > 0) {
+    rules.set(currentRuleName, currentOptions);
+  }
+
+  return implementedStylisticRuleNames
+    .filter((ruleName) => rules.has(ruleName))
+    .map((ruleName) => ({
+      name: ruleName,
+      options: rules.get(ruleName) ?? [],
+    }));
+}
+
+function reportStylisticDiagnostics(
+  context: ContextWithParserOptions,
+  program: ProgramNode,
+  diagnostics: readonly NativeLintDiagnostic[],
+): void {
+  for (const diagnostic of diagnostics) {
+    context.report({
+      node: rangeNode(program, diagnostic.range),
+      messageId: diagnostic.messageId,
+      ...(diagnostic.suggestions?.length
+        ? {
+            suggest: diagnostic.suggestions.map((suggestion) => ({
+              messageId: suggestion.messageId,
+              fix: (fixer: any) =>
+                suggestion.fixes.map((fix) =>
+                  fixer.replaceTextRange(oxlintRange(fix.range), fix.replacementText),
+                ),
+            })),
+          }
+        : {}),
+    } as never);
+  }
+}
+
+function rangeNode(program: ProgramNode, range: NativeLintRange): ProgramNode {
+  return {
+    ...program,
+    range: oxlintRange(range),
+  };
+}
+
+function oxlintRange(range: NativeLintRange): [number, number] {
+  return [range.start, range.end];
+}
+
+function sourceTextForContext(context: ContextWithParserOptions): string {
+  const text = (context.sourceCode as { text?: unknown }).text;
+  if (typeof text === "string") {
+    return text;
+  }
+  return context.sourceCode.getText({ type: "Program" } as never);
+}
+
+function currentRuleOptions(context: ContextWithParserOptions): CorsaStylisticRuleOptions {
+  return normalizeOptions((context as { options?: unknown }).options);
+}
+
+function normalizeOptions(options: unknown): CorsaStylisticRuleOptions {
+  if (Array.isArray(options)) {
+    return options;
+  }
+  if (options == null) {
+    return [];
+  }
+  return [options];
+}
+
+function assertKnownStylisticRuleName(name: string): asserts name is CorsaStylisticRuleName {
+  if (!(implementedStylisticRuleNames as readonly string[]).includes(name)) {
+    throw new Error(`unknown corsa stylistic rule: ${name}`);
+  }
+}
+
+function stylisticRuleMeta(ruleName: CorsaStylisticRuleName): NativeLintRuleMeta {
+  const meta = stylisticMetasByName.get(ruleName);
+  if (!meta) {
+    throw new Error(`corsa stylistic native Rust rule is not registered: ${ruleName}`);
+  }
+  return meta;
+}

--- a/src/bindings/nodejs/corsa_oxlint/ts/types.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/types.ts
@@ -28,6 +28,10 @@ export interface CorsaOxlintSettings extends TypeAwareParserOptions {
   parserOptions?: TypeAwareParserOptions;
 }
 
+export interface CorsaStylisticSettings {
+  rules?: Record<string, readonly unknown[]>;
+}
+
 export interface ResolvedRuntimeOptions {
   executable: string;
   cwd: string;
@@ -156,6 +160,7 @@ export type ContextWithParserOptions = Context & {
   };
   readonly settings?: {
     readonly corsaOxlint?: CorsaOxlintSettings;
+    readonly corsaStylistic?: CorsaStylisticSettings;
     readonly [key: string]: unknown;
   };
   readonly parserServices?: ParserServices;

--- a/src/core/corsa_core/src/lint/mod.rs
+++ b/src/core/corsa_core/src/lint/mod.rs
@@ -4,6 +4,7 @@ mod context;
 mod helpers;
 mod registry;
 mod rules;
+mod stylistic;
 #[cfg(test)]
 mod tests;
 mod types;
@@ -30,6 +31,9 @@ pub use rules::{
     RestrictTemplateExpressionsRule, ReturnAwaitRule, StrictBooleanExpressionsRule,
     StrictVoidReturnRule, SwitchExhaustivenessCheckRule, UnboundMethodRule,
     UseUnknownInCatchCallbackVariableRule,
+};
+pub use stylistic::{
+    StylisticRuleConfig, StylisticRunConfig, run_stylistic_lint, stylistic_rule_metas,
 };
 pub use types::{
     LintDiagnostic, LintFix, LintNode, LintSuggestion, RuleMessage, RuleMeta, TextRange,

--- a/src/core/corsa_core/src/lint/stylistic/helpers.rs
+++ b/src/core/corsa_core/src/lint/stylistic/helpers.rs
@@ -1,0 +1,106 @@
+use serde_json::Value;
+
+use crate::lint::{LintDiagnostic, LintFix, LintSuggestion, TextRange};
+
+pub(crate) fn option_str(options: &Value, index: usize) -> Option<&str> {
+    option_at(options, index).and_then(Value::as_str)
+}
+
+pub(crate) fn option_bool(options: &Value, index: usize, key: &str, default: bool) -> bool {
+    option_at(options, index)
+        .and_then(|value| value.get(key))
+        .and_then(Value::as_bool)
+        .unwrap_or(default)
+}
+
+pub(crate) fn option_usize(options: &Value, index: usize, key: &str, default: usize) -> usize {
+    option_at(options, index)
+        .and_then(|value| value.get(key))
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .unwrap_or(default)
+}
+
+fn option_at(options: &Value, index: usize) -> Option<&Value> {
+    match options {
+        Value::Array(items) => items.get(index),
+        Value::Null => None,
+        _ if index == 0 => Some(options),
+        _ => None,
+    }
+}
+
+pub(crate) fn push_replacement_diagnostic(
+    diagnostics: &mut Vec<LintDiagnostic>,
+    rule_name: &'static str,
+    message_id: &'static str,
+    message: &'static str,
+    start: usize,
+    end: usize,
+    suggestion_id: &'static str,
+    suggestion_message: &'static str,
+    replacement: impl Into<String>,
+) {
+    let replacement = replacement.into();
+    push_diagnostic(
+        diagnostics,
+        rule_name,
+        message_id,
+        message,
+        start,
+        end,
+        Some((suggestion_id, suggestion_message, move |range| {
+            LintFix::replace_range(range, replacement.clone())
+        })),
+    );
+}
+
+pub(crate) fn push_diagnostic<F>(
+    diagnostics: &mut Vec<LintDiagnostic>,
+    rule_name: &'static str,
+    message_id: &'static str,
+    message: &'static str,
+    start: usize,
+    end: usize,
+    suggestion: Option<(&'static str, &'static str, F)>,
+) where
+    F: Fn(TextRange) -> LintFix,
+{
+    let Some(range) = text_range(start, end) else {
+        return;
+    };
+    let suggestions = suggestion
+        .map(|(suggestion_id, suggestion_message, fix)| LintSuggestion {
+            message_id: suggestion_id.to_owned(),
+            message: suggestion_message.to_owned(),
+            fixes: vec![fix(range)],
+        })
+        .into_iter()
+        .collect();
+    diagnostics.push(LintDiagnostic {
+        rule_name: rule_name.to_owned(),
+        message_id: message_id.to_owned(),
+        message: message.to_owned(),
+        range,
+        suggestions,
+    });
+}
+
+fn text_range(start: usize, end: usize) -> Option<TextRange> {
+    Some(TextRange::new(
+        u32::try_from(start).ok()?,
+        u32::try_from(end).ok()?,
+    ))
+}
+
+pub(crate) fn is_space(byte: u8) -> bool {
+    matches!(byte, b' ' | b'\t' | 0x0b | 0x0c)
+}
+
+pub(crate) fn is_identifier_start(byte: u8) -> bool {
+    byte == b'_' || byte == b'$' || byte.is_ascii_alphabetic()
+}
+
+pub(crate) fn is_identifier_continue(byte: u8) -> bool {
+    is_identifier_start(byte) || byte.is_ascii_digit()
+}

--- a/src/core/corsa_core/src/lint/stylistic/line_index.rs
+++ b/src/core/corsa_core/src/lint/stylistic/line_index.rs
@@ -1,0 +1,106 @@
+use super::helpers::is_space;
+
+#[derive(Clone, Copy)]
+pub(crate) struct LineInfo {
+    pub(crate) start: usize,
+    pub(crate) content_end: usize,
+    pub(crate) end: usize,
+    pub(crate) newline_start: usize,
+    pub(crate) newline_len: usize,
+    pub(crate) newline: Newline,
+    pub(crate) is_blank: bool,
+    pub(crate) is_comment_only: bool,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) enum Newline {
+    None,
+    Lf,
+    Crlf,
+    Cr,
+}
+
+pub(crate) fn collect_lines(source_text: &str) -> Vec<LineInfo> {
+    let bytes = source_text.as_bytes();
+    let mut lines = Vec::new();
+    let mut start = 0;
+    let mut in_block_comment = false;
+
+    while start < bytes.len() {
+        let mut cursor = start;
+        while cursor < bytes.len() && bytes[cursor] != b'\n' && bytes[cursor] != b'\r' {
+            cursor += 1;
+        }
+
+        let newline_start = cursor;
+        let (newline, newline_len) = newline_at(bytes, cursor);
+        let end = newline_start + newline_len;
+        let is_blank = bytes[start..newline_start]
+            .iter()
+            .all(|byte| is_space(*byte));
+        let is_comment_only =
+            classify_comment_line(&bytes[start..newline_start], &mut in_block_comment);
+
+        lines.push(LineInfo {
+            start,
+            content_end: newline_start,
+            end,
+            newline_start,
+            newline_len,
+            newline,
+            is_blank,
+            is_comment_only,
+        });
+        start = end;
+    }
+
+    lines
+}
+
+fn newline_at(bytes: &[u8], cursor: usize) -> (Newline, usize) {
+    if cursor >= bytes.len() {
+        (Newline::None, 0)
+    } else if bytes[cursor] == b'\r' && bytes.get(cursor + 1) == Some(&b'\n') {
+        (Newline::Crlf, 2)
+    } else if bytes[cursor] == b'\r' {
+        (Newline::Cr, 1)
+    } else {
+        (Newline::Lf, 1)
+    }
+}
+
+fn classify_comment_line(line: &[u8], in_block_comment: &mut bool) -> bool {
+    let trimmed_start = line
+        .iter()
+        .position(|byte| !is_space(*byte))
+        .unwrap_or(line.len());
+    let starts_inside_block = *in_block_comment;
+    let starts_with_line_comment = line
+        .get(trimmed_start..)
+        .is_some_and(|value| value.starts_with(b"//"));
+    let starts_with_block_comment = line
+        .get(trimmed_start..)
+        .is_some_and(|value| value.starts_with(b"/*"));
+
+    update_block_comment_state(line, in_block_comment);
+
+    starts_inside_block || starts_with_line_comment || starts_with_block_comment
+}
+
+fn update_block_comment_state(line: &[u8], in_block_comment: &mut bool) {
+    let mut cursor = 0;
+    while cursor + 1 < line.len() {
+        if *in_block_comment {
+            if line[cursor] == b'*' && line[cursor + 1] == b'/' {
+                *in_block_comment = false;
+                cursor += 2;
+                continue;
+            }
+        } else if line[cursor] == b'/' && line[cursor + 1] == b'*' {
+            *in_block_comment = true;
+            cursor += 2;
+            continue;
+        }
+        cursor += 1;
+    }
+}

--- a/src/core/corsa_core/src/lint/stylistic/line_rules.rs
+++ b/src/core/corsa_core/src/lint/stylistic/line_rules.rs
@@ -1,0 +1,228 @@
+use serde_json::Value;
+
+use crate::lint::{LintDiagnostic, LintFix};
+
+use super::{
+    helpers::{
+        option_bool, option_str, option_usize, push_diagnostic, push_replacement_diagnostic,
+    },
+    line_index::{LineInfo, Newline},
+};
+
+pub(crate) fn check_no_trailing_spaces(
+    source_text: &str,
+    lines: &[LineInfo],
+    options: &Value,
+    diagnostics: &mut Vec<LintDiagnostic>,
+) {
+    let skip_blank_lines = option_bool(options, 0, "skipBlankLines", false);
+    let ignore_comments = option_bool(options, 0, "ignoreComments", false);
+
+    for line in lines {
+        if (skip_blank_lines && line.is_blank) || (ignore_comments && line.is_comment_only) {
+            continue;
+        }
+        let trailing_start =
+            trim_ascii_space_end(source_text.as_bytes(), line.start, line.content_end);
+        if trailing_start < line.content_end {
+            push_diagnostic(
+                diagnostics,
+                "no-trailing-spaces",
+                "trailingSpace",
+                "Trailing spaces are not allowed.",
+                trailing_start,
+                line.content_end,
+                Some((
+                    "removeTrailingSpace",
+                    "Remove trailing spaces.",
+                    LintFix::remove_range,
+                )),
+            );
+        }
+    }
+}
+
+pub(crate) fn check_eol_last(
+    source_text: &str,
+    options: &Value,
+    diagnostics: &mut Vec<LintDiagnostic>,
+) {
+    if source_text.is_empty() {
+        return;
+    }
+
+    match option_str(options, 0).unwrap_or("always") {
+        "never" => check_no_eol_last(source_text, diagnostics),
+        _ if !source_text.ends_with('\n') && !source_text.ends_with('\r') => {
+            push_replacement_diagnostic(
+                diagnostics,
+                "eol-last",
+                "missing",
+                "Expected newline at end of file.",
+                source_text.len(),
+                source_text.len(),
+                "insertNewline",
+                "Insert a newline.",
+                "\n",
+            );
+        }
+        _ => {}
+    }
+}
+
+pub(crate) fn check_linebreak_style(
+    lines: &[LineInfo],
+    options: &Value,
+    diagnostics: &mut Vec<LintDiagnostic>,
+) {
+    let expected = option_str(options, 0).unwrap_or("unix");
+    for line in lines {
+        if line.newline == Newline::None {
+            continue;
+        }
+        match expected {
+            "windows" if line.newline != Newline::Crlf => report_linebreak(
+                diagnostics,
+                line,
+                "expectedWindows",
+                "Expected Windows linebreaks.",
+                "\r\n",
+            ),
+            _ if expected != "windows" && line.newline != Newline::Lf => report_linebreak(
+                diagnostics,
+                line,
+                "expectedUnix",
+                "Expected Unix linebreaks.",
+                "\n",
+            ),
+            _ => {}
+        }
+    }
+}
+
+pub(crate) fn check_no_multiple_empty_lines(
+    lines: &[LineInfo],
+    options: &Value,
+    diagnostics: &mut Vec<LintDiagnostic>,
+) {
+    let max = option_usize(options, 0, "max", 2);
+    let max_bof = option_usize(options, 0, "maxBOF", max);
+    let max_eof = option_usize(options, 0, "maxEOF", max);
+    let Some(first_non_blank) = lines.iter().position(|line| !line.is_blank) else {
+        report_extra_blank_lines(lines, max_bof.min(max_eof), diagnostics);
+        return;
+    };
+    let last_non_blank = lines
+        .iter()
+        .rposition(|line| !line.is_blank)
+        .unwrap_or(first_non_blank);
+
+    report_extra_blank_lines(&lines[..first_non_blank], max_bof, diagnostics);
+    report_extra_blank_lines(&lines[last_non_blank + 1..], max_eof, diagnostics);
+    report_middle_blank_runs(lines, first_non_blank, last_non_blank, max, diagnostics);
+}
+
+fn check_no_eol_last(source_text: &str, diagnostics: &mut Vec<LintDiagnostic>) {
+    let trim_start = source_text
+        .as_bytes()
+        .iter()
+        .rposition(|byte| *byte != b'\n' && *byte != b'\r')
+        .map_or(0, |index| index + 1);
+    if trim_start < source_text.len() {
+        push_diagnostic(
+            diagnostics,
+            "eol-last",
+            "unexpected",
+            "Unexpected newline at end of file.",
+            trim_start,
+            source_text.len(),
+            Some((
+                "removeNewline",
+                "Remove trailing newlines.",
+                LintFix::remove_range,
+            )),
+        );
+    }
+}
+
+fn report_linebreak(
+    diagnostics: &mut Vec<LintDiagnostic>,
+    line: &LineInfo,
+    message_id: &'static str,
+    message: &'static str,
+    replacement: &'static str,
+) {
+    push_replacement_diagnostic(
+        diagnostics,
+        "linebreak-style",
+        message_id,
+        message,
+        line.newline_start,
+        line.newline_start + line.newline_len,
+        "fixLinebreak",
+        "Replace linebreak.",
+        replacement,
+    );
+}
+
+fn report_middle_blank_runs(
+    lines: &[LineInfo],
+    first_non_blank: usize,
+    last_non_blank: usize,
+    max: usize,
+    diagnostics: &mut Vec<LintDiagnostic>,
+) {
+    let mut run_start = None;
+    for (index, line) in lines
+        .iter()
+        .enumerate()
+        .take(last_non_blank)
+        .skip(first_non_blank + 1)
+    {
+        if line.is_blank {
+            run_start.get_or_insert(index);
+        } else if let Some(start) = run_start.take() {
+            report_extra_blank_lines(&lines[start..index], max, diagnostics);
+        }
+    }
+    if let Some(start) = run_start {
+        report_extra_blank_lines(&lines[start..last_non_blank], max, diagnostics);
+    }
+}
+
+fn report_extra_blank_lines(
+    blank_lines: &[LineInfo],
+    allowed: usize,
+    diagnostics: &mut Vec<LintDiagnostic>,
+) {
+    if blank_lines.len() <= allowed {
+        return;
+    }
+    for line in &blank_lines[allowed..] {
+        push_diagnostic(
+            diagnostics,
+            "no-multiple-empty-lines",
+            "tooMany",
+            "Too many blank lines.",
+            line.start,
+            line.end,
+            Some((
+                "removeBlankLine",
+                "Remove extra blank line.",
+                LintFix::remove_range,
+            )),
+        );
+    }
+}
+
+fn trim_ascii_space_end(bytes: &[u8], start: usize, end: usize) -> usize {
+    let mut cursor = end;
+    while cursor > start {
+        let byte = bytes[cursor - 1];
+        if byte != b' ' && byte != b'\t' {
+            return cursor;
+        }
+        cursor -= 1;
+    }
+    start
+}

--- a/src/core/corsa_core/src/lint/stylistic/mod.rs
+++ b/src/core/corsa_core/src/lint/stylistic/mod.rs
@@ -1,0 +1,194 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::{LintDiagnostic, RuleMeta};
+
+mod helpers;
+mod line_index;
+mod line_rules;
+mod quote_convert;
+mod quotes;
+mod tabs;
+mod unicode_bom;
+
+const PROGRAM_LISTENER: &[&str] = &["Program"];
+
+const NO_TRAILING_SPACES_MESSAGES: &[(&str, &str)] = &[
+    ("trailingSpace", "Trailing spaces are not allowed."),
+    ("removeTrailingSpace", "Remove trailing spaces."),
+];
+const EOL_LAST_MESSAGES: &[(&str, &str)] = &[
+    ("missing", "Expected newline at end of file."),
+    ("unexpected", "Unexpected newline at end of file."),
+    ("insertNewline", "Insert a newline."),
+    ("removeNewline", "Remove trailing newlines."),
+];
+const LINEBREAK_STYLE_MESSAGES: &[(&str, &str)] = &[
+    ("expectedUnix", "Expected Unix linebreaks."),
+    ("expectedWindows", "Expected Windows linebreaks."),
+    ("fixLinebreak", "Replace linebreak."),
+];
+const NO_MULTIPLE_EMPTY_LINES_MESSAGES: &[(&str, &str)] = &[
+    ("tooMany", "Too many blank lines."),
+    ("removeBlankLine", "Remove extra blank line."),
+];
+const NO_TABS_MESSAGES: &[(&str, &str)] = &[
+    ("unexpectedTab", "Unexpected tab character."),
+    ("replaceTab", "Replace tab with a space."),
+];
+const QUOTES_MESSAGES: &[(&str, &str)] = &[
+    (
+        "wrongQuote",
+        "String literals must use the configured quote style.",
+    ),
+    ("fixQuote", "Convert quote style."),
+];
+const UNICODE_BOM_MESSAGES: &[(&str, &str)] = &[
+    ("expected", "Expected Unicode byte order mark."),
+    ("unexpected", "Unexpected Unicode byte order mark."),
+    ("insertBom", "Insert Unicode byte order mark."),
+    ("removeBom", "Remove Unicode byte order mark."),
+];
+
+/// One stylistic rule invocation requested by the JavaScript bridge.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StylisticRuleConfig {
+    /// Stable stylistic rule name, for example `quotes`.
+    pub name: String,
+    /// Rule options in Oxlint/ESLint shape, without severity.
+    #[serde(default)]
+    pub options: Value,
+}
+
+/// Source-wide stylistic lint configuration.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StylisticRunConfig {
+    /// Rules to run in one native pass.
+    #[serde(default)]
+    pub rules: Vec<StylisticRuleConfig>,
+}
+
+#[derive(Clone, Copy)]
+struct StylisticRuleDefinition {
+    name: &'static str,
+    docs_description: &'static str,
+    messages: &'static [(&'static str, &'static str)],
+}
+
+const STYLISTIC_RULES: &[StylisticRuleDefinition] = &[
+    StylisticRuleDefinition {
+        name: "eol-last",
+        docs_description: "Require or disallow a newline at the end of files.",
+        messages: EOL_LAST_MESSAGES,
+    },
+    StylisticRuleDefinition {
+        name: "linebreak-style",
+        docs_description: "Enforce consistent linebreak characters.",
+        messages: LINEBREAK_STYLE_MESSAGES,
+    },
+    StylisticRuleDefinition {
+        name: "no-multiple-empty-lines",
+        docs_description: "Limit consecutive blank lines.",
+        messages: NO_MULTIPLE_EMPTY_LINES_MESSAGES,
+    },
+    StylisticRuleDefinition {
+        name: "no-tabs",
+        docs_description: "Disallow tab characters.",
+        messages: NO_TABS_MESSAGES,
+    },
+    StylisticRuleDefinition {
+        name: "no-trailing-spaces",
+        docs_description: "Disallow whitespace at the end of lines.",
+        messages: NO_TRAILING_SPACES_MESSAGES,
+    },
+    StylisticRuleDefinition {
+        name: "quotes",
+        docs_description: "Enforce single or double quotes for string literals.",
+        messages: QUOTES_MESSAGES,
+    },
+    StylisticRuleDefinition {
+        name: "unicode-bom",
+        docs_description: "Require or disallow Unicode byte order marks.",
+        messages: UNICODE_BOM_MESSAGES,
+    },
+];
+
+/// Returns metadata for every Rust-backed stylistic rule.
+pub fn stylistic_rule_metas() -> Vec<RuleMeta> {
+    STYLISTIC_RULES
+        .iter()
+        .map(|definition| RuleMeta {
+            name: definition.name.to_owned(),
+            docs_description: definition.docs_description.to_owned(),
+            messages: definition
+                .messages
+                .iter()
+                .map(|(id, description)| ((*id).to_owned(), (*description).to_owned()))
+                .collect::<BTreeMap<_, _>>(),
+            has_suggestions: true,
+            listeners: PROGRAM_LISTENER
+                .iter()
+                .map(|listener| (*listener).to_owned())
+                .collect(),
+            requires_type_texts: false,
+        })
+        .collect()
+}
+
+/// Runs native stylistic rules against a full source text.
+///
+/// The implementation intentionally works on bytes and does a small number of
+/// linear scans. The JavaScript plugin batches rule configs into this function
+/// so multiple style rules share the same N-API call and line index.
+pub fn run_stylistic_lint(
+    source_text: &str,
+    config: &StylisticRunConfig,
+) -> Result<Vec<LintDiagnostic>, String> {
+    let needs_lines = config.rules.iter().any(|rule| {
+        matches!(
+            rule.name.as_str(),
+            "linebreak-style" | "no-multiple-empty-lines" | "no-tabs" | "no-trailing-spaces"
+        )
+    });
+    let lines = needs_lines.then(|| line_index::collect_lines(source_text));
+    let mut diagnostics = Vec::new();
+
+    for rule in &config.rules {
+        match rule.name.as_str() {
+            "eol-last" => line_rules::check_eol_last(source_text, &rule.options, &mut diagnostics),
+            "linebreak-style" => line_rules::check_linebreak_style(
+                lines.as_deref().unwrap_or(&[]),
+                &rule.options,
+                &mut diagnostics,
+            ),
+            "no-multiple-empty-lines" => line_rules::check_no_multiple_empty_lines(
+                lines.as_deref().unwrap_or(&[]),
+                &rule.options,
+                &mut diagnostics,
+            ),
+            "no-trailing-spaces" => line_rules::check_no_trailing_spaces(
+                source_text,
+                lines.as_deref().unwrap_or(&[]),
+                &rule.options,
+                &mut diagnostics,
+            ),
+            "no-tabs" => tabs::check_no_tabs(
+                source_text,
+                lines.as_deref().unwrap_or(&[]),
+                &rule.options,
+                &mut diagnostics,
+            ),
+            "quotes" => quotes::check_quotes(source_text, &rule.options, &mut diagnostics),
+            "unicode-bom" => {
+                unicode_bom::check_unicode_bom(source_text, &rule.options, &mut diagnostics)
+            }
+            unknown => return Err(format!("unknown native stylistic rule: {unknown}")),
+        }
+    }
+
+    Ok(diagnostics)
+}

--- a/src/core/corsa_core/src/lint/stylistic/quote_convert.rs
+++ b/src/core/corsa_core/src/lint/stylistic/quote_convert.rs
@@ -1,0 +1,51 @@
+pub(crate) fn contains_unescaped_quote(content: &str, quote: u8) -> bool {
+    let mut escaped = false;
+    for byte in content.bytes() {
+        if escaped {
+            escaped = false;
+        } else if byte == b'\\' {
+            escaped = true;
+        } else if byte == quote {
+            return true;
+        }
+    }
+    false
+}
+
+pub(crate) fn convert_quote_literal(literal: &str, current: u8, preferred: u8) -> Option<String> {
+    let content = literal.get(1..literal.len().saturating_sub(1))?;
+    let mut output = String::with_capacity(literal.len() + 4);
+    output.push(preferred as char);
+
+    let mut cursor = 0;
+    while cursor < content.len() {
+        let tail = &content[cursor..];
+        let mut chars = tail.chars();
+        let ch = chars.next()?;
+        if ch == '\n' || ch == '\r' {
+            return None;
+        }
+        if ch == '\\' {
+            let Some(next) = chars.next() else {
+                output.push(ch);
+                break;
+            };
+            if next as u32 == current as u32 {
+                output.push(next);
+            } else {
+                output.push('\\');
+                output.push(next);
+            }
+            cursor += ch.len_utf8() + next.len_utf8();
+            continue;
+        }
+        if ch as u32 == preferred as u32 {
+            output.push('\\');
+        }
+        output.push(ch);
+        cursor += ch.len_utf8();
+    }
+
+    output.push(preferred as char);
+    Some(output)
+}

--- a/src/core/corsa_core/src/lint/stylistic/quotes.rs
+++ b/src/core/corsa_core/src/lint/stylistic/quotes.rs
@@ -1,0 +1,242 @@
+use serde_json::Value;
+
+use crate::lint::LintDiagnostic;
+
+use super::helpers::{
+    is_identifier_continue, is_identifier_start, option_bool, option_str,
+    push_replacement_diagnostic,
+};
+use super::quote_convert::{contains_unescaped_quote, convert_quote_literal};
+
+pub(crate) fn check_quotes(
+    source_text: &str,
+    options: &Value,
+    diagnostics: &mut Vec<LintDiagnostic>,
+) {
+    let preferred = match option_str(options, 0).unwrap_or("double") {
+        "single" => b'\'',
+        _ => b'"',
+    };
+    let avoid_escape = option_bool(options, 1, "avoidEscape", false);
+    let bytes = source_text.as_bytes();
+    let mut cursor = 0;
+    let mut previous_significant = None;
+
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'\'' | b'"' => {
+                let quote = bytes[cursor];
+                let start = cursor;
+                let Some(end) = scan_string_literal(bytes, cursor, quote) else {
+                    cursor += 1;
+                    continue;
+                };
+                cursor = end;
+                previous_significant = Some(b'S');
+                report_quote_if_needed(
+                    source_text,
+                    start,
+                    end,
+                    quote,
+                    preferred,
+                    avoid_escape,
+                    diagnostics,
+                );
+            }
+            b'`' => {
+                cursor = scan_template_literal(bytes, cursor).unwrap_or(cursor + 1);
+                previous_significant = Some(b'T');
+            }
+            b'/' if bytes.get(cursor + 1) == Some(&b'/') => {
+                cursor = skip_line_comment(bytes, cursor + 2);
+            }
+            b'/' if bytes.get(cursor + 1) == Some(&b'*') => {
+                cursor = skip_block_comment(bytes, cursor + 2);
+            }
+            b'/' if looks_like_regex_start(previous_significant) => {
+                cursor = skip_regex_literal(bytes, cursor + 1);
+                previous_significant = Some(b'R');
+            }
+            byte if is_identifier_start(byte) => {
+                let start = cursor;
+                cursor += 1;
+                while cursor < bytes.len() && is_identifier_continue(bytes[cursor]) {
+                    cursor += 1;
+                }
+                previous_significant =
+                    Some(if is_regex_prefix_keyword(&source_text[start..cursor]) {
+                        b'K'
+                    } else {
+                        b'I'
+                    });
+            }
+            byte if byte.is_ascii_whitespace() => {
+                cursor += 1;
+            }
+            byte => {
+                previous_significant = Some(byte);
+                cursor += 1;
+            }
+        }
+    }
+}
+
+fn report_quote_if_needed(
+    source_text: &str,
+    start: usize,
+    end: usize,
+    quote: u8,
+    preferred: u8,
+    avoid_escape: bool,
+    diagnostics: &mut Vec<LintDiagnostic>,
+) {
+    if quote == preferred {
+        return;
+    }
+    if avoid_escape && contains_unescaped_quote(&source_text[start + 1..end - 1], preferred) {
+        return;
+    }
+    if let Some(replacement) = convert_quote_literal(&source_text[start..end], quote, preferred) {
+        push_replacement_diagnostic(
+            diagnostics,
+            "quotes",
+            "wrongQuote",
+            "String literals must use the configured quote style.",
+            start,
+            end,
+            "fixQuote",
+            "Convert quote style.",
+            replacement,
+        );
+    }
+}
+
+fn scan_string_literal(bytes: &[u8], start: usize, quote: u8) -> Option<usize> {
+    let mut cursor = start + 1;
+    let mut escaped = false;
+    while cursor < bytes.len() {
+        let byte = bytes[cursor];
+        if escaped {
+            escaped = false;
+        } else if byte == b'\\' {
+            escaped = true;
+        } else if byte == quote {
+            return Some(cursor + 1);
+        } else if byte == b'\n' || byte == b'\r' {
+            return None;
+        }
+        cursor += 1;
+    }
+    None
+}
+
+fn scan_template_literal(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut cursor = start + 1;
+    let mut escaped = false;
+    while cursor < bytes.len() {
+        let byte = bytes[cursor];
+        if escaped {
+            escaped = false;
+        } else if byte == b'\\' {
+            escaped = true;
+        } else if byte == b'`' {
+            return Some(cursor + 1);
+        }
+        cursor += 1;
+    }
+    None
+}
+
+fn skip_line_comment(bytes: &[u8], start: usize) -> usize {
+    let mut cursor = start;
+    while cursor < bytes.len() && bytes[cursor] != b'\n' && bytes[cursor] != b'\r' {
+        cursor += 1;
+    }
+    cursor
+}
+
+fn skip_block_comment(bytes: &[u8], start: usize) -> usize {
+    let mut cursor = start;
+    while cursor + 1 < bytes.len() {
+        if bytes[cursor] == b'*' && bytes[cursor + 1] == b'/' {
+            return cursor + 2;
+        }
+        cursor += 1;
+    }
+    bytes.len()
+}
+
+fn skip_regex_literal(bytes: &[u8], start: usize) -> usize {
+    let mut cursor = start;
+    let mut escaped = false;
+    let mut in_class = false;
+    while cursor < bytes.len() {
+        let byte = bytes[cursor];
+        if escaped {
+            escaped = false;
+        } else if byte == b'\\' {
+            escaped = true;
+        } else if byte == b'[' {
+            in_class = true;
+        } else if byte == b']' {
+            in_class = false;
+        } else if byte == b'/' && !in_class {
+            return skip_regex_flags(bytes, cursor + 1);
+        } else if byte == b'\n' || byte == b'\r' {
+            return cursor;
+        }
+        cursor += 1;
+    }
+    cursor
+}
+
+fn skip_regex_flags(bytes: &[u8], mut cursor: usize) -> usize {
+    while cursor < bytes.len() && is_identifier_continue(bytes[cursor]) {
+        cursor += 1;
+    }
+    cursor
+}
+
+fn looks_like_regex_start(previous_significant: Option<u8>) -> bool {
+    previous_significant.is_none_or(|byte| {
+        matches!(
+            byte,
+            b'(' | b'['
+                | b'{'
+                | b':'
+                | b';'
+                | b','
+                | b'='
+                | b'!'
+                | b'?'
+                | b'&'
+                | b'|'
+                | b'+'
+                | b'-'
+                | b'*'
+                | b'%'
+                | b'^'
+                | b'~'
+                | b'<'
+                | b'>'
+                | b'K'
+        )
+    })
+}
+
+fn is_regex_prefix_keyword(word: &str) -> bool {
+    matches!(
+        word,
+        "return"
+            | "throw"
+            | "case"
+            | "delete"
+            | "void"
+            | "typeof"
+            | "instanceof"
+            | "in"
+            | "of"
+            | "yield"
+            | "await"
+    )
+}

--- a/src/core/corsa_core/src/lint/stylistic/tabs.rs
+++ b/src/core/corsa_core/src/lint/stylistic/tabs.rs
@@ -1,0 +1,48 @@
+use serde_json::Value;
+
+use crate::lint::{LintDiagnostic, LintFix};
+
+use super::{
+    helpers::{option_bool, push_diagnostic},
+    line_index::LineInfo,
+};
+
+pub(crate) fn check_no_tabs(
+    source_text: &str,
+    lines: &[LineInfo],
+    options: &Value,
+    diagnostics: &mut Vec<LintDiagnostic>,
+) {
+    let allow_indentation_tabs = option_bool(options, 0, "allowIndentationTabs", false);
+    let bytes = source_text.as_bytes();
+
+    for line in lines {
+        let mut cursor = line.start;
+        let mut indentation = true;
+        while cursor < line.content_end {
+            let byte = bytes[cursor];
+            if byte == b'\t' {
+                if !allow_indentation_tabs || !indentation {
+                    report_tab(cursor, diagnostics);
+                }
+            } else if byte != b' ' {
+                indentation = false;
+            }
+            cursor += 1;
+        }
+    }
+}
+
+fn report_tab(offset: usize, diagnostics: &mut Vec<LintDiagnostic>) {
+    push_diagnostic(
+        diagnostics,
+        "no-tabs",
+        "unexpectedTab",
+        "Unexpected tab character.",
+        offset,
+        offset + 1,
+        Some(("replaceTab", "Replace tab with a space.", |range| {
+            LintFix::replace_range(range, " ")
+        })),
+    );
+}

--- a/src/core/corsa_core/src/lint/stylistic/unicode_bom.rs
+++ b/src/core/corsa_core/src/lint/stylistic/unicode_bom.rs
@@ -1,0 +1,44 @@
+use serde_json::Value;
+
+use crate::lint::{LintDiagnostic, LintFix};
+
+use super::helpers::{option_str, push_diagnostic, push_replacement_diagnostic};
+
+const BOM: &str = "\u{feff}";
+
+pub(crate) fn check_unicode_bom(
+    source_text: &str,
+    options: &Value,
+    diagnostics: &mut Vec<LintDiagnostic>,
+) {
+    let requires_bom = option_str(options, 0).unwrap_or("never") == "always";
+    let has_bom = source_text.starts_with(BOM);
+
+    match (requires_bom, has_bom) {
+        (true, false) => push_replacement_diagnostic(
+            diagnostics,
+            "unicode-bom",
+            "expected",
+            "Expected Unicode byte order mark.",
+            0,
+            0,
+            "insertBom",
+            "Insert Unicode byte order mark.",
+            BOM,
+        ),
+        (false, true) => push_diagnostic(
+            diagnostics,
+            "unicode-bom",
+            "unexpected",
+            "Unexpected Unicode byte order mark.",
+            0,
+            BOM.len(),
+            Some((
+                "removeBom",
+                "Remove Unicode byte order mark.",
+                LintFix::remove_range,
+            )),
+        ),
+        _ => {}
+    }
+}

--- a/src/core/corsa_core/src/lint/tests.rs
+++ b/src/core/corsa_core/src/lint/tests.rs
@@ -2,7 +2,130 @@ use std::collections::BTreeMap;
 
 use serde_json::json;
 
-use super::{LintNode, LintRuleRegistry, TextRange};
+use super::{
+    LintNode, LintRuleRegistry, StylisticRuleConfig, StylisticRunConfig, TextRange,
+    run_stylistic_lint,
+};
+
+#[test]
+fn stylistic_rules_run_in_one_source_pass() {
+    let diagnostics = run_stylistic_lint(
+        "const\tlabel = \"value\";  \r\n\n\n",
+        &StylisticRunConfig {
+            rules: vec![
+                StylisticRuleConfig {
+                    name: "quotes".to_owned(),
+                    options: json!(["single"]),
+                },
+                StylisticRuleConfig {
+                    name: "no-trailing-spaces".to_owned(),
+                    options: json!([]),
+                },
+                StylisticRuleConfig {
+                    name: "no-tabs".to_owned(),
+                    options: json!([]),
+                },
+                StylisticRuleConfig {
+                    name: "linebreak-style".to_owned(),
+                    options: json!(["unix"]),
+                },
+                StylisticRuleConfig {
+                    name: "no-multiple-empty-lines".to_owned(),
+                    options: json!([{ "max": 1 }]),
+                },
+            ],
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.rule_name.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "quotes",
+            "no-trailing-spaces",
+            "no-tabs",
+            "linebreak-style",
+            "no-multiple-empty-lines"
+        ]
+    );
+    assert_eq!(diagnostics[0].range, TextRange::new(14, 21));
+    assert_eq!(
+        diagnostics[0].suggestions[0].fixes[0].replacement_text,
+        "'value'"
+    );
+}
+
+#[test]
+fn stylistic_tabs_and_bom_respect_options() {
+    let diagnostics = run_stylistic_lint(
+        "\u{feff}const value = 1;\n\tconst ok = 2;\nconst\tother = 3;\n",
+        &StylisticRunConfig {
+            rules: vec![
+                StylisticRuleConfig {
+                    name: "unicode-bom".to_owned(),
+                    options: json!(["never"]),
+                },
+                StylisticRuleConfig {
+                    name: "no-tabs".to_owned(),
+                    options: json!([{ "allowIndentationTabs": true }]),
+                },
+            ],
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.rule_name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["unicode-bom", "no-tabs"]
+    );
+    assert_eq!(diagnostics[0].range, TextRange::new(0, 3));
+    assert_eq!(diagnostics[1].message_id, "unexpectedTab");
+}
+
+#[test]
+fn stylistic_eol_last_reports_missing_and_unexpected_newline() {
+    let missing = run_stylistic_lint(
+        "const value = 1;",
+        &StylisticRunConfig {
+            rules: vec![StylisticRuleConfig {
+                name: "eol-last".to_owned(),
+                options: json!(["always"]),
+            }],
+        },
+    )
+    .unwrap();
+
+    assert_eq!(missing.len(), 1);
+    assert_eq!(missing[0].message_id, "missing");
+    assert_eq!(
+        missing[0].suggestions[0].fixes[0].range,
+        TextRange::new(16, 16)
+    );
+
+    let unexpected = run_stylistic_lint(
+        "const value = 1;\n\n",
+        &StylisticRunConfig {
+            rules: vec![StylisticRuleConfig {
+                name: "eol-last".to_owned(),
+                options: json!(["never"]),
+            }],
+        },
+    )
+    .unwrap();
+
+    assert_eq!(unexpected.len(), 1);
+    assert_eq!(unexpected[0].message_id, "unexpected");
+    assert_eq!(
+        unexpected[0].suggestions[0].fixes[0].range,
+        TextRange::new(16, 18)
+    );
+}
 
 #[test]
 fn reports_array_delete_with_splice_suggestion() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
       "corsa-oxlint/oxlint-utils": ["./src/bindings/nodejs/corsa_oxlint/ts/oxlint_utils.ts"],
       "corsa-oxlint/rule-tester": ["./src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts"],
       "corsa-oxlint/rules": ["./src/bindings/nodejs/corsa_oxlint/ts/rules/index.ts"],
+      "corsa-oxlint/stylistic": ["./src/bindings/nodejs/corsa_oxlint/ts/stylistic.ts"],
       "corsa-oxlint/ts-estree": ["./src/bindings/nodejs/corsa_oxlint/ts/ts_estree.ts"],
       "corsa-oxlint/ts-eslint": ["./src/bindings/nodejs/corsa_oxlint/ts/ts_eslint.ts"],
       "corsa-oxlint/ts-utils": ["./src/bindings/nodejs/corsa_oxlint/ts/ts_utils.ts"]


### PR DESCRIPTION
## Summary

- add a separate `corsa-oxlint/stylistic` entrypoint and Oxlint plugin for Rust-backed stylistic rules
- implement native source-wide stylistic scanning for `eol-last`, `linebreak-style`, `no-multiple-empty-lines`, `no-tabs`, `no-trailing-spaces`, `quotes`, and `unicode-bom`
- expose N-API bindings, TypeScript types, examples, and documentation for batched stylistic rule execution

## Notes

The stylistic path avoids per-node N-API calls. It sends source text and rule options to Rust once per source/config, then shares diagnostics through the JS plugin cache. Added Rust modules are split to keep files around the requested 250-line limit.

## Validation

- `vp check`
- `cargo fmt --all --check`
- `cargo test -p corsa_core`
- `cargo test -p corsa_node`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/**/*.test.ts`
- `vp run -w build_corsa_oxlint_ci`
- `git diff --check`