### PR TITLE
fix: keep getImplementedTypesOfType working after getBaseTypes (#206)

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
@@ -149,6 +149,88 @@ describe("corsa oxlint implemented types", () => {
     expect(seen.byType).toEqual(["IChild"]);
   });
 
+  integrationCase(
+    "resolves implemented interfaces after getBaseTypes has been called on the same type",
+    () => {
+      const seen: Record<string, readonly string[] | undefined> = {};
+      const errors: Record<string, string | undefined> = {};
+      const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+      const rule = createRule({
+        name: "implemented-types-after-get-base-types",
+        meta: {
+          type: "problem",
+          docs: {
+            description: "exercise getImplementedTypesOfType after getBaseTypes on the same handle",
+            requiresTypeChecking: true,
+          },
+          messages: {
+            unexpected: "unexpected",
+          },
+          schema: [],
+        },
+        defaultOptions: [],
+        create(context: any) {
+          const services = OxlintUtils.getParserServices(context);
+          const checker = services.program.getTypeChecker();
+          return {
+            NewExpression(node: any) {
+              const type = checker.getTypeAtLocation(node);
+              if (!type) {
+                return;
+              }
+              const name = checker.typeToString(type);
+              // Drain the bases first to invalidate the type handle before we
+              // ask for implemented interfaces - regressing GH#206.
+              checker.getBaseTypes(type);
+              try {
+                seen[name] = checker
+                  .getImplementedTypesOfType(type)
+                  .map((implemented) => checker.typeToString(implemented));
+              } catch (error) {
+                errors[name] = error instanceof Error ? error.message : String(error);
+              }
+            },
+          };
+        },
+      });
+
+      const tester = new RuleTester();
+      tester.run("implemented-types-after-get-base-types", rule as any, {
+        valid: [
+          {
+            code: [
+              "interface IA {",
+              "  readonly a: string;",
+              "}",
+              "class Base implements IA {",
+              '  readonly a = "x";',
+              "}",
+              "class Derived extends Base {",
+              '  readonly b = "y";',
+              "}",
+              "new Base();",
+              "new Derived();",
+            ].join("\n"),
+            settings: {
+              corsaOxlint: {
+                parserOptions: {
+                  corsa: {
+                    executable: realCorsaBinary,
+                  },
+                },
+              },
+            },
+          },
+        ],
+        invalid: [],
+      });
+
+      expect(errors).toEqual({});
+      expect(seen.Base).toEqual(["IA"]);
+      expect(seen.Derived).toEqual(["IA"]);
+    },
+  );
+
   integrationCase("returns inherited implemented interfaces from class types", () => {
     const seen: Record<string, readonly string[] | undefined> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
@@ -64,4 +64,84 @@ describe("CorsaProjectSession", () => {
 
     expect(clients[0]?.updateSnapshot).toHaveBeenCalledTimes(1);
   });
+
+  // Regression for GH#206: upstream Corsa occasionally drops a type handle
+  // from its snapshot registry after a base-types query on a class with no
+  // explicit `extends` clause, which then makes a follow-up
+  // `getImplementedTypesOfType` on the same handle throw "type handle ...
+  // not found in snapshot registry". The wrapper should treat that as "no
+  // base types" so the caller can still see the type's own `implements`.
+  it("treats a 'handle not found in snapshot registry' error from getBaseTypes as no bases", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    session.getTypeAtPosition("/tmp/one.ts", 0);
+    const client = clients[0];
+    if (!client) {
+      throw new Error("expected a fake client");
+    }
+    client.callJson.mockImplementationOnce(() => {
+      throw new Error(
+        'protocol error: api: client error: type handle "t0000000000000057" not found in snapshot registry',
+      );
+    });
+
+    const result = session.getBaseTypes({
+      id: "type-1",
+      flags: 0,
+      texts: ["Base"],
+    } as never);
+
+    expect(result).toEqual([]);
+  });
+
+  it("rethrows unexpected errors from getBaseTypes", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    session.getTypeAtPosition("/tmp/one.ts", 0);
+    const client = clients[0];
+    if (!client) {
+      throw new Error("expected a fake client");
+    }
+    client.callJson.mockImplementationOnce(() => {
+      throw new Error("protocol error: api: unexpected failure");
+    });
+
+    expect(() =>
+      session.getBaseTypes({
+        id: "type-1",
+        flags: 0,
+        texts: ["Base"],
+      } as never),
+    ).toThrow(/unexpected failure/);
+  });
 });

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -281,7 +281,12 @@ export class CorsaProjectSession {
         }) ?? [],
       );
     } catch (error) {
-      if (isProtocolPanicError(error)) {
+      // Upstream Corsa occasionally drops a type handle from its snapshot
+      // registry after the first base-types query on a class that has no
+      // explicit `extends` clause. Treating that as "no base types" lets a
+      // follow-up `getImplementedTypesOfType` on the same handle still report
+      // the type's own `implements` clause instead of throwing (GH#206).
+      if (isProtocolPanicError(error) || isStaleHandleError(error)) {
         return [];
       }
       throw error;
@@ -848,6 +853,11 @@ function overlayTextFor(fileName: string, sourceText?: string): string | undefin
 function isProtocolPanicError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return message.includes("protocol error: panic:") || message.includes("panic: runtime error");
+}
+
+function isStaleHandleError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /handle "[^"]*" not found in snapshot registry/.test(message);
 }
 
 function statMtimeMs(fileName: string): number {


### PR DESCRIPTION
Closes #206.

## What changed

`CorsaProjectSession.getBaseTypes` now treats `"handle ... not found in snapshot registry"` errors from upstream Corsa the same way it already treats upstream protocol panics: it returns an empty list of bases instead of propagating the error.

That keeps the wrapper's `getImplementedTypesOfType` working when the user happens to call `getBaseTypes(t)` first on the same handle — that ordering otherwise drops the type handle out of Corsa's snapshot registry on classes with no explicit `extends` clause, and the next internal `getBaseTypes(t)` (issued from inside `implementedTypesFromTypeAndBases`) would crash. With this change the wrapper still recovers the class's own `implements` clause from the source-text fallback.

## Why a wrapper-level fix

The handle drop is a real upstream regression for the call sequence `getBaseTypes(t)` → `getImplementedTypesOfType(t)`, but our `no forks, no patches` policy on `ref/corsa-upstream` means we cannot land it directly there. Catching the named error in the wrapper is conservative — `getBaseTypes` already had the same shape of fallback for upstream panics — and gives users the documented behavior without waiting on an upstream snapshot bump.

## Tests

- New `CorsaProjectSession` unit tests cover the stale-handle fallback and confirm that other client errors still surface.
- New integration test under `implemented_types.test.ts` exercises the user-visible flow (call `getBaseTypes` first, then ask for implemented interfaces on `Base` and `Derived`) and asserts both still resolve `["IA"]` without throwing.
- `vp check` (fmt + lint + type-check) and `vp test src/bindings/nodejs/corsa_oxlint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)