### PR TITLE
ci: migrate Ubuntu runners to Blacksmith 32vCPU tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   js-format:
     name: JS/TS Format
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 15
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -41,7 +41,7 @@ jobs:
 
   js-lint-types:
     name: JS/TS Lint and Types
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 15
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -62,7 +62,7 @@ jobs:
 
   rust-format:
     name: Rust Format
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 15
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -81,7 +81,7 @@ jobs:
 
   rust-lint:
     name: Rust Lint
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest","macos-15","windows-latest"]') }}
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["blacksmith-32vcpu-ubuntu-2404"]' || '["blacksmith-32vcpu-ubuntu-2404","macos-15","windows-latest"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -153,7 +153,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - blacksmith-32vcpu-ubuntu-2404
           - macos-15
           - windows-latest
     steps:
@@ -180,7 +180,7 @@ jobs:
 
   public-facade:
     name: Public Facade
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -203,7 +203,7 @@ jobs:
 
   non-node-bindings:
     name: Non-Node Bindings
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 20
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -256,7 +256,7 @@ jobs:
 
   quality:
     name: Quality
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 5
     needs:
       - js-format
@@ -308,7 +308,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - blacksmith-32vcpu-ubuntu-2404
           - macos-15
           - windows-latest
     steps:
@@ -352,7 +352,7 @@ jobs:
 
   bench-corsa-ref:
     name: Corsa Ref Bench
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 60
     if: ${{ github.event_name != 'pull_request' }}
     steps:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -30,7 +30,7 @@ jobs:
   github-release:
     if: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'push' && startsWith(github.event.workflow_run.head_branch, 'v') && github.event.workflow_run.conclusion == 'success') || (github.event_name == 'workflow_dispatch' && inputs.confirm == 'github-release') }}
     name: Create GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 60
     environment: release
     steps:

--- a/.github/workflows/pr-performance.yml
+++ b/.github/workflows/pr-performance.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   benchmark:
     name: Benchmark ${{ matrix.ref-role }} TypeScript ${{ matrix.typescript.channel }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 90
     continue-on-error: ${{ matrix.ref-role == 'base' }}
     strategy:
@@ -182,7 +182,7 @@ jobs:
 
   comment:
     name: Comment benchmark result
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     needs: benchmark
     steps:
       - name: Checkout

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -37,7 +37,7 @@ jobs:
   release-gates:
     if: ${{ (github.event_name == 'push' && github.ref_type == 'tag') || (github.event_name == 'workflow_dispatch' && inputs.confirm == 'publish-npm' && inputs.tag != '') }}
     name: Release Gates
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -103,7 +103,7 @@ jobs:
     name: Resolve native binding targets
     needs:
       - release-gates
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 10
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -206,7 +206,7 @@ jobs:
     needs:
       - release-gates
       - build-native-bindings
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 45
     environment: release
     permissions:

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -33,7 +33,7 @@ jobs:
   release-gates:
     if: ${{ (github.event_name == 'push' || inputs.confirm == 'publish-rust') && github.ref_type == 'tag' }}
     name: Release Gates
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 90
     steps:
       - name: Checkout
@@ -98,7 +98,7 @@ jobs:
     name: Publish Rust Crates
     needs:
       - release-gates
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
     environment: release
     permissions:

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   release-dry-run:
     name: Release Dry Run
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   scorecard:
     name: OpenSSF Scorecard
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 20
     permissions:
       actions: read

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   cargo-deny:
     name: Cargo Deny
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -36,7 +36,7 @@ jobs:
 
   sbom:
     name: SBOM Generation
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/bench/src/npm_release_utils.test.ts
+++ b/bench/src/npm_release_utils.test.ts
@@ -118,7 +118,7 @@ describe("npm release utils", () => {
       },
       {
         crossCompile: false,
-        os: "ubuntu-latest",
+        os: "blacksmith-32vcpu-ubuntu-2404",
         target: "x86_64-unknown-linux-gnu",
         useNapiCross: true,
       },
@@ -136,19 +136,19 @@ describe("npm release utils", () => {
       },
       {
         crossCompile: true,
-        os: "ubuntu-latest",
+        os: "blacksmith-32vcpu-ubuntu-2404",
         target: "x86_64-unknown-linux-musl",
         useNapiCross: false,
       },
       {
         crossCompile: false,
-        os: "ubuntu-latest",
+        os: "blacksmith-32vcpu-ubuntu-2404",
         target: "aarch64-unknown-linux-gnu",
         useNapiCross: true,
       },
       {
         crossCompile: true,
-        os: "ubuntu-latest",
+        os: "blacksmith-32vcpu-ubuntu-2404",
         target: "aarch64-unknown-linux-musl",
         useNapiCross: false,
       },

--- a/docs/ci_guide.md
+++ b/docs/ci_guide.md
@@ -371,10 +371,10 @@ requests cannot merge until the current CI surface is green.
 
 Required status checks for `main` should include:
 
-- `Quality (ubuntu-latest)`
+- `Quality (blacksmith-32vcpu-ubuntu-2404)`
 - `Quality (macos-latest)`
 - `Quality (windows-latest)`
-- `Real Corsa Smoke (ubuntu-latest)`
+- `Real Corsa Smoke (blacksmith-32vcpu-ubuntu-2404)`
 - `Real Corsa Smoke (macos-latest)`
 - `Real Corsa Smoke (windows-latest)`
 - `Corsa Ref Bench`

--- a/scripts/npm_release_utils.ts
+++ b/scripts/npm_release_utils.ts
@@ -155,22 +155,22 @@ const nodeBindingBuildTargetConfig: Record<string, NodeBindingBuildTargetConfig>
   },
   "x86_64-unknown-linux-gnu": {
     crossCompile: false,
-    os: "ubuntu-latest",
+    os: "blacksmith-32vcpu-ubuntu-2404",
     useNapiCross: true,
   },
   "aarch64-unknown-linux-gnu": {
     crossCompile: false,
-    os: "ubuntu-latest",
+    os: "blacksmith-32vcpu-ubuntu-2404",
     useNapiCross: true,
   },
   "x86_64-unknown-linux-musl": {
     crossCompile: true,
-    os: "ubuntu-latest",
+    os: "blacksmith-32vcpu-ubuntu-2404",
     useNapiCross: false,
   },
   "aarch64-unknown-linux-musl": {
     crossCompile: true,
-    os: "ubuntu-latest",
+    os: "blacksmith-32vcpu-ubuntu-2404",
     useNapiCross: false,
   },
 };


### PR DESCRIPTION
## Summary
- Switch every `ubuntu-latest` runner in `.github/workflows/*.yml` to `blacksmith-32vcpu-ubuntu-2404` (Blacksmith's highest Linux tier).
- Update the napi cross-build matrix in `scripts/npm_release_utils.ts` (and its test fixtures) so Linux native bindings build on the same Blacksmith tier.
- Refresh the required-check names in `docs/ci_guide.md` to match the new matrix label.
- macOS (`macos-15`, `macos-15-intel`) and Windows (`windows-latest`) matrix entries are left untouched.

## Test plan
- [ ] CI workflow runs green on the new runner label
- [ ] PR Performance benchmark workflow schedules on the Blacksmith runner
- [ ] Release Dry Run, Supply Chain, and Scorecard workflows succeed
- [ ] Update branch-protection required-check names to the new `(blacksmith-32vcpu-ubuntu-2404)` suffixes before next merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)