### PR TITLE
chore: move repository references to ubugeeei-prod org

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ members = [
 resolver = "2"
 
 [workspace.package]
-documentation = "https://github.com/ubugeeei/corsa-bind/tree/main/docs"
-homepage = "https://github.com/ubugeeei/corsa-bind"
+documentation = "https://github.com/ubugeeei-prod/corsa-bind/tree/main/docs"
+homepage = "https://github.com/ubugeeei-prod/corsa-bind"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/ubugeeei/corsa-bind"
+repository = "https://github.com/ubugeeei-prod/corsa-bind"
 rust-version = "1.85"
 
 [workspace.dependencies]

--- a/docs/build/api.ts
+++ b/docs/build/api.ts
@@ -137,7 +137,7 @@ function renderEntry(entry: ApiEntry): string {
         .join("\n")}`
     : "";
   const returns = entry.returns ? `\n\nReturns: \`${entry.returns}\`` : "";
-  return `## ${entry.name}\n\n${entry.description || "_No documentation comment yet._"}\n\n\`\`\`ts\n${entry.signature}\n\`\`\`\n\n[Source](https://github.com/ubugeeei/corsa-bind/blob/main/${entry.sourcePath}#L${entry.line})${params}${returns}`;
+  return `## ${entry.name}\n\n${entry.description || "_No documentation comment yet._"}\n\n\`\`\`ts\n${entry.signature}\n\`\`\`\n\n[Source](https://github.com/ubugeeei-prod/corsa-bind/blob/main/${entry.sourcePath}#L${entry.line})${params}${returns}`;
 }
 
 function indexPage(pages: MarkdownPage[]): MarkdownPage {

--- a/docs/production_readiness_audit.md
+++ b/docs/production_readiness_audit.md
@@ -15,17 +15,17 @@ status.
 
 | Priority | Issue                                                     | Area               | Status                                                                                    |
 | -------- | --------------------------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------- |
-| P0       | [#94](https://github.com/ubugeeei/corsa-bind/issues/94)   | Orchestrator       | Covered by unbounded result fan-in and regression tests for oversized batches and panics. |
-| P0       | [#98](https://github.com/ubugeeei/corsa-bind/issues/98)   | C ABI              | C strings now carry explicit lengths and tolerate interior NUL bytes.                     |
-| P1       | [#96](https://github.com/ubugeeei/corsa-bind/issues/96)   | JSON-RPC           | Connections now close outbound state and join reader threads with bounded fallback.       |
-| P1       | [#97](https://github.com/ubugeeei/corsa-bind/issues/97)   | Client lifecycle   | Initialize and capability handshakes now use singleflight caching.                        |
-| P1       | [#99](https://github.com/ubugeeei/corsa-bind/issues/99)   | FFI wrappers       | Optional byte payloads now expose explicit error, none, and some status.                  |
-| P1       | [#101](https://github.com/ubugeeei/corsa-bind/issues/101) | oxlint integration | Type-aware sessions send in-memory source overlays when the runtime supports them.        |
-| P1       | [#105](https://github.com/ubugeeei/corsa-bind/issues/105) | Semantic coverage  | Real Corsa positive and negative semantic fixtures are covered in the Rust test suite.    |
-| P2       | [#95](https://github.com/ubugeeei/corsa-bind/issues/95)   | Snapshot cleanup   | Snapshot releases flow through a bounded shared cleanup worker.                           |
-| P2       | [#100](https://github.com/ubugeeei/corsa-bind/issues/100) | Node binding       | Promise-based N-API methods are available for Corsa requests and lifecycle operations.    |
-| P2       | [#102](https://github.com/ubugeeei/corsa-bind/issues/102) | CI coverage        | CI now smoke-checks the supported C ABI, C++ header, and Go wrapper surfaces.             |
-| P2       | [#103](https://github.com/ubugeeei/corsa-bind/issues/103) | Supply chain       | Release and supply-chain workflows now generate SPDX SBOM artifacts.                      |
+| P0       | [#94](https://github.com/ubugeeei-prod/corsa-bind/issues/94)   | Orchestrator       | Covered by unbounded result fan-in and regression tests for oversized batches and panics. |
+| P0       | [#98](https://github.com/ubugeeei-prod/corsa-bind/issues/98)   | C ABI              | C strings now carry explicit lengths and tolerate interior NUL bytes.                     |
+| P1       | [#96](https://github.com/ubugeeei-prod/corsa-bind/issues/96)   | JSON-RPC           | Connections now close outbound state and join reader threads with bounded fallback.       |
+| P1       | [#97](https://github.com/ubugeeei-prod/corsa-bind/issues/97)   | Client lifecycle   | Initialize and capability handshakes now use singleflight caching.                        |
+| P1       | [#99](https://github.com/ubugeeei-prod/corsa-bind/issues/99)   | FFI wrappers       | Optional byte payloads now expose explicit error, none, and some status.                  |
+| P1       | [#101](https://github.com/ubugeeei-prod/corsa-bind/issues/101) | oxlint integration | Type-aware sessions send in-memory source overlays when the runtime supports them.        |
+| P1       | [#105](https://github.com/ubugeeei-prod/corsa-bind/issues/105) | Semantic coverage  | Real Corsa positive and negative semantic fixtures are covered in the Rust test suite.    |
+| P2       | [#95](https://github.com/ubugeeei-prod/corsa-bind/issues/95)   | Snapshot cleanup   | Snapshot releases flow through a bounded shared cleanup worker.                           |
+| P2       | [#100](https://github.com/ubugeeei-prod/corsa-bind/issues/100) | Node binding       | Promise-based N-API methods are available for Corsa requests and lifecycle operations.    |
+| P2       | [#102](https://github.com/ubugeeei-prod/corsa-bind/issues/102) | CI coverage        | CI now smoke-checks the supported C ABI, C++ header, and Go wrapper surfaces.             |
+| P2       | [#103](https://github.com/ubugeeei-prod/corsa-bind/issues/103) | Supply chain       | Release and supply-chain workflows now generate SPDX SBOM artifacts.                      |
 
 ## Readiness Gate
 

--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -164,7 +164,7 @@ long-lived `CARGO_REGISTRY_TOKEN` secret is required after the initial release.
 After the first manual publish of each npm package, configure npm Trusted
 Publishing for each package with:
 
-- GitHub organization or user: `ubugeeei`
+- GitHub organization or user: `ubugeeei-prod`
 - repository: `corsa-bind`
 - workflow filename: `publish-npm.yml`
 - environment: `release`
@@ -244,7 +244,7 @@ vp exec node --strip-types ./scripts/setup_npm_trusted_publish.ts
 
 The npm trusted publisher must match:
 
-- GitHub organization or user: `ubugeeei`
+- GitHub organization or user: `ubugeeei-prod`
 - repository: `corsa-bind`
 - workflow filename: `publish-npm.yml`
 - environment: `release`

--- a/examples/corsa_oxlint/custom_rule.ts
+++ b/examples/corsa_oxlint/custom_rule.ts
@@ -1,7 +1,7 @@
 import { OxlintUtils } from "corsa-oxlint";
 
 const createRule = OxlintUtils.RuleCreator(
-  (name) => `https://github.com/ubugeeei/corsa-bind/tree/main/examples/corsa_oxlint/${name}.ts`,
+  (name) => `https://github.com/ubugeeei-prod/corsa-bind/tree/main/examples/corsa_oxlint/${name}.ts`,
 );
 
 export const noStringPlusNumberRule = createRule({

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "corsa-workspace",
   "private": true,
   "description": "Rust, Node, and orchestration tooling for production-style Corsa workflows",
-  "homepage": "https://github.com/ubugeeei/corsa-bind",
+  "homepage": "https://github.com/ubugeeei-prod/corsa-bind",
   "bugs": {
-    "url": "https://github.com/ubugeeei/corsa-bind/issues"
+    "url": "https://github.com/ubugeeei-prod/corsa-bind/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ubugeeei/corsa-bind.git"
+    "url": "https://github.com/ubugeeei-prod/corsa-bind.git"
   },
   "type": "module",
   "devDependencies": {

--- a/scripts/generate_sbom.ts
+++ b/scripts/generate_sbom.ts
@@ -29,7 +29,7 @@ const document = {
   dataLicense: "CC0-1.0",
   SPDXID: "SPDXRef-DOCUMENT",
   name: `corsa-bind-${target}-sbom`,
-  documentNamespace: `https://github.com/ubugeeei/corsa-bind/sbom/${target}/${now}`,
+  documentNamespace: `https://github.com/ubugeeei-prod/corsa-bind/sbom/${target}/${now}`,
   creationInfo: {
     created: now,
     creators: ["Tool: scripts/generate_sbom.ts"],

--- a/scripts/setup_npm_trusted_publish.ts
+++ b/scripts/setup_npm_trusted_publish.ts
@@ -9,7 +9,7 @@ const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const npxCommand = process.platform === "win32" ? "npx.cmd" : "npx";
 const minimumNpmVersion = "11.10.0";
 const defaultRegistry = "https://registry.npmjs.org";
-const defaultRepository = "ubugeeei/corsa-bind";
+const defaultRepository = "ubugeeei-prod/corsa-bind";
 const defaultWorkflowFile = "publish-npm.yml";
 const defaultEnvironment = "release";
 

--- a/src/bindings/go/corsa_utils/cmd/bench/main.go
+++ b/src/bindings/go/corsa_utils/cmd/bench/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	corsautils "github.com/ubugeeei/corsa-bind/src/bindings/go/corsa_utils"
+	corsautils "github.com/ubugeeei-prod/corsa-bind/src/bindings/go/corsa_utils"
 )
 
 func main() {

--- a/src/bindings/go/corsa_utils/go.mod
+++ b/src/bindings/go/corsa_utils/go.mod
@@ -1,3 +1,3 @@
-module github.com/ubugeeei/corsa-bind/src/bindings/go/corsa_utils
+module github.com/ubugeeei-prod/corsa-bind/src/bindings/go/corsa_utils
 
 go 1.25.0

--- a/src/bindings/moonbit/corsa_utils/moon.mod.json
+++ b/src/bindings/moonbit/corsa_utils/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "ubugeeei/corsa_utils",
   "version": "0.1.0",
   "readme": "README.mbt.md",
-  "repository": "https://github.com/ubugeeei/corsa-bind",
+  "repository": "https://github.com/ubugeeei-prod/corsa-bind",
   "license": "MIT",
   "keywords": ["ffi", "native", "utils", "corsa"],
   "description": "MoonBit wrapper over the Rust-based corsa utils C ABI"

--- a/src/bindings/nodejs/corsa_node/package.json
+++ b/src/bindings/nodejs/corsa_node/package.json
@@ -2,14 +2,14 @@
   "name": "@corsa-bind/napi",
   "version": "0.24.0",
   "description": "Native JS runtime bindings for Corsa stdio workflows",
-  "homepage": "https://github.com/ubugeeei/corsa-bind/tree/main/src/bindings/nodejs/corsa_node",
+  "homepage": "https://github.com/ubugeeei-prod/corsa-bind/tree/main/src/bindings/nodejs/corsa_node",
   "bugs": {
-    "url": "https://github.com/ubugeeei/corsa-bind/issues"
+    "url": "https://github.com/ubugeeei-prod/corsa-bind/issues"
   },
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ubugeeei/corsa-bind.git",
+    "url": "https://github.com/ubugeeei-prod/corsa-bind.git",
     "directory": "src/bindings/nodejs/corsa_node"
   },
   "files": [

--- a/src/bindings/nodejs/corsa_oxlint/package.json
+++ b/src/bindings/nodejs/corsa_oxlint/package.json
@@ -2,14 +2,14 @@
   "name": "corsa-oxlint",
   "version": "0.24.0",
   "description": "Type-aware Oxlint helpers powered by Corsa",
-  "homepage": "https://github.com/ubugeeei/corsa-bind/tree/main/src/bindings/nodejs/corsa_oxlint",
+  "homepage": "https://github.com/ubugeeei-prod/corsa-bind/tree/main/src/bindings/nodejs/corsa_oxlint",
   "bugs": {
-    "url": "https://github.com/ubugeeei/corsa-bind/issues"
+    "url": "https://github.com/ubugeeei-prod/corsa-bind/issues"
   },
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ubugeeei/corsa-bind.git",
+    "url": "https://github.com/ubugeeei-prod/corsa-bind.git",
     "directory": "src/bindings/nodejs/corsa_oxlint"
   },
   "files": [

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/rule_creator.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/rule_creator.ts
@@ -13,7 +13,7 @@ export function createNativeRule(
       ...meta,
       docs: {
         requiresTypeChecking: true,
-        url: `https://github.com/ubugeeei/corsa-bind/tree/main/src/bindings/nodejs/corsa_oxlint/ts/rules/${name.replaceAll("-", "_")}.ts`,
+        url: `https://github.com/ubugeeei-prod/corsa-bind/tree/main/src/bindings/nodejs/corsa_oxlint/ts/rules/${name.replaceAll("-", "_")}.ts`,
         ...(meta.docs as object | undefined),
       },
     },

--- a/src/bindings/nodejs/corsa_oxlint/ts/stylistic.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/stylistic.ts
@@ -83,7 +83,7 @@ function createStylisticRule(ruleName: CorsaStylisticRuleName) {
       docs: {
         description: meta.docsDescription,
         requiresTypeChecking: false,
-        url: `https://github.com/ubugeeei/corsa-bind/tree/main/src/bindings/nodejs/corsa_oxlint/ts/stylistic.ts`,
+        url: `https://github.com/ubugeeei-prod/corsa-bind/tree/main/src/bindings/nodejs/corsa_oxlint/ts/stylistic.ts`,
       },
       fixable: "whitespace",
       hasSuggestions: meta.hasSuggestions,


### PR DESCRIPTION
## Summary

リポジトリが `ubugeeei/corsa-bind` から `ubugeeei-prod/corsa-bind` に移動したため、コードベース内の参照を更新しました。

- repo URL / slug を `ubugeeei-prod/corsa-bind` に更新（Cargo.toml, package.json 各種, docs, scripts, examples, 各 binding）
- Go モジュールパスとインポートを更新（`go.mod` の module 宣言と `cmd/bench/main.go` のインポートを整合）
- MoonBit `moon.mod.json` の `repository` URL を更新
- `docs/release_guide.md` の npm Trusted Publishing の org 表記を `ubugeeei-prod` に更新

### 意図的に据え置いた箇所（「corsa-bind のみ移動」の前提）

- `flake.nix` / `flake.tnix` / `flake.lock` の `github:ubugeeei/tnix`（別リポジトリのため）
- `.github/CODEOWNERS` の `@ubugeeei`（個人アカウントのハンドル）
- `src/bindings/moonbit/corsa_utils/moon.mod.json` の パッケージ名 `ubugeeei/corsa_utils`（mooncakes の名前空間）
- `LICENSE` の著作権表記 `ubugeeei and contributors`

## Test plan

- [ ] `grep -rn "ubugeeei/corsa-bind"` で残存参照がないことを確認
- [ ] Go: `cd src/bindings/go/corsa_utils && go build ./...` が通る
- [ ] npm パッケージの metadata（homepage / repository / bugs）が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)