### PR TITLE
ci: isolate experimental cargo test target dirs to unblock Windows

### DIFF
--- a/scripts/vite/tasks/test_tasks.ts
+++ b/scripts/vite/tasks/test_tasks.ts
@@ -11,13 +11,23 @@ export const testTasks = {
     command: "cargo test --workspace",
     dependsOn: ["verify_ref", "build_rust", "build_mock"],
   },
+  // These two cargo invocations use non-default feature flags, so cargo would
+  // rebuild the `corsa` crate (and its `mock_corsa` bin) in the shared `target/`
+  // directory. On Windows that races with concurrent consumers of
+  // `target/debug/mock_corsa.exe` (vitest in `test_ts`, integration tests in
+  // `test_rust`, `examples_rust_smoke`, ...) and fails with
+  // `failed to remove file ... Access is denied. (os error 5)`.
+  // Isolate each feature combo in its own target dir so the shared
+  // `target/debug/mock_corsa.exe` is never re-linked while another process is
+  // holding it open.
   test_rust_experimental: {
-    command: "cargo test -p corsa --no-default-features --test orchestrator",
+    command:
+      "cargo test -p corsa --no-default-features --test orchestrator --target-dir .cache/test-target-no-default",
     dependsOn: ["test_rust_experimental_feature"],
   },
   test_rust_experimental_feature: {
-    command: "cargo test -p corsa --features experimental-distributed --test orchestrator",
-    dependsOn: ["build_mock"],
+    command:
+      "cargo test -p corsa --features experimental-distributed --test orchestrator --target-dir .cache/test-target-experimental",
   },
   test_ts: {
     command: "vp test run --config ./vite.config.ts",


### PR DESCRIPTION
## Summary

- give `test_rust_experimental` and `test_rust_experimental_feature` their own `--target-dir` under `.cache/` so they no longer relink the shared `target/debug/mock_corsa.exe`
- drop the now-unnecessary `build_mock` dep on `test_rust_experimental_feature` — cargo builds the bin into the isolated target dir via `CARGO_BIN_EXE_mock_corsa`

## Context

`Test (windows-latest)` failed on the v0.19.0 release commit ([CI run 26569260263](https://github.com/ubugeeei/corsa-bind/actions/runs/26569260263)) with:

```
error: failed to remove file `D:\a\corsa-bind\corsa-bind\target\debug\mock_corsa.exe`
  Access is denied. (os error 5)
```

The diff between 9cbb246 (green) and 13337d2 (red) is version-bump-only, so this is a latent race that finally bit.

`vp run -w test` fans out into:

- `test_rust` → `cargo test --workspace` (default features, builds & spawns `mock_corsa` via integration tests)
- `test_rust_experimental_feature` → `cargo test -p corsa --features experimental-distributed --test orchestrator` (different feature set → cargo invalidates the `corsa` crate in shared `target/` and relinks `mock_corsa.exe`)
- `test_rust_experimental` → `cargo test -p corsa --no-default-features --test orchestrator` (another distinct feature set → another relink)
- `test_ts` → vitest, which spawns `target/debug/mock_corsa.exe` as a child process
- `examples_smoke_ci` → `cargo run --example …` plus node smoke scripts that spawn the same `mock_corsa.exe`

On Linux/macOS, relinking an executable that another process is currently running succeeds. On Windows the file is locked and the relink fails. With this many concurrent consumers of `target/debug/mock_corsa.exe`, the experimental feature-flagged cargo invocations only need to lose the race once.

Isolating the two feature-flag variants into `.cache/test-target-no-default/` and `.cache/test-target-experimental/` keeps cargo from rewriting the shared bin, so the only writer of `target/debug/mock_corsa.exe` is `build_mock` (which runs before any consumer reads it). The dependency between `test_rust_experimental` and `test_rust_experimental_feature` is preserved so they still run sequentially.

## Validation

- `vp run -w test` — full graph passes locally; `.cache/test-target-no-default/debug/mock_corsa` and `.cache/test-target-experimental/debug/mock_corsa` are built in isolation as expected.
- `vp fmt scripts/vite/tasks/test_tasks.ts` / `vp lint scripts/vite/tasks/test_tasks.ts` — clean.
- The decisive Windows verification will happen post-merge: `Test (windows-latest)` is gated by `if: github.event_name != 'pull_request'` in `.github/workflows/ci.yml`, so the PR CI run won't exercise it. (Heads up for review.)

## Trade-offs

- Each isolated target dir is a separate build cache, so the first run after a `rust-cache` miss takes longer. Subsequent runs hit `Swatinem/rust-cache`'s workspace cache for `target/` but not the `.cache/test-target-*/` dirs (`rust-cache` only caches the default workspace `target/`). If this becomes a CI-time issue we can teach `rust-cache` about the extra paths via its `workspaces` input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)