### PR TITLE
fix: tolerate stale type handles from the tsgo backend (#211)

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -114,7 +114,7 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
       const sourceText = sourceTextFor(context, node);
       const sourceNode = sourceText ? corsaNodeFromEstree(context, node) : undefined;
       if (sourceText && sourceNode) {
-        const implemented = implementedTypesFromSourceText(sourceNode, sourceText, this);
+        const implemented = implementedTypesFromSourceText(context, sourceNode, sourceText, this);
         if (implemented.length > 0) {
           return implemented;
         }
@@ -276,7 +276,7 @@ function implementedTypesFromCorsaNode(
   }
   const sourceText = sourceTextFor(context, node);
   if (sourceText) {
-    return implementedTypesFromSourceText(node, sourceText, checker);
+    return implementedTypesFromSourceText(context, node, sourceText, checker);
   }
   const type = checker.getTypeAtLocation(node);
   return type ? checker.getImplementedTypesOfType(type) : [];
@@ -356,11 +356,12 @@ function implementedTypesFromTypeDeclaration(
     ? sourceTextForPath(context, declarationNode.fileName)
     : undefined;
   return declarationNode && sourceText
-    ? implementedTypesFromSourceText(declarationNode, sourceText, checker)
+    ? implementedTypesFromSourceText(context, declarationNode, sourceText, checker)
     : [];
 }
 
 function implementedTypesFromSourceText(
+  context: ContextWithParserOptions,
   node: CorsaNode,
   sourceText: string,
   checker: CorsaTypeCheckerShape,
@@ -377,6 +378,7 @@ function implementedTypesFromSourceText(
   if (implementsIndex < 0) {
     return [];
   }
+  const session = sessionForContext(context).session;
   const clauseText = headerText.slice(implementsIndex + "implements".length);
   const clauseStart = node.pos + headerStart + implementsIndex + "implements".length;
   return splitTopLevelRanges(clauseText, ",")
@@ -396,9 +398,17 @@ function implementedTypesFromSourceText(
         range: [pos, end] as const,
       };
       const symbol = checker.getSymbolAtLocation(lookupNode);
-      return symbol
+      const type = symbol
         ? (checker.getDeclaredTypeOfSymbol(symbol) ?? checker.getTypeOfSymbol(symbol))
         : checker.getTypeAtLocation(lookupNode);
+      if (type) {
+        // Implemented-interface handles come back with empty `texts`, so warm
+        // the type-text cache with the `implements` identifier. If upstream
+        // later evicts the handle, `typeToString` falls back to this name
+        // instead of throwing (GH#211).
+        session.rememberTypeText(type.id, raw.slice(leading, raw.length - trailing));
+      }
+      return type;
     })
     .filter((type): type is CorsaType => type !== undefined);
 }

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
@@ -14,6 +14,7 @@ class FakeClient {
     flags: 0,
     texts: ["string"],
   }));
+  readonly typeToString = vi.fn(() => "type:string");
   readonly releaseHandle = vi.fn();
   readonly close = vi.fn();
 
@@ -143,5 +144,45 @@ describe("CorsaProjectSession", () => {
         texts: ["Base"],
       } as never),
     ).toThrow(/unexpected failure/);
+  });
+
+  // Regression for GH#211 crash site 1: implemented-interface handles have
+  // empty `texts`, and upstream Corsa sometimes evicts the handle from its
+  // snapshot registry before typeToString runs. The checker warms the cache
+  // with the `implements` identifier via rememberTypeText, so typeToString
+  // should return that name instead of rethrowing the stale-handle error.
+  it("returns a remembered type text when typeToString hits a stale handle", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    session.getTypeAtPosition("/tmp/one.ts", 0);
+    const client = clients[0];
+    if (!client) {
+      throw new Error("expected a fake client");
+    }
+
+    const type = { id: "type-7", flags: 0, texts: [] as string[] };
+    session.rememberTypeText(type.id, "Serializable");
+    client.typeToString.mockImplementationOnce(() => {
+      throw new Error(
+        'protocol error: api: client error: type handle "type-7" not found in snapshot registry',
+      );
+    });
+
+    expect(session.typeToString(type as never)).toBe("Serializable");
   });
 });

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -212,6 +212,18 @@ export class CorsaProjectSession {
     }
   }
 
+  // Seeds the type-text cache from a name the caller already knows (for
+  // example the identifier in an `implements` clause). Implemented-interface
+  // handles come back with empty `texts`, and upstream Corsa sometimes evicts
+  // them from its snapshot registry before `typeToString` runs, so warming the
+  // cache here lets `typeToString` fall back to the source name instead of
+  // throwing (GH#211). Never overwrites a value the server already provided.
+  rememberTypeText(typeId: string, text: string): void {
+    if (!this.#typeTextById.has(typeId)) {
+      this.#typeTextById.set(typeId, text);
+    }
+  }
+
   getBaseTypeOfLiteralType(type: CorsaType): CorsaType | undefined {
     return this.rememberType(
       this.client().callJson("getBaseTypeOfLiteralType", {

--- a/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
@@ -1,6 +1,6 @@
 use crate::{Result, common, jsonrpc};
 use base64::Engine as _;
-use corsa::jsonrpc::{RawMessage, RequestId};
+use corsa::jsonrpc::{RawMessage, RequestId, RpcResponseError};
 use serde_json::{Value, json};
 use std::{
     fs::{OpenOptions, create_dir_all},
@@ -8,6 +8,11 @@ use std::{
     path::Path,
     time::Duration,
 };
+
+/// Type handle the mock pretends it has evicted from its snapshot registry, so
+/// integration tests can drive the stale-handle degradation path in
+/// `getTypeArguments`.
+const STALE_TYPE_HANDLE: &str = "t00000000000000ff";
 
 pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
     let stdin = std::io::stdin();
@@ -23,6 +28,11 @@ pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
         let id = message.id.clone();
         let params = message.params.unwrap_or(Value::Null);
         record_params(method.as_str(), &params);
+        if let (Some(id), Some(error)) = (id.clone(), stale_handle_error(method.as_str(), &params))
+        {
+            jsonrpc::write_message(&mut writer, &RawMessage::error(id, error))?;
+            continue;
+        }
         let response = match method.as_str() {
             "initialize" => Some(json!({
                 "useCaseSensitiveFileNames": true,
@@ -136,6 +146,24 @@ pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
             jsonrpc::write_message(&mut writer, &RawMessage::response(id, response))?;
         }
     }
+}
+
+fn stale_handle_error(method: &str, params: &Value) -> Option<RpcResponseError> {
+    if method != "getTypeArguments" {
+        return None;
+    }
+    let handle = params.get("type").and_then(Value::as_str)?;
+    if handle != STALE_TYPE_HANDLE {
+        return None;
+    }
+    Some(RpcResponseError {
+        code: -32603,
+        message: format!(
+            "api: client error: type handle \"{handle}\" not found in snapshot registry"
+        )
+        .into(),
+        data: None,
+    })
 }
 
 fn record_params(method: &str, params: &Value) {

--- a/src/bindings/rust/corsa/tests/api_async.rs
+++ b/src/bindings/rust/corsa/tests/api_async.rs
@@ -494,6 +494,50 @@ fn async_api_full_surface_methods() {
     });
 }
 
+#[test]
+fn get_type_arguments_degrades_stale_handle_to_empty() {
+    block_on(async {
+        let client = ApiClient::spawn(support::api_config(ApiMode::AsyncJsonRpcStdio))
+            .await
+            .unwrap();
+        let snapshot = client
+            .update_snapshot(UpdateSnapshotParams {
+                open_project: Some("/workspace/tsconfig.json".into()),
+                file_changes: None,
+                overlay_changes: None,
+            })
+            .await
+            .unwrap();
+        let project = snapshot.projects[0].id.clone();
+
+        // A live handle returns the mock's normal single-element response.
+        let live = client
+            .get_type_arguments(
+                snapshot.handle.clone(),
+                project.clone(),
+                corsa::api::TypeHandle::from("t0000000000000001"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(live.len(), 1);
+
+        // The mock reports this sentinel handle as evicted from its snapshot
+        // registry; the client must degrade that to "no type arguments"
+        // (regression for GH#211) instead of surfacing the error.
+        let stale = client
+            .get_type_arguments(
+                snapshot.handle.clone(),
+                project.clone(),
+                corsa::api::TypeHandle::from("t00000000000000ff"),
+            )
+            .await
+            .unwrap();
+        assert!(stale.is_empty());
+
+        client.close().await.unwrap();
+    });
+}
+
 fn count_lines(path: impl AsRef<std::path::Path>) -> usize {
     fs::read_to_string(path)
         .map(|text| text.lines().count())

--- a/src/core/corsa_client/src/api/client.rs
+++ b/src/core/corsa_client/src/api/client.rs
@@ -531,6 +531,24 @@ impl ApiClient {
         }
     }
 
+    /// Reports whether an error means the server dropped a type handle from its
+    /// snapshot registry.
+    ///
+    /// Upstream Corsa occasionally evicts a live handle mid-session (for
+    /// example after a base-types query on a class with no explicit `extends`
+    /// clause). A follow-up relation query on that handle then fails with
+    /// "type handle ... not found in snapshot registry". Relation endpoints
+    /// treat this as missing data so analysis can continue instead of aborting.
+    /// The message arrives as [`CorsaError::Protocol`] over msgpack and as
+    /// [`CorsaError::Rpc`] over JSON-RPC, so both variants are inspected.
+    pub(crate) fn is_stale_handle_error(error: &CorsaError) -> bool {
+        match error {
+            CorsaError::Rpc(rpc) => is_stale_handle_message(&rpc.message),
+            CorsaError::Protocol(message) => is_stale_handle_message(message),
+            _ => false,
+        }
+    }
+
     async fn request_after_initialize<T, P>(&self, method: &str, params: &P) -> Result<T>
     where
         T: DeserializeOwned,
@@ -639,6 +657,10 @@ fn is_unknown_api_method_message(message: &str) -> bool {
     message.contains("unknown API method")
 }
 
+fn is_stale_handle_message(message: &str) -> bool {
+    message.contains("not found in snapshot registry")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{ApiClient, is_unknown_api_method_message};
@@ -684,5 +706,46 @@ mod tests {
             error,
             CorsaError::Unsupported("file diagnostics are not supported")
         ));
+    }
+
+    #[test]
+    fn recognizes_stale_handle_protocol_error() {
+        assert!(ApiClient::is_stale_handle_error(&CorsaError::Protocol(
+            CompactString::from(
+                "api: client error: type handle \"t0000000000000057\" not found in snapshot registry",
+            ),
+        )));
+    }
+
+    #[test]
+    fn recognizes_stale_handle_rpc_error() {
+        assert!(ApiClient::is_stale_handle_error(&CorsaError::Rpc(
+            RpcResponseError {
+                code: -32603,
+                message: CompactString::from(
+                    "type handle \"t00000000000000c4\" not found in snapshot registry",
+                ),
+                data: None,
+            },
+        )));
+    }
+
+    #[test]
+    fn unrelated_errors_are_not_stale_handles() {
+        assert!(!ApiClient::is_stale_handle_error(&CorsaError::Protocol(
+            CompactString::from("api: client error: unexpected failure"),
+        )));
+        assert!(!ApiClient::is_stale_handle_error(&CorsaError::Rpc(
+            RpcResponseError {
+                code: -32601,
+                message: CompactString::from(
+                    "api: invalid request: unknown API method \"getBaseTypes\"",
+                ),
+                data: None,
+            },
+        )));
+        assert!(!ApiClient::is_stale_handle_error(&CorsaError::Closed(
+            "api"
+        )));
     }
 }

--- a/src/core/corsa_client/src/api/methods_relations.rs
+++ b/src/core/corsa_client/src/api/methods_relations.rs
@@ -158,23 +158,31 @@ impl ApiClient {
 
     /// Returns the type arguments of an instantiated type.
     ///
-    /// Missing server data is normalized to an empty vector.
+    /// Missing server data is normalized to an empty vector. A stale type
+    /// handle that the server has dropped from its snapshot registry is also
+    /// treated as "no type arguments" so callers can keep analyzing the type;
+    /// see [`ApiClient::is_stale_handle_error`].
     pub async fn get_type_arguments(
         &self,
         snapshot: SnapshotHandle,
         project: ProjectHandle,
         r#type: TypeHandle,
     ) -> Result<Vec<TypeResponse>> {
-        self.call::<Option<Vec<TypeResponse>>, _>(
-            "getTypeArguments",
-            TypeProjectRequest {
-                snapshot,
-                project,
-                r#type,
-            },
-        )
-        .await
-        .map(|items| items.unwrap_or_default())
+        match self
+            .call::<Option<Vec<TypeResponse>>, _>(
+                "getTypeArguments",
+                TypeProjectRequest {
+                    snapshot,
+                    project,
+                    r#type,
+                },
+            )
+            .await
+        {
+            Ok(items) => Ok(items.unwrap_or_default()),
+            Err(error) if Self::is_stale_handle_error(&error) => Ok(Vec::new()),
+            Err(error) => Err(error),
+        }
     }
 
     /// Returns the target type underlying an instantiated or mapped type.


### PR DESCRIPTION
## Summary

Fixes the `getImplementedTypesOfType` crash under the tsgo backend (#211).

The tsgo backend can evict a type handle from its snapshot registry after a `getImplementedTypesOfType` / `getBaseTypes` query, so a follow-up relation query on the **same** handle fails with `type handle "…" not found in snapshot registry` and crashes type-aware rules. There are two crash sites:

- **`getTypeArguments`** on the original class type. Fixed in the Rust `corsa_client` layer: a new `is_stale_handle_error` detector (recognizes the error as `Protocol` over msgpack and `Rpc` over JSON-RPC) lets `get_type_arguments` degrade to an empty result instead of propagating the error.
- **`typeToString`** on the handle returned by `getImplementedTypesOfType`. Implemented-interface handles come back with empty `texts`, so the JS type-text cache is cold and a stale handle makes `typeToString` throw. The checker now warms the cache with the `implements` identifier (`rememberTypeText`) so `typeToString` falls back to the source name — no extra server calls.

The Go server in `ref/` is vendored/reference-only, so the fix is graceful degradation in the layers we ship, consistent with the existing GH#206 handling.

## Test plan

- [x] `cargo test -p corsa_client` — new `is_stale_handle_error` unit tests (Protocol + Rpc + negative cases)
- [x] `cargo test -p corsa --test api_async` — new mock sentinel integration test (`get_type_arguments_degrades_stale_handle_to_empty`)
- [x] `vitest` corsa_oxlint suite (98 tests) incl. new session test for the `typeToString` stale-handle fallback
- [x] `cargo clippy -p corsa_client -p corsa --all-targets -- -D warnings`, `cargo fmt --all --check`, and `tsc --noEmit` all clean

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)