### PR TITLE
fix: walk base chain in eslint fallback getImplementedTypesOfType (#207)

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -321,6 +321,194 @@ describe("corsa oxlint", () => {
     expect(corsaChecker.getNodeById("missing")).toBeUndefined();
   });
 
+  // Regression for GH#207: the @typescript-eslint fallback used to walk only
+  // the type's own `implements` clause, so a class that implemented an
+  // interface only through a base class came back empty here while the tsgo
+  // backend reported the interface. The fallback now walks the base chain
+  // too, matching tsgo.
+  it("includes inherited implemented interfaces in the eslint fallback checker", () => {
+    const interfaceType = { name: "IA" };
+    const interfaceExpression = { kind: "ia-expression" };
+    const baseImplementsClause = {
+      getText() {
+        return "implements IA";
+      },
+      types: [{ expression: interfaceExpression }],
+    };
+    const baseDeclaration = {
+      heritageClauses: [baseImplementsClause],
+    };
+    const baseType: { symbol: { declarations: unknown[] } } = {
+      symbol: { declarations: [baseDeclaration] },
+    };
+    const baseExpression = { kind: "base-expression" };
+    const derivedExtendsClause = {
+      getText() {
+        return "extends Base";
+      },
+      types: [{ expression: baseExpression }],
+    };
+    const derivedDeclaration = {
+      heritageClauses: [derivedExtendsClause],
+    };
+    const derivedType = {
+      symbol: { declarations: [derivedDeclaration] },
+    };
+
+    const checker = {
+      getTypeAtLocation(node: unknown) {
+        if (node === interfaceExpression) {
+          return interfaceType;
+        }
+        if (node === baseExpression) {
+          return baseType;
+        }
+        return undefined;
+      },
+      getSymbolAtLocation() {
+        return { kind: "symbol" };
+      },
+      getBaseTypes(type: unknown) {
+        return type === derivedType ? [baseType] : [];
+      },
+    };
+    const program = {
+      getTypeChecker() {
+        return checker;
+      },
+    };
+    const parserServices = {
+      program,
+      esTreeNodeToTSNodeMap: {
+        get() {
+          return undefined;
+        },
+        has() {
+          return false;
+        },
+      },
+      tsNodeToESTreeNodeMap: {
+        get() {
+          return { type: "Identifier" };
+        },
+        has() {
+          return true;
+        },
+      },
+    };
+
+    const services = getParserServices({
+      cwd: workspaceRoot,
+      filename: resolve(workspaceRoot, "fixture.ts"),
+      languageOptions: {
+        parserOptions: {},
+      },
+      report() {},
+      settings: {},
+      sourceCode: {
+        text: "",
+        parserServices: parserServices as never,
+      },
+    } as never);
+    const corsaChecker = services.program.getTypeChecker();
+
+    expect(corsaChecker.getImplementedTypesOfType(baseType as never)).toEqual([interfaceType]);
+    expect(corsaChecker.getImplementedTypesOfType(derivedType as never)).toEqual([interfaceType]);
+  });
+
+  // Companion to the GH#207 regression above: when the checker can't tell us
+  // the base types directly (the upstream `getBaseTypes` returns nothing), the
+  // fallback walks the `extends` clause from source and still reports
+  // inherited interfaces.
+  it("walks extends-clause base types when the eslint checker omits them", () => {
+    const interfaceType = { name: "IA" };
+    const interfaceExpression = { kind: "ia-expression" };
+    const baseImplementsClause = {
+      getText() {
+        return "implements IA";
+      },
+      types: [{ expression: interfaceExpression }],
+    };
+    const baseDeclaration = {
+      heritageClauses: [baseImplementsClause],
+    };
+    const baseType = {
+      symbol: { declarations: [baseDeclaration] },
+    };
+    const baseExpression = { kind: "base-expression" };
+    const derivedExtendsClause = {
+      getText() {
+        return "extends Base";
+      },
+      types: [{ expression: baseExpression }],
+    };
+    const derivedDeclaration = {
+      heritageClauses: [derivedExtendsClause],
+    };
+    const derivedType = {
+      symbol: { declarations: [derivedDeclaration] },
+    };
+
+    const checker = {
+      getTypeAtLocation(node: unknown) {
+        if (node === interfaceExpression) {
+          return interfaceType;
+        }
+        if (node === baseExpression) {
+          return baseType;
+        }
+        return undefined;
+      },
+      getSymbolAtLocation() {
+        return { kind: "symbol" };
+      },
+      getBaseTypes() {
+        return [];
+      },
+    };
+    const program = {
+      getTypeChecker() {
+        return checker;
+      },
+    };
+    const parserServices = {
+      program,
+      esTreeNodeToTSNodeMap: {
+        get() {
+          return undefined;
+        },
+        has() {
+          return false;
+        },
+      },
+      tsNodeToESTreeNodeMap: {
+        get() {
+          return { type: "Identifier" };
+        },
+        has() {
+          return true;
+        },
+      },
+    };
+
+    const services = getParserServices({
+      cwd: workspaceRoot,
+      filename: resolve(workspaceRoot, "fixture.ts"),
+      languageOptions: {
+        parserOptions: {},
+      },
+      report() {},
+      settings: {},
+      sourceCode: {
+        text: "",
+        parserServices: parserServices as never,
+      },
+    } as never);
+    const corsaChecker = services.program.getTypeChecker();
+
+    expect(corsaChecker.getImplementedTypesOfType(derivedType as never)).toEqual([interfaceType]);
+  });
+
   it("propagates corsaOxlint settings through RuleTester", () => {
     let seen: Record<string, unknown> | undefined;
     const tester = new RuleTester();

--- a/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
@@ -191,7 +191,7 @@ function createEslintTypeChecker(
       );
     },
     getImplementedTypesOfType(type) {
-      return heritageTypes(type, source, "implements");
+      return implementedTypesIncludingBases(type, source);
     },
     getTypeArguments(type) {
       return asReadonlyArray(callChecker(source, "getTypeArguments", type));
@@ -289,6 +289,43 @@ function heritageTypes(
   return declarations.flatMap((declaration) =>
     heritageTypesFromDeclaration(declaration, checker, keyword),
   );
+}
+
+/**
+ * Mirrors the tsgo-backed `getImplementedTypesOfType` behaviour by walking the
+ * base-type chain so a class that implements an interface only through a base
+ * class still reports that interface. Without this, a rule shared between
+ * oxlint (tsgo) and ESLint (this `@typescript-eslint` fallback checker) would
+ * see different implemented types for the same source (GH#207).
+ */
+function implementedTypesIncludingBases(
+  type: unknown,
+  checker: Record<string, unknown>,
+): readonly never[] {
+  const visited = new Set<unknown>();
+  const seenImplemented = new Set<unknown>();
+  const implemented: never[] = [];
+  const queue: unknown[] = [type];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current === undefined || current === null || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    for (const ownType of heritageTypes(current, checker, "implements")) {
+      if (seenImplemented.has(ownType)) {
+        continue;
+      }
+      seenImplemented.add(ownType);
+      implemented.push(ownType);
+    }
+    const directBases = asReadonlyArray(callChecker(checker, "getBaseTypes", current));
+    const bases = directBases.length > 0 ? directBases : heritageTypes(current, checker, "extends");
+    for (const baseType of bases) {
+      queue.push(baseType);
+    }
+  }
+  return implemented;
 }
 
 function heritageTypesFromDeclaration(

--- a/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
@@ -297,22 +297,32 @@ function heritageTypes(
  * class still reports that interface. Without this, a rule shared between
  * oxlint (tsgo) and ESLint (this `@typescript-eslint` fallback checker) would
  * see different implemented types for the same source (GH#207).
+ *
+ * The traversal is a DFS so we can use `pop()` (O(1)) instead of a queue with
+ * `shift()` (O(n)) — visit order doesn't matter because we dedupe implemented
+ * types by identity. We also `continue` on already-visited bases before
+ * touching `Set.add`, so a deep diamond hierarchy never quadruples work.
  */
 function implementedTypesIncludingBases(
   type: unknown,
   checker: Record<string, unknown>,
 ): readonly never[] {
+  if (type === undefined || type === null) {
+    return [];
+  }
   const visited = new Set<unknown>();
   const seenImplemented = new Set<unknown>();
   const implemented: never[] = [];
-  const queue: unknown[] = [type];
-  while (queue.length > 0) {
-    const current = queue.shift();
+  const stack: unknown[] = [type];
+  while (stack.length > 0) {
+    const current = stack.pop();
     if (current === undefined || current === null || visited.has(current)) {
       continue;
     }
     visited.add(current);
-    for (const ownType of heritageTypes(current, checker, "implements")) {
+    const ownImplemented = heritageTypes(current, checker, "implements");
+    for (let index = 0; index < ownImplemented.length; index += 1) {
+      const ownType = ownImplemented[index];
       if (seenImplemented.has(ownType)) {
         continue;
       }
@@ -321,8 +331,12 @@ function implementedTypesIncludingBases(
     }
     const directBases = asReadonlyArray(callChecker(checker, "getBaseTypes", current));
     const bases = directBases.length > 0 ? directBases : heritageTypes(current, checker, "extends");
-    for (const baseType of bases) {
-      queue.push(baseType);
+    for (let index = bases.length - 1; index >= 0; index -= 1) {
+      const baseType = bases[index];
+      if (baseType === undefined || baseType === null || visited.has(baseType)) {
+        continue;
+      }
+      stack.push(baseType);
     }
   }
   return implemented;


### PR DESCRIPTION
Closes #207.

## What changed

The `@typescript-eslint` parser-services fallback in `createEslintTypeChecker` used to return only the type's own `implements` clause for `getImplementedTypesOfType`. For `class Derived extends Base` where `Base implements IA`, that meant ESLint saw `[]` while the tsgo backend (and the user's expectation, per the existing `implementedTypesFromTypeAndBases` helper in [checker.ts](src/bindings/nodejs/corsa_oxlint/ts/checker.ts)) reported `["IA"]`.

The fallback now mirrors the tsgo path by walking the base-type chain: for each visited type it collects own `implements`, then queues up `checker.getBaseTypes(type)` (falling back to the declaration's `extends` clause when the upstream checker returns nothing) and recurses, deduplicating by type identity.

## Why this matters

Rules built on `corsa-oxlint` are intentionally portable across the two backends:

- under oxlint, the tsgo path runs;
- under a plain ESLint setup (`@typescript-eslint/parser` parser services, no `settings.corsaOxlint`), the fallback in [parser_services.ts](src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts) runs.

A shared rule that asks "does this class implement `IA`?" should answer the same way in either case. Today it doesn't, which is the bug #207 reports.

## Tests

- Two new unit tests in [framework.test.ts](src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts) exercise the fallback through `getParserServices` with stubbed parser services:
  - one where the stub checker reports a base type directly,
  - one where the stub returns no bases and the helper falls back to reading the `extends` clause from the declaration.
  
  Both confirm the inherited `IA` interface comes through.
- I verified each new test fails on `main` (returns `[]` instead of `[IA]`) by reverting only the `parser_services.ts` change locally and re-running.
- `vp check` and the full `vp test src/bindings/nodejs/corsa_oxlint` suite (83 tests) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)