### PR TITLE
perf(checker): iterative DFS for implementedTypesFromTypeAndBases

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -305,30 +305,42 @@ function implementedTypesFromTypeAndBases(
   type: CorsaType,
   checker: CorsaTypeCheckerShape,
 ): readonly CorsaType[] {
+  // Iterative DFS over the base chain so we don't pay for one closure call
+  // and one `push(...subResult)` spread per base (each spread used to copy
+  // the entire growing accumulator). Visit order doesn't matter because we
+  // dedupe by `type.id`.
   const seenTypes = new Set<string>();
   const seenImplementedTypes = new Set<string>();
-
-  function collect(current: CorsaType): CorsaType[] {
+  const implemented: CorsaType[] = [];
+  const stack: CorsaType[] = [type];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
     if (seenTypes.has(current.id)) {
-      return [];
+      continue;
     }
     seenTypes.add(current.id);
 
-    const implemented: CorsaType[] = [];
-    for (const ownType of implementedTypesFromTypeDeclaration(context, current, checker)) {
+    const ownImplemented = implementedTypesFromTypeDeclaration(context, current, checker);
+    for (let index = 0; index < ownImplemented.length; index += 1) {
+      const ownType = ownImplemented[index]!;
       if (seenImplementedTypes.has(ownType.id)) {
         continue;
       }
       seenImplementedTypes.add(ownType.id);
       implemented.push(ownType);
     }
-    for (const baseType of checker.getBaseTypes(current)) {
-      implemented.push(...collect(baseType));
-    }
-    return implemented;
-  }
 
-  return collect(type);
+    const bases = checker.getBaseTypes(current);
+    // Push in reverse so the natural visit order matches the recursive form.
+    for (let index = bases.length - 1; index >= 0; index -= 1) {
+      const baseType = bases[index]!;
+      if (seenTypes.has(baseType.id)) {
+        continue;
+      }
+      stack.push(baseType);
+    }
+  }
+  return implemented;
 }
 
 function implementedTypesFromTypeDeclaration(


### PR DESCRIPTION
The tsgo-backed `getImplementedTypesOfType` in [checker.ts](src/bindings/nodejs/corsa_oxlint/ts/checker.ts) walked the base chain recursively and concatenated each sub-result with `implemented.push(...collect(baseType))`. That spread allocated and copied a fresh intermediate array per base, so for a hierarchy of depth N the original walk did O(N) extra copies on top of the actual collection — plus one JS call frame per level.

The new shape is an iterative DFS over a small stack: each visited type appends straight into one accumulator, and we re-check the visited set before pushing a base back onto the stack so we never pay for re-pushed bases. Behaviour is unchanged because the algorithm already deduped by `type.id` (visit order didn't matter).

This is the same shape change I made in the `@typescript-eslint` fallback path in [#209](https://github.com/ubugeeei/corsa-bind/pull/209) — now lifted into the primary tsgo path which actually runs in oxlint.

## Microbenchmark (Node 24)

```
depth 8,  3 implements/level: recursive  1.13 M ops/s → iterative 1.46 M ops/s   (1.29x)
depth 50, 8 implements/level: recursive 49.8 K ops/s → iterative  109  K ops/s   (2.19x)
```

The deeper the hierarchy the bigger the win — the push-spread's cost grew linearly with depth.

## Tests

- `vp test src/bindings/nodejs/corsa_oxlint` — 86 tests pass (the `implemented_types.test.ts` integration cases for tsgo are the meaningful coverage here; they exercise both the own-implements path and the inherited-via-base path).
- `vp check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)