### PR TITLE
fix: satisfy stylistic replacement clippy

### DIFF
--- a/src/core/corsa_core/src/lint/stylistic/helpers.rs
+++ b/src/core/corsa_core/src/lint/stylistic/helpers.rs
@@ -30,28 +30,34 @@ fn option_at(options: &Value, index: usize) -> Option<&Value> {
     }
 }
 
+pub(crate) struct ReplacementDiagnostic {
+    pub(crate) rule_name: &'static str,
+    pub(crate) message_id: &'static str,
+    pub(crate) message: &'static str,
+    pub(crate) start: usize,
+    pub(crate) end: usize,
+    pub(crate) suggestion_id: &'static str,
+    pub(crate) suggestion_message: &'static str,
+}
+
 pub(crate) fn push_replacement_diagnostic(
     diagnostics: &mut Vec<LintDiagnostic>,
-    rule_name: &'static str,
-    message_id: &'static str,
-    message: &'static str,
-    start: usize,
-    end: usize,
-    suggestion_id: &'static str,
-    suggestion_message: &'static str,
+    diagnostic: ReplacementDiagnostic,
     replacement: impl Into<String>,
 ) {
     let replacement = replacement.into();
     push_diagnostic(
         diagnostics,
-        rule_name,
-        message_id,
-        message,
-        start,
-        end,
-        Some((suggestion_id, suggestion_message, move |range| {
-            LintFix::replace_range(range, replacement.clone())
-        })),
+        diagnostic.rule_name,
+        diagnostic.message_id,
+        diagnostic.message,
+        diagnostic.start,
+        diagnostic.end,
+        Some((
+            diagnostic.suggestion_id,
+            diagnostic.suggestion_message,
+            move |range| LintFix::replace_range(range, replacement.clone()),
+        )),
     );
 }
 

--- a/src/core/corsa_core/src/lint/stylistic/line_rules.rs
+++ b/src/core/corsa_core/src/lint/stylistic/line_rules.rs
@@ -4,7 +4,8 @@ use crate::lint::{LintDiagnostic, LintFix};
 
 use super::{
     helpers::{
-        option_bool, option_str, option_usize, push_diagnostic, push_replacement_diagnostic,
+        ReplacementDiagnostic, option_bool, option_str, option_usize, push_diagnostic,
+        push_replacement_diagnostic,
     },
     line_index::{LineInfo, Newline},
 };
@@ -56,13 +57,15 @@ pub(crate) fn check_eol_last(
         _ if !source_text.ends_with('\n') && !source_text.ends_with('\r') => {
             push_replacement_diagnostic(
                 diagnostics,
-                "eol-last",
-                "missing",
-                "Expected newline at end of file.",
-                source_text.len(),
-                source_text.len(),
-                "insertNewline",
-                "Insert a newline.",
+                ReplacementDiagnostic {
+                    rule_name: "eol-last",
+                    message_id: "missing",
+                    message: "Expected newline at end of file.",
+                    start: source_text.len(),
+                    end: source_text.len(),
+                    suggestion_id: "insertNewline",
+                    suggestion_message: "Insert a newline.",
+                },
                 "\n",
             );
         }
@@ -154,13 +157,15 @@ fn report_linebreak(
 ) {
     push_replacement_diagnostic(
         diagnostics,
-        "linebreak-style",
-        message_id,
-        message,
-        line.newline_start,
-        line.newline_start + line.newline_len,
-        "fixLinebreak",
-        "Replace linebreak.",
+        ReplacementDiagnostic {
+            rule_name: "linebreak-style",
+            message_id,
+            message,
+            start: line.newline_start,
+            end: line.newline_start + line.newline_len,
+            suggestion_id: "fixLinebreak",
+            suggestion_message: "Replace linebreak.",
+        },
         replacement,
     );
 }

--- a/src/core/corsa_core/src/lint/stylistic/quotes.rs
+++ b/src/core/corsa_core/src/lint/stylistic/quotes.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 use crate::lint::LintDiagnostic;
 
 use super::helpers::{
-    is_identifier_continue, is_identifier_start, option_bool, option_str,
+    ReplacementDiagnostic, is_identifier_continue, is_identifier_start, option_bool, option_str,
     push_replacement_diagnostic,
 };
 use super::quote_convert::{contains_unescaped_quote, convert_quote_literal};
@@ -99,13 +99,15 @@ fn report_quote_if_needed(
     if let Some(replacement) = convert_quote_literal(&source_text[start..end], quote, preferred) {
         push_replacement_diagnostic(
             diagnostics,
-            "quotes",
-            "wrongQuote",
-            "String literals must use the configured quote style.",
-            start,
-            end,
-            "fixQuote",
-            "Convert quote style.",
+            ReplacementDiagnostic {
+                rule_name: "quotes",
+                message_id: "wrongQuote",
+                message: "String literals must use the configured quote style.",
+                start,
+                end,
+                suggestion_id: "fixQuote",
+                suggestion_message: "Convert quote style.",
+            },
             replacement,
         );
     }

--- a/src/core/corsa_core/src/lint/stylistic/unicode_bom.rs
+++ b/src/core/corsa_core/src/lint/stylistic/unicode_bom.rs
@@ -2,7 +2,9 @@ use serde_json::Value;
 
 use crate::lint::{LintDiagnostic, LintFix};
 
-use super::helpers::{option_str, push_diagnostic, push_replacement_diagnostic};
+use super::helpers::{
+    ReplacementDiagnostic, option_str, push_diagnostic, push_replacement_diagnostic,
+};
 
 const BOM: &str = "\u{feff}";
 
@@ -17,13 +19,15 @@ pub(crate) fn check_unicode_bom(
     match (requires_bom, has_bom) {
         (true, false) => push_replacement_diagnostic(
             diagnostics,
-            "unicode-bom",
-            "expected",
-            "Expected Unicode byte order mark.",
-            0,
-            0,
-            "insertBom",
-            "Insert Unicode byte order mark.",
+            ReplacementDiagnostic {
+                rule_name: "unicode-bom",
+                message_id: "expected",
+                message: "Expected Unicode byte order mark.",
+                start: 0,
+                end: 0,
+                suggestion_id: "insertBom",
+                suggestion_message: "Insert Unicode byte order mark.",
+            },
             BOM,
         ),
         (false, true) => push_diagnostic(


### PR DESCRIPTION
## Summary

- group replacement diagnostic metadata into `ReplacementDiagnostic`
- keep stylistic replacement helpers under the release gate's clippy argument limit

## Context

The `v0.18.0` publish workflows failed in release gates at `cargo clippy --workspace --all-targets -- -D warnings` with `clippy::too_many_arguments` for `push_replacement_diagnostic`.

## Validation

- `cargo fmt --all`
- `cargo clippy -p corsa_core --all-targets -- -D warnings`
- `vp run -w lint_rust`