### PR TITLE
docs: add logo, expand guides, and slim the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,395 +1,108 @@
-# corsa-bind
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./assets/logo-dark.svg">
+    <img alt="corsa-bind" src="./assets/logo.svg" width="320">
+  </picture>
+</p>
 
-Rust bindings, orchestration layers, and JS runtime bindings for Corsa over stdio.
+<p align="center">
+  Rust, Node.js, and native bindings for the upstream Corsa checker — over stdio, with no forks and no patches.
+</p>
+
+---
+
+`corsa-bind` is a multi-crate workspace for talking to [Corsa](https://devblogs.microsoft.com/typescript/typescript-native-port/)
+(the native TypeScript 7 implementation line) from Rust and JavaScript runtimes.
+Hot paths live in Rust and stay zero-cost; `napi-rs` and a shared C ABI surface
+that performance to JS/TS, C, C++, Go, Zig, C#, Swift, and MoonBit — so you can
+author custom checker tooling and lint rules without reimplementing the checker.
 
 > [!WARNING]
-> This repository is still evolving.
-> The local Rust and Node API/LSP surfaces are now hardened for production-style use,
-> but distributed orchestration remains behind the `experimental-distributed`
-> cargo feature and some upstream-facing endpoints remain explicitly experimental.
+> This repository is still evolving. The local Rust and Node API/LSP surfaces
+> are hardened for production-style use, but distributed orchestration stays
+> behind the `experimental-distributed` cargo feature and some upstream-facing
+> endpoints remain explicitly experimental.
 
 > [!IMPORTANT]
-> `corsa-bind` is intentionally built around upstream-supported Corsa
-> workflows. We follow Corsa's recommended stdio/API/LSP integration points,
-> keep `ref/corsa-upstream` as an exact upstream checkout, and preserve a strict
-> `no forks, no patches` policy.
+> `corsa-bind` is built around upstream-supported Corsa workflows. We follow
+> Corsa's recommended stdio/API/LSP integration points, keep
+> `ref/corsa-upstream` as an exact upstream checkout, and preserve a strict
+> **no forks, no patches** policy.
 
-## What This Is
+## Quick start
 
-`corsa-bind` is a multi-crate workspace for talking to Corsa from Rust and JavaScript runtimes without patching upstream, with a Rust-backed native FFI layer that exposes Corsa API, virtual-document, and `utils` surfaces across C-family and other native languages.
-
-## Naming Note
-
-`corsa-bind` is the repository and distribution name for bindings around the
-Corsa effort: the native TypeScript 7 implementation line we track here in the
-`typescript-go` codebase.
-The TypeScript roadmap describes this as the JS-based TypeScript 6 line versus
-the native TypeScript 7 line, and it also uses `Strada` for the original
-TypeScript codename and `Corsa` for this effort:
-[TypeScript Native Port: Versioning Roadmap](https://devblogs.microsoft.com/typescript/typescript-native-port/#versioning-roadmap).
-We keep `corsa` for crate, binary, and upstream-facing labels where that matches
-the implementation surface, instead of the more generic `tsc` or `tsgo` labels
-that are easy to misread in docs, code, and release notes.
-
-In practice, that means:
-
-- use Corsa through the interfaces it already intends consumers to use
-- track upstream by exact commit so behavior is reproducible and auditable
-- never maintain a fork and never carry local patches against Corsa upstream
-- implement hot paths in Rust, keep them zero-cost and high-performance, and
-  expose them to JS through `napi-rs` so end users can author custom plugins
-  and custom rules in JS/TS
-
-Current focus:
-
-- Full Rust-side stdio bindings for the Corsa API
-- stdio LSP bindings with virtual-file support
-- zero-cost-lean hot paths with msgpack-first defaults
-- `napi-rs` bindings that surface Rust performance to JS/TS authoring workflows
-- Rust-backed Corsa API, `utils`, and virtual-document bindings for C, C++, Go, Zig, C#, Swift, and MoonBit
-- local multi-process orchestration, cache reuse, and experimental replicated state
-- strict upstream pinning by exact Corsa upstream commit
-- regression tests and benchmarks against the real pinned upstream server
-
-## Current Status
-
-- License: MIT
-- Upstream policy: `ref/corsa-upstream` is pinned and tracked by exact commit, with no local patching
-- Default API transport: `SyncMsgpackStdio`
-- Runtime: custom in-house runtime, no `tokio`
-- Fast-path bias: `CompactString`, `SmallVec`, `bumpalo`, `memchr`, `phf`, `FxHash`
-- JS toolchain: Vite+ (`vp`) with vp-managed Node `24`, pnpm `10`, `oxfmt`, and `oxlint`
-- Repo automation: `scripts/*.ts` executed directly through Node `24` with `--strip-types`
-- JS bindings: `@corsa-bind/napi` (`src/bindings/nodejs/corsa_node`) and `corsa oxlint` (`src/bindings/nodejs/corsa_oxlint`, published as `corsa-oxlint`) (public npm packages that still expect a caller-managed Corsa executable)
-- Distributed orchestration: `experimental-distributed` cargo feature
-- TS benchmark project: `bench`
-- Example workspace: `examples`
-- Default request timeout: `30s`
-- Default graceful shutdown timeout: `2s`
-- Default outbound queue capacity: `256`
-- Unstable upstream endpoints such as `printNode` are opt-in
-- Structured event sink: `CorsaObserver` / `CorsaEvent`
-
-Corsa upstream snapshot at the time of writing:
-
-- Repository: `https://github.com/microsoft/typescript-go.git`
-- Commit: `f4a1d2a1d0d5df4333f2440500e3a6c4b4702d9a`
-- Lock file: [`corsa_ref.lock.toml`](./corsa_ref.lock.toml), which is the
-  source of truth for the exact upstream ref and tree.
-
-## Sponsors
-
-CI/CD runners for this project are supported by
-[Blacksmith](https://www.blacksmith.sh/).
-
-## Workspace Layout
-
-- `corsa_core`: shared errors, process handles, and fast-path primitives
-- `corsa_jsonrpc`: stdio JSON-RPC framing and connection management
-- `corsa_client`: typed Corsa stdio client bindings for JSON-RPC and msgpack
-- `corsa_lsp`: LSP client support plus virtual-document overlays
-- `corsa_orchestrator`: local orchestration, caching, and experimental replicated state / Raft core
-- `corsa_runtime`: lightweight custom runtime and task primitives
-- `corsa_ref`: exact upstream pin, sync, and verification tooling
-- `corsa`: top-level facade crate, mock server, and native benchmark binaries
-- `src/bindings/c/corsa_ffi`: shared C ABI over the Rust `corsa_client::ApiClient`, `corsa_core::utils`, and `corsa_lsp::VirtualDocument` surfaces
-- `src/bindings/cpp`, `src/bindings/go`, `src/bindings/zig`, `src/bindings/csharp`, `src/bindings/swift`, `src/bindings/moonbit`: thin language bindings layered on top of `corsa_ffi`
-- `src/bindings/nodejs/corsa_node`: `napi-rs` native bindings and the `@corsa-bind/napi` TypeScript wrapper package
-- `src/bindings/nodejs/corsa_oxlint`: type-aware Oxlint rule framework powered by Corsa
-- `bench`: Vitest benchmark project for the Node binding
-- `examples`: curated `examples/nodejs`, `examples/rust`, and `examples/corsa_oxlint` flows from minimal start to real-project runs
-
-For a detailed architecture walkthrough, design strategy, and implementation tips, see [docs/project_guide.md](./docs/project_guide.md).
-The generated Ox Content documentation site starts at [docs/index.md](./docs/index.md).
-For deployment-oriented defaults, supported scope, and release checks, see [docs/production_readiness.md](./docs/production_readiness.md).
-For support guarantees, compatibility, and semver expectations, see [docs/support_policy.md](./docs/support_policy.md).
-For distribution decisions and release dry-runs, see [docs/release_guide.md](./docs/release_guide.md).
-For dependency-policy and release-hardening expectations, see [docs/supply_chain_policy.md](./docs/supply_chain_policy.md).
-
-Once trusted publishing is bootstrapped, a release is cut from `main` with:
-
-```bash
-vp run -w release minor
-```
-
-## Quick Start
-
-Enter the Nix dev shell first. It includes the toolchains for every binding
-target under `src/bindings`:
+Enter the Nix dev shell and build the workspace:
 
 ```bash
 nix develop
 vp install
-```
-
-The Nix shell itself is authored in [`flake.tnix`](./flake.tnix) and compiled
-to [`flake.nix`](./flake.nix) with `tnix`:
-
-```bash
-tnix check-project .
-tnix compile ./flake.tnix -o ./flake.nix
-```
-
-`flake.tnix` is intentionally kept as a thin `tnix` entrypoint, while the full
-outputs implementation lives in [`nix/flake-outputs.nix`](./nix/flake-outputs.nix).
-That split avoids current `tnix` edges around some larger flake constructs.
-See [docs/tnix_notes.md](./docs/tnix_notes.md) for the current limitations and
-the reasoning behind the layout.
-
-Sync and verify the Corsa upstream checkout:
-
-```bash
-vp run -w sync_ref
-vp run -w verify_ref
-```
-
-Build everything through Vite+:
-
-```bash
-vp install
 vp run -w build
-vp check
 ```
 
-Build the Ox Content documentation site and deploy it with Void:
-
-```bash
-vp run -w docs_build
-npx void deploy
-```
-
-Repository automation scripts now assume Node `24` so they can run TypeScript
-directly through `node --strip-types`. The published npm packages themselves
-target Node `22+`, Deno `2.0+`, and Bun `1.2+`.
-
-## Examples
-
-The repository now ships executable examples for Rust, `@corsa-bind/napi`, and
-`corsa oxlint` under [`examples/`](./examples/README.md), from
-minimal virtual-document edits up through checker-query walkthroughs and
-opt-in upstream printer flows.
-
-Run the smoke-tested examples with:
-
-```bash
-vp run -w examples_smoke
-```
-
-Run only the Rust smoke examples with:
-
-```bash
-vp run -w examples_rust_smoke
-```
-
-Run only the Node / TypeScript smoke examples with:
-
-```bash
-vp run -w examples_node_smoke
-```
-
-Run the real pinned Corsa examples with:
-
-```bash
-vp run -w sync_ref
-vp run -w verify_ref
-vp run -w build_corsa
-vp run -w examples_real
-```
-
-Run the experimental distributed Rust example with:
-
-```bash
-vp run -w examples_rust_experimental
-```
-
-## Type-Aware Oxlint
-
-`corsa oxlint` lets us write Oxlint JS plugins with a compact, self-hosted
-type-aware authoring model while sourcing type information from the pinned
-Corsa binary. The heavy lifting stays in Rust, then `napi-rs` binds
-that implementation into JS so end users can keep writing custom plugins and
-custom rules in JS/TS.
-
-```ts
-import { OxlintUtils } from "corsa-oxlint";
-
-const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
-
-export const noStringPlusNumber = createRule({
-  name: "no-string-plus-number",
-  meta: {
-    type: "problem",
-    docs: {
-      description: "forbid string + number",
-      requiresTypeChecking: true,
-    },
-    messages: {
-      unexpected: "string plus number is forbidden",
-    },
-    schema: [],
-  },
-  defaultOptions: [],
-  create(context) {
-    const services = OxlintUtils.getParserServices(context);
-    const checker = services.program.getTypeChecker();
-
-    return {
-      BinaryExpression(node) {
-        if (node.operator !== "+") {
-          return;
-        }
-        const left = checker.getTypeAtLocation(node.left);
-        const right = checker.getTypeAtLocation(node.right);
-        if (!left || !right) {
-          return;
-        }
-        if (
-          checker.typeToString(checker.getBaseTypeOfLiteralType(left) ?? left) === "string" &&
-          checker.typeToString(checker.getBaseTypeOfLiteralType(right) ?? right) === "number"
-        ) {
-          context.report({ node, messageId: "unexpected" });
-        }
-      },
-    };
-  },
-});
-```
-
-The rule-side type-aware config lives under `settings.corsaOxlint`. Package
-details and caveats are documented in [`src/bindings/nodejs/corsa_oxlint/README.md`](./src/bindings/nodejs/corsa_oxlint/README.md).
-
-`corsa oxlint` exposes a TS-native type-aware rule set and plugin via `corsa-oxlint/rules`:
-
-```ts
-import { corsaOxlintPlugin } from "corsa-oxlint/rules";
-
-export default [
-  {
-    plugins: {
-      typescript: corsaOxlintPlugin,
-    },
-    rules: {
-      "typescript/no-floating-promises": "error",
-      "typescript/prefer-promise-reject-errors": "error",
-      "typescript/restrict-plus-operands": ["error", { allowNumberAndString: false }],
-    },
-  },
-];
-```
-
-The rule framework is self-hosted and does not depend on third-party
-TypeScript lint helper packages. Upstream `tsgolint/internal/rules` is now
-used as a parity target and drift oracle rather than as a runtime bridge.
-
-The intended rule architecture has two lanes:
-
-- user-defined type-aware rules keep the `typescript-eslint`-style JS/TS
-  authoring model through `OxlintUtils.RuleCreator()` and parser services
-- common built-in rules can move onto the Rust hot path through
-  `corsa::lint::RustLintRule`, then surface back through the same
-  `corsa-oxlint/rules` Oxlint JS plugin shape
-
-This keeps the public integration point aligned with Oxlint's JS plugin API
-while leaving room for Rust-authored rule crates, in the spirit of swc-style
-Rust extension points. The Rust-authored builtin set now covers the tracked
-upstream `tsgolint/internal/rules` surface exposed by
-`corsa-oxlint/rules`.
-
-## Example
+A first program in Rust — no Corsa binary required:
 
 ```rust
 use corsa::{
-    api::{ApiClient, ApiSpawnConfig},
+    lsp::{VirtualChange, VirtualDocument},
     runtime::block_on,
 };
+use lsp_types::{Position, Range};
 
 fn main() -> Result<(), corsa::CorsaError> {
     block_on(async {
-        let client = ApiClient::spawn(
-            ApiSpawnConfig::new(".cache/corsa")
-                .with_cwd("ref/corsa-upstream/_packages/native-preview"),
-        )
-        .await?;
-
-        let init = client.initialize().await?;
-        println!("{}", init.current_directory);
-
-        client.close().await?;
+        let mut doc =
+            VirtualDocument::untitled("/virtual/minimal.ts", "typescript", "const answer = 41;\n")?;
+        doc.apply_changes(&[VirtualChange::splice(
+            Range::new(Position::new(0, 15), Position::new(0, 17)),
+            "42",
+        )])?;
         Ok(())
     })
 }
 ```
 
-## Benchmarks
-
-The repo ships two benchmark layers:
-
-- Native Rust benchmark: `vp run -w bench_native`
-- Native profiling benchmark: `vp run -w bench_native_profile`
-- Tooling comparison benchmark: `vp run -w bench_tooling_compare`
-- Node binding benchmark: `vp run -w bench_ts`
-- `corsa oxlint` checker benchmark: `vp test bench --config ./vite.config.ts bench/src/corsa_oxlint.bench.ts`
-- `corsa oxlint` native-rule benchmark: `vp test bench --config ./vite.config.ts bench/src/corsa_oxlint_rules.bench.ts`
-- Combined benchmark + budget guard: `vp run -w bench`
-
-The TS benchmark writes machine-readable output to `.cache/bench_ts.json`.
-The native benchmark writes machine-readable output to `.cache/bench_native.json`.
-The native profiling benchmark writes machine-readable output to `.cache/bench_native_profile.json`.
-The native Rust benchmark uses the real pinned Corsa binary through [`bench_real_corsa`](./src/bindings/rust/corsa/src/bin/bench_real_corsa/main.rs).
-
-Latest native measurements are documented in [docs/performance.md](./docs/performance.md).
-Benchmarking rationale, implementation notes, and usage tips are documented in [docs/benchmarking_guide.md](./docs/benchmarking_guide.md).
-CI structure, local reproduction steps, and troubleshooting notes are documented in [docs/ci_guide.md](./docs/ci_guide.md).
-On the exact Corsa upstream commit and bundled datasets, `msgpack` was consistently faster than async JSON-RPC, which is why `ApiSpawnConfig::new()` defaults to `SyncMsgpackStdio`.
-
-## Regression Strategy
-
-The repository is intentionally aggressive about change detection because Corsa upstream is still unstable.
-
-- `cargo test --workspace` includes mock-server integration tests, policy tests, and real-Corsa regression tests when `.cache/corsa` is available
-- `src/bindings/rust/corsa/tests/real_corsa_baseline.rs` locks a real-server API summary to the pinned upstream commit
-- `src/bindings/rust/corsa/tests/real_corsa_regression.rs` checks both transports against the real pinned Corsa binary
-- the real-Corsa regression suite includes a hot-path guard that fails if msgpack falls too far behind JSON-RPC on the same machine
-- `vp run -w bench_native` and `vp run -w bench_ts` give repeatable transport-level measurements for Rust and Node
-- `vp run -w bench_verify` regenerates both reports and fails if benchmark samples disappear or hot-path budgets regress
-- `corsa_ref` enforces detached-HEAD exact-commit verification for `ref/corsa-upstream`
-- CI structure and local reproduction notes live in [`docs/ci_guide.md`](./docs/ci_guide.md)
-
-## Upstream Tracking
-
-Corsa upstream is under heavy development, so reproducibility is treated as a hard requirement.
-
-- exact commit metadata lives in [`corsa_ref.lock.toml`](./corsa_ref.lock.toml)
-- sync and drift tooling lives in [`docs/corsa_upstream_dependency.md`](./docs/corsa_upstream_dependency.md)
-- CI and local reproduction details live in [`docs/ci_guide.md`](./docs/ci_guide.md)
-- `ref/corsa-upstream` must remain on detached `HEAD`
-- dirty upstream worktrees fail verification
-
-## Known Limitations
-
-- Public APIs are still `0.x`, so compatibility should be treated as conservative rather than frozen.
-- `printNode` is disabled by default because the pinned Corsa upstream commit can panic in `internal/printer` on real project data; opt in only when you accept that risk.
-- The distributed layer currently includes an in-process Raft core; full network transport between nodes is not finished yet.
-- Some binary API surfaces are still exposed as opaque encoded payloads rather than fully decoded Rust AST types.
-
-## Development
-
-Useful commands:
-
 ```bash
-vp install
-vp fmt
-vp lint
-vp test
-vp check
-vp run -w build
-vp run -w bench
-vp run -w bench_native
-vp run -w bench_native_profile
-vp run -w bench_ts
-vp run -w bench_verify
-vp test run --config ./vite.config.ts
-vp test bench --config ./vite.config.ts --outputJson .cache/bench_ts.json
-vp run -w sync_ref
-vp run -w verify_ref
+cargo run -p corsa --example minimal_start
 ```
+
+The [Getting started guide](./docs/getting_started.md) covers the Node.js and
+type-aware Oxlint entry points and how to run against the real pinned Corsa
+binary.
+
+## Documentation
+
+Full guides live under [`docs/`](./docs/index.md):
+
+| Guide                                                  | What it covers                                                |
+| ------------------------------------------------------ | ------------------------------------------------------------- |
+| [Getting started](./docs/getting_started.md)           | First program in Rust, Node.js, and Oxlint                    |
+| [Architecture](./docs/project_guide.md)                | Workspace shape, upstream policy, extension points, naming    |
+| [Node.js binding](./docs/nodejs_binding.md)            | `@corsa-bind/napi` for Node, Deno, and Bun                    |
+| [Language bindings](./docs/language_bindings.md)       | The `corsa_ffi` C ABI for C, C++, Go, Zig, C#, Swift, MoonBit |
+| [Type-aware Oxlint](./docs/oxlint_guide.md)            | `corsa-oxlint` rule authoring, native and stylistic rules     |
+| [Performance](./docs/performance.md)                   | Benchmark entry points and measured numbers                   |
+| [CI and local checks](./docs/ci_guide.md)              | Reproduce the GitHub checks locally                           |
+| [Production readiness](./docs/production_readiness.md) | Runtime controls and release gates                            |
+| [Support policy](./docs/support_policy.md)             | Supported platforms, bindings, and experimental scope         |
+
+The generated documentation site starts at [`docs/index.md`](./docs/index.md)
+and is built with `vp run -w docs_build`.
+
+## Status
+
+- **License:** MIT
+- **Upstream:** `ref/corsa-upstream` is pinned by exact commit in
+  [`corsa_ref.lock.toml`](./corsa_ref.lock.toml), with no local patching
+- **Default transport:** `SyncMsgpackStdio` (msgpack-first)
+- **Runtime:** custom in-house runtime, no `tokio`
+- **Published packages:** [`@corsa-bind/napi`](./src/bindings/nodejs/corsa_node)
+  and [`corsa-oxlint`](./src/bindings/nodejs/corsa_oxlint) (both expect a
+  caller-provided Corsa executable)
+- **Distributed orchestration:** behind the `experimental-distributed` cargo feature
+
+Public APIs are still `0.x`, so treat compatibility as conservative. See
+[Known limitations](./docs/support_policy.md) for the current experimental scope.
+
+## Sponsors
+
+CI/CD runners for this project are supported by [Blacksmith](https://www.blacksmith.sh/).

--- a/assets/logo-dark.svg
+++ b/assets/logo-dark.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 252 64" role="img" aria-label="corsa-bind" fill="none">
+  <g stroke="#fafafa" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M20 15 H13 V49 H20" />
+    <path d="M44 15 H51 V49 H44" />
+    <path d="M24 24 L32 32 L24 40" />
+    <path d="M33 24 L41 32 L33 40" />
+  </g>
+  <text x="76" y="41" font-family="ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace" font-size="28" letter-spacing="-0.5">
+    <tspan fill="#fafafa" font-weight="700">corsa</tspan><tspan fill="#a1a1aa" font-weight="500">-bind</tspan>
+  </text>
+</svg>

--- a/assets/logo-mark.svg
+++ b/assets/logo-mark.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="corsa-bind" fill="none">
+  <g stroke="currentColor" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M20 15 H13 V49 H20" />
+    <path d="M44 15 H51 V49 H44" />
+    <path d="M24 24 L32 32 L24 40" />
+    <path d="M33 24 L41 32 L33 40" />
+  </g>
+</svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 252 64" role="img" aria-label="corsa-bind" fill="none">
+  <g stroke="#18181b" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M20 15 H13 V49 H20" />
+    <path d="M44 15 H51 V49 H44" />
+    <path d="M24 24 L32 32 L24 40" />
+    <path d="M33 24 L41 32 L33 40" />
+  </g>
+  <text x="76" y="41" font-family="ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace" font-size="28" letter-spacing="-0.5">
+    <tspan fill="#18181b" font-weight="700">corsa</tspan><tspan fill="#71717a" font-weight="500">-bind</tspan>
+  </text>
+</svg>

--- a/docs/build/html.ts
+++ b/docs/build/html.ts
@@ -9,7 +9,15 @@ const SITE_NAME = "corsa-bind";
 const NAV_GROUPS = [
   {
     title: "Start",
-    routes: ["index.html", "project_guide/index.html"],
+    routes: ["index.html", "getting_started/index.html", "project_guide/index.html"],
+  },
+  {
+    title: "Use",
+    routes: [
+      "nodejs_binding/index.html",
+      "language_bindings/index.html",
+      "oxlint_guide/index.html",
+    ],
   },
   {
     title: "Run",
@@ -41,7 +49,11 @@ const NAV_GROUPS = [
 
 const ROUTE_TITLES = new Map<string, string>([
   ["index.html", "Overview"],
+  ["getting_started/index.html", "Getting started"],
   ["project_guide/index.html", "Architecture"],
+  ["nodejs_binding/index.html", "Node.js binding"],
+  ["language_bindings/index.html", "Language bindings"],
+  ["oxlint_guide/index.html", "Type-aware Oxlint"],
   ["ci_guide/index.html", "CI and local checks"],
   ["performance/index.html", "Performance commands"],
   ["benchmarking_guide/index.html", "Benchmarking model"],
@@ -79,7 +91,7 @@ export function renderHtml(
   <div class="layout">
     <aside class="sidebar">
       <a class="brand" href="/index.html">
-        <span class="brand-mark">cb</span>
+        <span class="brand-mark" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"><path d="M20 15 H13 V49 H20"/><path d="M44 15 H51 V49 H44"/><path d="M24 24 L32 32 L24 40"/><path d="M33 24 L41 32 L33 40"/></svg></span>
         <span>
           <strong>${SITE_NAME}</strong>
           <small>Docs</small>

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,281 @@
+---
+title: Getting started
+description: Install the toolchain and run your first corsa-bind program from Rust, Node.js, and the type-aware Oxlint framework.
+---
+
+# Getting Started
+
+This guide takes you from a clean checkout to a working `corsa-bind` program.
+It covers three entry points:
+
+- the **Rust facade** crate (`corsa`)
+- the **Node.js binding** (`@corsa-bind/napi`)
+- the **type-aware Oxlint** framework (`corsa-oxlint`)
+
+You can complete the first two sections without building the real Corsa
+upstream binary. The [Real pinned Corsa](#run-against-the-real-pinned-corsa)
+section shows how to wire in the actual checker when you want end-to-end
+behavior.
+
+For the bigger picture and design rationale, read the
+[Architecture guide](./project_guide.md). For everything that ships as runnable
+code, see the [examples workspace](https://github.com/ubugeeei/corsa-bind/tree/main/examples).
+
+## 1. Set up the toolchain
+
+`corsa-bind` is a multi-language workspace. The Nix dev shell provides every
+toolchain used by the Rust crates, the Node binding, and the
+[language bindings](./language_bindings.md):
+
+```bash
+nix develop
+vp install
+```
+
+`vp` is [Vite+](https://vite.plus); it manages Node `24`, pnpm, `oxfmt`, and
+`oxlint` for the JS side. The Nix shell is authored in `flake.tnix` and compiled
+to `flake.nix` with `tnix`.
+
+Build the whole workspace once so the native binding and mock server exist:
+
+```bash
+vp run -w build
+```
+
+This produces, among other things:
+
+- the Rust workspace crates
+- the `@corsa-bind/napi` native addon and its TypeScript wrapper
+- the repo-local **mock Corsa binary** used by examples and tests
+
+> [!TIP]
+> The mock binary lets you exercise realistic API and LSP flows without
+> building the real upstream checker. Build only the mock with
+> `vp run -w build_mock`.
+
+## 2. First program in Rust
+
+The `corsa` facade crate re-exports the API client, LSP types, virtual
+documents, and the lightweight runtime. The smallest useful program edits an
+in-memory document — no Corsa binary required:
+
+```rust
+use corsa::{
+    lsp::{VirtualChange, VirtualDocument},
+    runtime::block_on,
+};
+use lsp_types::{Position, Range};
+
+fn main() -> Result<(), corsa::CorsaError> {
+    block_on(async {
+        let mut document =
+            VirtualDocument::untitled("/virtual/minimal.ts", "typescript", "const answer = 41;\n")?;
+
+        let events = document.apply_changes(&[VirtualChange::splice(
+            Range::new(Position::new(0, 15), Position::new(0, 17)),
+            "42",
+        )])?;
+
+        println!("emitted {} change event(s)", events.len());
+        Ok(())
+    })
+}
+```
+
+Run the bundled equivalent directly from the workspace:
+
+```bash
+cargo run -p corsa --example minimal_start
+```
+
+When you want to talk to a checker, spawn an `ApiClient`. Point
+`ApiSpawnConfig` at a cache directory and a working directory that contains a
+Corsa-resolvable project:
+
+```rust
+use corsa::{
+    api::{ApiClient, ApiSpawnConfig},
+    runtime::block_on,
+};
+
+fn main() -> Result<(), corsa::CorsaError> {
+    block_on(async {
+        let client = ApiClient::spawn(
+            ApiSpawnConfig::new(".cache/corsa")
+                .with_cwd("ref/corsa-upstream/_packages/native-preview"),
+        )
+        .await?;
+
+        let init = client.initialize().await?;
+        println!("current directory: {}", init.current_directory);
+
+        client.close().await?;
+        Ok(())
+    })
+}
+```
+
+`ApiSpawnConfig::new()` defaults to the `SyncMsgpackStdio` transport, which is
+the fastest transport on the pinned upstream commit. See the
+[Architecture guide](./project_guide.md) for the crate layout behind these
+types.
+
+## 3. First program in Node.js
+
+Install the published binding into any Node `22+`, Deno `2.0+`, or Bun `1.2+`
+project. The root package is JS-only and pulls in the matching native binary
+through platform-specific optional dependencies:
+
+```bash
+npm i @corsa-bind/napi
+```
+
+The no-binary minimal start mirrors the Rust example — edit a virtual document
+and call the Rust-backed type helpers:
+
+```ts
+import { CorsaVirtualDocument, isUnsafeAssignment } from "@corsa-bind/napi";
+
+const document = CorsaVirtualDocument.untitled(
+  "/virtual/minimal.ts",
+  "typescript",
+  "const answer = 41;\n",
+);
+
+document.applyChanges([
+  {
+    range: { start: { line: 0, character: 15 }, end: { line: 0, character: 17 } },
+    text: "42",
+  },
+]);
+
+console.log(document.state());
+console.log(
+  isUnsafeAssignment({ sourceTypeTexts: ["Set<any>"], targetTypeTexts: ["Set<string>"] }),
+);
+```
+
+To drive a checker, spawn `CorsaApiClient` with the path to a Corsa
+executable. The promise-based methods (`spawnAsync`, `initializeAsync`,
+`updateSnapshotAsync`, `callJsonAsync`, …) are the right choice for services and
+editor integrations; the synchronous variants stay available for short scripts:
+
+```ts
+import { CorsaApiClient } from "@corsa-bind/napi";
+
+const client = CorsaApiClient.spawn({
+  executable: process.env.CORSA_BIN!, // you provide the Corsa binary
+  cwd: process.cwd(),
+  mode: "msgpack",
+});
+
+try {
+  const init = client.initialize();
+  const snapshot = client.updateSnapshot({ openProject: "./tsconfig.json" });
+  const project = snapshot.projects[0];
+  const stringType = client.getStringType(snapshot.snapshot, project.id);
+  console.log(client.typeToString(snapshot.snapshot, project.id, stringType.id));
+} finally {
+  client.close();
+}
+```
+
+> [!IMPORTANT]
+> `@corsa-bind/napi` never bundles a Corsa executable. You must provide a
+> compatible binary and pass its path through `spawn({ executable })`. During
+> development the repo-local mock binary (`vp run -w build_mock`) works for most
+> flows.
+
+The full Node surface — spawn options, sync vs. async, virtual documents,
+`callJson`/`callBinary`, and LSP overlays — is documented in the
+[Node binding guide](./nodejs_binding.md).
+
+## 4. Type-aware Oxlint
+
+`corsa-oxlint` lets you author Oxlint JS plugins with real type information
+sourced from Corsa, keeping the `typescript-eslint`-style authoring model:
+
+```ts
+import { OxlintUtils } from "corsa-oxlint";
+
+const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+
+export const noStringPlusNumber = createRule({
+  name: "no-string-plus-number",
+  meta: {
+    type: "problem",
+    docs: { description: "forbid string + number", requiresTypeChecking: true },
+    messages: { unexpected: "string plus number is forbidden" },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = OxlintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+    return {
+      BinaryExpression(node) {
+        if (node.operator !== "+") return;
+        const left = checker.getTypeAtLocation(node.left);
+        const right = checker.getTypeAtLocation(node.right);
+        if (
+          checker.typeToString(checker.getBaseTypeOfLiteralType(left) ?? left) === "string" &&
+          checker.typeToString(checker.getBaseTypeOfLiteralType(right) ?? right) === "number"
+        ) {
+          context.report({ node, messageId: "unexpected" });
+        }
+      },
+    };
+  },
+});
+```
+
+Type-aware settings live under `settings.corsaOxlint`. The full authoring model,
+native rule set, and stylistic rules are covered in the
+[Oxlint guide](./oxlint_guide.md).
+
+## 5. Explore the examples
+
+The repository ships executable examples for Rust, `@corsa-bind/napi`, and
+`corsa-oxlint`. The smoke-tested set runs without the real upstream binary:
+
+```bash
+vp run -w examples_smoke          # all smoke examples
+vp run -w examples_node_smoke     # Node / TypeScript only
+vp run -w examples_rust_smoke     # Rust only
+```
+
+Run a single example directly:
+
+```bash
+pnpm --dir examples run minimal-start
+cargo run -p corsa --example minimal_start
+```
+
+The [examples README](https://github.com/ubugeeei/corsa-bind/tree/main/examples)
+has a goal-oriented map from minimal edits up through checker queries,
+orchestration, and observability.
+
+## Run against the real pinned Corsa
+
+When you want end-to-end behavior against the exact upstream commit, sync and
+verify the pinned checkout, build the real binary, then run the real examples:
+
+```bash
+vp run -w sync_ref      # materialize ref/corsa-upstream at the pinned commit
+vp run -w verify_ref    # confirm the checkout matches corsa_ref.lock.toml
+vp run -w build_corsa   # build the real Corsa binary into .cache/corsa
+vp run -w examples_real # run the real-snapshot examples
+```
+
+The pinned ref is the source of truth for reproducibility; how it is synced and
+verified is documented in
+[Upstream dependency management](./corsa_upstream_dependency.md).
+
+## Where to go next
+
+- [Architecture](./project_guide.md) — workspace shape, upstream policy, and extension points
+- [Node binding guide](./nodejs_binding.md) — the full `@corsa-bind/napi` surface
+- [Language bindings](./language_bindings.md) — C, C++, Go, Zig, C#, Swift, and MoonBit
+- [Oxlint guide](./oxlint_guide.md) — type-aware and native rule authoring
+- [CI and local checks](./ci_guide.md) — reproduce the GitHub checks locally
+- [Production readiness](./production_readiness.md) — runtime controls and release gates

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,10 +9,24 @@ Rust, Node.js, and integration tooling around the upstream Corsa checker.
 Use this site as the map for architecture, local verification, release work,
 and generated API reference pages.
 
-## Choose a path
+## Start here
 
+- [Getting started](./getting_started.md) takes you from a clean checkout to a
+  first program in Rust, Node.js, and the type-aware Oxlint framework.
 - [Architecture](./project_guide.md) explains the workspace shape, upstream
   policy, and extension points.
+
+## Use the bindings
+
+- [Node.js binding](./nodejs_binding.md) documents the full `@corsa-bind/napi`
+  surface for Node, Deno, and Bun.
+- [Language bindings](./language_bindings.md) covers the `corsa_ffi` C ABI and
+  the C, C++, Go, Zig, C#, Swift, and MoonBit wrappers.
+- [Type-aware Oxlint](./oxlint_guide.md) is the authoring guide for
+  `corsa-oxlint` rules, native rules, and stylistic rules.
+
+## Run and ship
+
 - [CI and local checks](./ci_guide.md) is the shortest path for reproducing
   GitHub checks on a local machine.
 - [Performance commands](./performance.md) lists benchmark entrypoints and the

--- a/docs/language_bindings.md
+++ b/docs/language_bindings.md
@@ -1,0 +1,230 @@
+---
+title: Language bindings
+description: Use the corsa_ffi C ABI from C, C++, Go, Zig, C#, Swift, and MoonBit — build the shared library, link it, and call the utils, API client, and virtual document surfaces.
+---
+
+# Language Bindings (C ABI)
+
+Every non-Node binding is layered on a single shared C ABI crate,
+[`corsa_ffi`](https://github.com/ubugeeei/corsa-bind/tree/main/src/bindings/c/corsa_ffi).
+It exposes the Rust `corsa_client::ApiClient`, `corsa_core::utils`, and
+`corsa_lsp::VirtualDocument` surfaces over a stable C interface, and the thin
+per-language wrappers add idiomatic ergonomics on top.
+
+```
+corsa_client / corsa_core::utils / corsa_lsp        (Rust)
+                  │
+            corsa_ffi  (C ABI: cdylib + staticlib)
+                  │
+   ┌────────┬─────┴──────┬──────┬──────┬──────────┐
+   C       C++          Go     Zig    C#   Swift / MoonBit
+```
+
+The Node.js binding is documented separately in the
+[Node binding guide](./nodejs_binding.md); it uses `napi-rs` rather than this
+C ABI.
+
+## What each binding exposes
+
+All seven language wrappers cover the same three surfaces:
+
+- **Utils** — Rust-backed type-text predicates and splitters
+  (`classify_type_text`, `is_string_like_type_texts`, `split_type_text`, …),
+  with no checker process required.
+- **Virtual document** — in-memory document editing
+  (`untitled`, `apply_changes`, `replace`, `state`).
+- **API client** — spawn a Corsa process and run checker queries
+  (`spawn`, `initialize`, `update_snapshot`, …).
+
+| Language | Wrapper location                   | Header / module                                                   |
+| -------- | ---------------------------------- | ----------------------------------------------------------------- |
+| C        | `src/bindings/c/corsa_ffi`         | `include/corsa_utils.h`                                           |
+| C++      | `src/bindings/cpp`                 | `corsa_api.hpp`, `corsa_utils.hpp`, `corsa_virtual_document.hpp`  |
+| Go       | `src/bindings/go/corsa_utils`      | `github.com/ubugeeei-prod/corsa-bind/src/bindings/go/corsa_utils` |
+| Zig      | `src/bindings/zig`                 | `corsa_api.zig`, `corsa_utils.zig`, `corsa_virtual_document.zig`  |
+| C#       | `src/bindings/csharp/CorsaUtils`   | `CorsaUtils.csproj`                                               |
+| Swift    | `src/bindings/swift/CorsaUtils`    | `Package.swift`                                                   |
+| MoonBit  | `src/bindings/moonbit/corsa_utils` | `moon.pkg.json`                                                   |
+
+> [!IMPORTANT]
+> Like the Node binding, these wrappers do **not** bundle a Corsa executable.
+> The API client surface requires a Corsa binary you provide at runtime. The
+> utils and virtual-document surfaces need no external process.
+
+## Build the shared library
+
+All bindings link against `corsa_ffi`. Build it first; the C ABI crate is
+configured as both a `cdylib` and a `staticlib`:
+
+```bash
+cargo build -p corsa_ffi
+```
+
+This writes the artifacts into the Cargo target directory:
+
+| Platform | Shared library                    | Static library                |
+| -------- | --------------------------------- | ----------------------------- |
+| Linux    | `target/debug/libcorsa_ffi.so`    | `target/debug/libcorsa_ffi.a` |
+| macOS    | `target/debug/libcorsa_ffi.dylib` | `target/debug/libcorsa_ffi.a` |
+| Windows  | `target/debug/corsa_ffi.dll`      | `target/debug/corsa_ffi.lib`  |
+
+The C header lives at
+`src/bindings/c/corsa_ffi/include/corsa_utils.h` and declares the full struct
+set (`CorsaStrRef`, `CorsaString`, `CorsaBytes`, `CorsaApiClient`,
+`CorsaVirtualDocument`, …) and functions.
+
+> [!NOTE]
+> When you link the dynamic library, the loader has to find it at runtime. Add
+> `target/debug` to `LD_LIBRARY_PATH` (Linux) or `DYLD_LIBRARY_PATH` (macOS),
+> or link the static library instead.
+
+## C
+
+Include the header and link the library:
+
+```c
+#include "corsa_utils.h"
+
+int main(void) {
+  CorsaStrRef text = { (const uint8_t *)"string[]", 8 };
+  CorsaString kind = corsa_utils_classify_type_text(text);
+  /* use kind.ptr / kind.len, then free Rust-owned strings via the take APIs */
+  return 0;
+}
+```
+
+```bash
+cargo build -p corsa_ffi
+cc main.c \
+  -I src/bindings/c/corsa_ffi/include \
+  -L target/debug -lcorsa_ffi \
+  -o main
+LD_LIBRARY_PATH=target/debug ./main
+```
+
+Strings returned as `CorsaString` are owned by Rust; release the thread-local
+last-error string with `corsa_error_message_take()` where the API documents it.
+
+## C++
+
+The C++ headers are header-only RAII wrappers over the same ABI. Include the
+headers and add both the `cpp` and C header directories to the include path:
+
+```cpp
+#include "corsa_api.hpp"
+#include "corsa_utils.hpp"
+#include "corsa_virtual_document.hpp"
+
+int main() {
+  auto ref = corsa::utils::to_ref("string");
+  return ref.len == 0 ? 1 : 0;
+}
+```
+
+```bash
+cargo build -p corsa_ffi
+c++ -std=c++20 \
+  -I src/bindings/cpp \
+  -I src/bindings/c/corsa_ffi/include \
+  main.cpp \
+  -L target/debug -lcorsa_ffi \
+  -o main
+```
+
+`corsa::api::corsa_api_client` is move-only and closes the underlying handle in
+its destructor, so client lifetime follows normal RAII scoping.
+
+## Go
+
+The Go module wraps the C ABI with cgo. Build the shared library, then point
+the loader at it:
+
+```bash
+cargo build -p corsa_ffi
+cd src/bindings/go/corsa_utils
+LD_LIBRARY_PATH=$PWD/../../../../target/debug go test ./...
+```
+
+Import it as:
+
+```go
+import corsa "github.com/ubugeeei-prod/corsa-bind/src/bindings/go/corsa_utils"
+```
+
+The package provides the utils predicates plus `VirtualDocument` and
+`ApiClient` types mirroring the Rust surface.
+
+## Zig
+
+The Zig wrapper imports the C header through `@cImport` and exposes typed
+`ApiClient`, `VirtualDocument`, and utils APIs:
+
+```zig
+const corsa = @import("corsa_api.zig");
+
+const client = try corsa.ApiClient.spawn(allocator, .{
+    .executable = "/path/to/corsa",
+    .cwd = ".",
+    .mode = .msgpack,
+});
+defer client.deinit();
+```
+
+`SpawnOptions` mirrors the C ABI spawn options (`executable`, `cwd`, `mode`,
+`request_timeout_ms`, `shutdown_timeout_ms`, `outbound_capacity`,
+`allow_unstable_upstream_calls`). Add `target/debug` to the library search path
+and link `corsa_ffi`.
+
+## C#
+
+The `CorsaUtils` project provides `CorsaUtils`, `CorsaApiClient`, and
+`CorsaVirtualDocument` over P/Invoke:
+
+```bash
+cargo build -p corsa_ffi
+dotnet build src/bindings/csharp/CorsaUtils/CorsaUtils.csproj
+```
+
+Ensure the native loader can find `corsa_ffi` at runtime (set the platform
+library path or copy the shared library next to the managed assembly).
+
+## Swift
+
+The Swift package links `corsa_ffi` from the Cargo target directory:
+
+```bash
+cargo build -p corsa_ffi
+cd src/bindings/swift/CorsaUtils
+swift build
+```
+
+`Package.swift` links the library with `-L ../../../../target/debug
+-lcorsa_ffi`. The `Sources/CorsaUtils` module exposes `CorsaUtils`,
+`CorsaApiClient`, and `CorsaVirtualDocument`.
+
+## MoonBit
+
+The MoonBit package wraps the C ABI through a small C shim (`cwrap.c`):
+
+```bash
+cargo build -p corsa_ffi
+cd src/bindings/moonbit/corsa_utils
+moon test
+```
+
+See `README.mbt.md` in that directory for the MoonBit-specific build details.
+The package mirrors the same utils, API client, and virtual document surfaces.
+
+## How they are verified
+
+CI builds `corsa_ffi`, runs the Go binding tests, and compiles a C++ smoke
+translation unit against the headers in the `non-node-bindings` job. The
+binding benchmark harness (`scripts/bench_bindings.ts`, `vp run -w
+bench_bindings`) builds and links the C, C++, and Go bindings against the same
+shared library. See the [CI guide](./ci_guide.md) for the full job layout.
+
+## See also
+
+- [Node.js binding](./nodejs_binding.md) — the `napi-rs` JavaScript surface
+- [Architecture](./project_guide.md) — where `corsa_ffi` sits in the workspace
+- [Support policy](./support_policy.md) — supported platforms and experimental scope

--- a/docs/nodejs_binding.md
+++ b/docs/nodejs_binding.md
@@ -1,0 +1,265 @@
+---
+title: Node.js binding
+description: Use @corsa-bind/napi from Node.js, Deno, and Bun — spawn options, sync vs. async, virtual documents, checker queries, and the raw call escape hatches.
+---
+
+# Node.js Binding (`@corsa-bind/napi`)
+
+`@corsa-bind/napi` exposes the `corsa` Rust workspace to JavaScript runtimes
+through `napi-rs`. The performance-critical work stays in Rust; the package
+gives you an ergonomic, Promise-friendly TypeScript surface on top.
+
+This guide covers the public API. For the authoring model of type-aware lint
+rules built on the same Rust core, see the [Oxlint guide](./oxlint_guide.md).
+
+## Install
+
+```bash
+npm i @corsa-bind/napi
+```
+
+The published root package is JS-only and pulls in the matching native binary
+through platform-specific optional dependencies. Supported runtimes:
+
+| Runtime | Minimum version |
+| ------- | --------------- |
+| Node.js | `22+`           |
+| Deno    | `2.0+`          |
+| Bun     | `1.2+`          |
+
+Deno needs npm resolution with a local `node_modules` directory and native
+addon permissions:
+
+```bash
+deno run --node-modules-dir=auto --allow-ffi --allow-read --allow-env --allow-run ./main.ts
+```
+
+Bun installs and imports the package directly:
+
+```bash
+bun add @corsa-bind/napi
+bun run ./main.ts
+```
+
+> [!IMPORTANT]
+> The package never bundles a Corsa executable. You must provide a compatible
+> binary yourself and pass its path through `CorsaApiClient.spawn({ executable })`.
+> During local development the repo-local mock binary
+> (`vp run -w build_mock`) is enough for most flows.
+
+## Sync vs. async
+
+Every client method ships in two forms:
+
+- **`*Async` (Promise-based)** — the right choice for production Node services
+  and editor integrations. Work runs off the JavaScript call path.
+- **synchronous** — convenient for short scripts and latency-bounded tooling,
+  but it runs on the JS call path and will block the event loop.
+
+The examples below use the synchronous form for brevity; prepend `Async` and
+`await` for the non-blocking variant.
+
+## Spawning an API client
+
+`CorsaApiClient.spawn(options)` starts a Corsa process and returns a client.
+
+```ts
+import { CorsaApiClient } from "@corsa-bind/napi";
+
+const client = CorsaApiClient.spawn({
+  executable: "/path/to/corsa",
+  cwd: process.cwd(),
+  mode: "msgpack",
+});
+```
+
+### `ApiClientOptions`
+
+| Field                        | Type                     | Default      | Notes                                                          |
+| ---------------------------- | ------------------------ | ------------ | -------------------------------------------------------------- |
+| `executable`                 | `string`                 | _(required)_ | Path to the Corsa binary you provide.                          |
+| `cwd`                        | `string`                 | process cwd  | Working directory the checker resolves projects against.       |
+| `mode`                       | `"jsonrpc" \| "msgpack"` | `"msgpack"`  | Transport. `msgpack` is fastest on the pinned upstream commit. |
+| `requestTimeoutMs`           | `number`                 | `30000`      | Per-request timeout.                                           |
+| `shutdownTimeoutMs`          | `number`                 | `2000`       | Graceful shutdown budget on `close()`.                         |
+| `outboundCapacity`           | `number`                 | `256`        | Outbound request queue capacity.                               |
+| `allowUnstableUpstreamCalls` | `boolean`                | `false`      | Opt in to unstable upstream endpoints such as `printNode`.     |
+
+Always pair a `spawn()` with a `close()` (use `try`/`finally`):
+
+```ts
+try {
+  client.initialize();
+  // ... work ...
+} finally {
+  client.close();
+}
+```
+
+## A complete checker roundtrip
+
+```ts
+import { CorsaApiClient } from "@corsa-bind/napi";
+
+const client = CorsaApiClient.spawn({ executable: process.env.CORSA_BIN!, mode: "jsonrpc" });
+
+let snapshotHandle: string | undefined;
+try {
+  const init = client.initialize();
+
+  const snapshot = client.updateSnapshot({ openProject: "./tsconfig.json" });
+  snapshotHandle = snapshot.snapshot;
+  const project = snapshot.projects[0];
+  if (!project) throw new Error("no project resolved");
+
+  // Read a source file as it sees it.
+  const sourceFile = client.getSourceFile(snapshot.snapshot, project.id, "./src/index.ts");
+  console.log(Buffer.from(sourceFile ?? []).toString("utf8"));
+
+  // Query a type and stringify it.
+  const stringType = client.getStringType(snapshot.snapshot, project.id);
+  console.log(client.typeToString(snapshot.snapshot, project.id, stringType.id));
+
+  console.log("checker cwd:", init.currentDirectory);
+} finally {
+  if (snapshotHandle) client.releaseHandle(snapshotHandle);
+  client.close();
+}
+```
+
+### Snapshots and handles
+
+`updateSnapshot()` returns a `snapshot` handle plus the resolved `projects`.
+Most query methods take `(snapshot, projectId, …)`. Handles are owned by the
+Rust side — release them with `releaseHandle(handle)` when you are done, and
+always `close()` the client.
+
+`updateSnapshot()` accepts:
+
+- `openProject` — a `tsconfig.json` to open
+- `fileChanges` — on-disk file change notifications
+- `overlayChanges` — in-memory overlay edits
+
+## Query methods
+
+All of these have `*Async` counterparts.
+
+| Method                                                   | Returns                                        |
+| -------------------------------------------------------- | ---------------------------------------------- |
+| `initialize()`                                           | `InitializeResponse` (e.g. `currentDirectory`) |
+| `parseConfigFile(file)`                                  | `ConfigResponse`                               |
+| `updateSnapshot(params?)`                                | `{ snapshot, projects }`                       |
+| `getSourceFile(snapshot, project, file)`                 | `Buffer \| null`                               |
+| `getStringType(snapshot, project)`                       | `TypeResponse`                                 |
+| `getTypeAtPosition(snapshot, project, file, position)`   | `TypeResponse \| null`                         |
+| `getSymbolAtPosition(snapshot, project, file, position)` | symbol response                                |
+| `getTypeArguments(snapshot, project, type)`              | type list                                      |
+| `getTypeOfSymbol(snapshot, project, symbol)`             | `TypeResponse \| null`                         |
+| `getDeclaredTypeOfSymbol(snapshot, project, symbol)`     | `TypeResponse \| null`                         |
+| `typeToString(snapshot, project, type)`                  | `string`                                       |
+
+For endpoints without a typed wrapper, drop down to the raw calls below.
+
+## Raw calls (escape hatch)
+
+When you need an endpoint that does not have a dedicated method, call it
+directly. `callJson` is the readable path; `callBinary` returns the raw msgpack
+payload for hot loops.
+
+```ts
+const result = client.callBinary("getSomethingCustom", { snapshot, project: project.id });
+```
+
+`callJson`/`callBinary` are how the advanced `checker_queries` and `raw_calls`
+examples reach symbol, signature, and relation endpoints.
+
+> [!NOTE]
+> `printNode` and other unstable upstream endpoints are disabled unless you
+> pass `allowUnstableUpstreamCalls: true`. The pinned Corsa commit can panic in
+> `internal/printer` on real project data — opt in only when you accept that.
+
+## Virtual documents
+
+`CorsaVirtualDocument` edits in-memory documents without any Corsa process.
+This is the fastest way to prototype rules and editor flows.
+
+```ts
+import { CorsaVirtualDocument } from "@corsa-bind/napi";
+
+const document = CorsaVirtualDocument.untitled(
+  "/virtual/example.ts",
+  "typescript",
+  "const answer = 41;\n",
+);
+
+document.applyChanges([
+  {
+    range: { start: { line: 0, character: 15 }, end: { line: 0, character: 17 } },
+    text: "42",
+  },
+]);
+
+console.log(document.state()); // { uri, languageId, version, text }
+```
+
+- `CorsaVirtualDocument.untitled(path, languageId, text)` — untitled document
+- `CorsaVirtualDocument.inMemory(authority, path, languageId, text)` — authority-scoped document
+- `document.replace(text)` — full-text replace
+- `document.applyChanges(changes)` — incremental LSP-style edits
+- `document.state()` — current `{ uri, languageId, version, text }`
+
+A `VirtualChange` with a `range` splices that range; omit the `range` to replace
+the whole document.
+
+## Type helpers and `Utils`
+
+The binding re-exports the Rust-backed type-text helpers used by the lint layer.
+They work on type-text strings (e.g. `"Promise<any>"`) with no checker process:
+
+```ts
+import { isUnsafeAssignment, isUnsafeReturn, classifyTypeText, Utils } from "@corsa-bind/napi";
+
+isUnsafeAssignment({ sourceTypeTexts: ["Set<any>"], targetTypeTexts: ["Set<string>"] }); // true
+isUnsafeReturn({ sourceTypeTexts: ["Promise<any>"], targetTypeTexts: ["Promise<string>"] });
+classifyTypeText("string[]");
+```
+
+`Utils` groups the predicate family: `isStringLikeTypeTexts`,
+`isNumberLikeTypeTexts`, `isPromiseLikeTypeTexts`, `splitTopLevelTypeText`,
+`splitTypeText`, and friends. The native lint entry points
+(`runNativeLintRule`, `nativeLintRuleMetas`, `runNativeStylisticLint`) are also
+exported here and are what `corsa-oxlint` builds on.
+
+## LSP and distributed orchestration
+
+- The Rust crate `corsa_lsp` provides full LSP client support with virtual
+  document overlays; the Node binding surfaces the document primitives shown
+  above. See the Rust `lsp_overlay` example for the `didOpen`/`didChange`/
+  `didClose` flow.
+- `CorsaDistributedOrchestrator` exposes the experimental replicated-state API
+  (`campaign`, `leaderId`, `openVirtualDocument`, `changeVirtualDocument`). This
+  is behind the experimental distributed work — see
+  [Support policy](./support_policy.md) for its scope.
+
+## Development
+
+Build and test the binding from the workspace:
+
+```bash
+vp install
+vp run -w build_wrapper
+vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_node/ts/**/*.test.ts
+```
+
+Benchmarks for the Node binding:
+
+```bash
+vp run -w bench_ts
+```
+
+## See also
+
+- [Getting started](./getting_started.md) — first program in Node and Rust
+- [Oxlint guide](./oxlint_guide.md) — type-aware rules on the same Rust core
+- [Performance](./performance.md) — transport measurements and benchmark entry points
+- [Examples](https://github.com/ubugeeei/corsa-bind/tree/main/examples) — runnable Node samples

--- a/docs/oxlint_guide.md
+++ b/docs/oxlint_guide.md
@@ -1,0 +1,250 @@
+---
+title: Type-aware Oxlint
+description: Author type-aware Oxlint rules with corsa-oxlint — RuleCreator, parser services, settings.corsaOxlint config, the native rule set, stylistic rules, and RuleTester.
+---
+
+# Type-Aware Oxlint (`corsa-oxlint`)
+
+`corsa-oxlint` is a self-hosted framework for building Oxlint JS plugins with
+real type information powered by Corsa. The performance-critical work lives in
+Rust and is bridged into Node through `@corsa-bind/napi`, while you keep
+authoring custom rules in plain JS/TS with the familiar
+`typescript-eslint`-style model.
+
+> [!WARNING]
+> This package is an early WIP. The core direction is stable, but the API
+> surface will keep moving while Corsa upstream, Oxlint's JS plugin APIs, and
+> the surrounding benchmarks evolve.
+
+## Install
+
+```bash
+npm i corsa-oxlint
+```
+
+The package exposes several entry points:
+
+| Import                                                | Purpose                                                   |
+| ----------------------------------------------------- | --------------------------------------------------------- |
+| `corsa-oxlint`                                        | `OxlintUtils`, `RuleTester`, and compatibility namespaces |
+| `corsa-oxlint/rules`                                  | the built-in TS-native / Rust-backed rule plugin          |
+| `corsa-oxlint/stylistic`                              | the native stylistic rule plugin                          |
+| `corsa-oxlint/ast-utils`, `corsa-oxlint/eslint-utils` | AST and ESLint-style helpers                              |
+
+It also re-exports compatibility namespaces (`ESLintUtils`, `TSESLint`,
+`TSESTree`, `TSUtils`) so existing `typescript-eslint`-style code ports with
+minimal changes, and it does **not** depend on any third-party TypeScript lint
+helper package.
+
+## Authoring a type-aware rule
+
+Use `OxlintUtils.RuleCreator()` to define a rule, then pull type information
+from `getParserServices()`:
+
+```ts
+import { OxlintUtils } from "corsa-oxlint";
+
+const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+
+export const noStringPlusNumber = createRule({
+  name: "no-string-plus-number",
+  meta: {
+    type: "problem",
+    docs: {
+      description: "forbid string + number",
+      requiresTypeChecking: true,
+    },
+    messages: { unexpected: "string plus number is forbidden" },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = OxlintUtils.getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    return {
+      BinaryExpression(node) {
+        if (node.operator !== "+") return;
+        const left = checker.getTypeAtLocation(node.left);
+        const right = checker.getTypeAtLocation(node.right);
+        if (!left || !right) return;
+
+        const leftText = checker.typeToString(checker.getBaseTypeOfLiteralType(left) ?? left);
+        const rightText = checker.typeToString(checker.getBaseTypeOfLiteralType(right) ?? right);
+        if (leftText === "string" && rightText === "number") {
+          context.report({ node, messageId: "unexpected" });
+        }
+      },
+    };
+  },
+});
+```
+
+Setting `requiresTypeChecking: true` is what tells the framework a rule needs
+the type-aware path. The checker object behaves like the TypeScript checker
+(`getTypeAtLocation`, `typeToString`, `getBaseTypeOfLiteralType`, …), but the
+types come from the pinned Corsa binary.
+
+## Configuration: `settings.corsaOxlint`
+
+Oxlint does not expose arbitrary parser options at runtime, so `corsa-oxlint`
+reads its type-aware settings from `settings.corsaOxlint` in your flat config:
+
+```js
+export default [
+  {
+    settings: {
+      corsaOxlint: {
+        parserOptions: {
+          project: ["./tsconfig.json"],
+          tsconfigRootDir: import.meta.dirname,
+          corsa: {
+            executable: "./.cache/corsa", // the Corsa binary you provide
+            mode: "msgpack",
+            requestTimeoutMs: 30000,
+          },
+        },
+      },
+    },
+  },
+];
+```
+
+The `corsa` block maps onto the same runtime controls as the
+[Node binding](./nodejs_binding.md): `executable`, `mode`, `requestTimeoutMs`,
+`shutdownTimeoutMs`, `outboundCapacity`, and `allowUnstableUpstreamCalls`.
+Leaving `allowUnstableUpstreamCalls` unset keeps unstable upstream endpoints
+such as `printNode` disabled.
+
+> [!IMPORTANT]
+> `corsa-oxlint` needs a Corsa binary at the `executable` path. It is not
+> bundled. During development, point it at the repo-local mock
+> (`vp run -w build_mock`) or a real build (`vp run -w build_corsa`).
+
+## Built-in native rules
+
+`corsa-oxlint/rules` exports a ready-made plugin whose rules are implemented in
+Rust and surfaced through the same Oxlint JS plugin shape. Rule parity is
+tracked against upstream `tsgolint/internal/rules`, but the runtime
+implementation lives entirely in this package.
+
+```ts
+import { corsaOxlintPlugin } from "corsa-oxlint/rules";
+
+export default [
+  {
+    plugins: { typescript: corsaOxlintPlugin },
+    rules: {
+      "typescript/no-floating-promises": "error",
+      "typescript/prefer-promise-reject-errors": "error",
+      "typescript/restrict-plus-operands": ["error", { allowNumberAndString: false }],
+    },
+  },
+];
+```
+
+Current coverage is exported from `implementedNativeRuleNames`. It now covers
+the tracked upstream `tsgolint/internal/rules` surface — the unsafe,
+unnecessary, promise/control-flow, preference/style, and type/export families.
+`pendingNativeRuleNames` is intentionally empty, and a test fails if the
+implemented + pending sets drift away from the tracked upstream list.
+
+## Stylistic rules
+
+`corsa-oxlint/stylistic` is a separate path for Rust-backed style rules that do
+**not** need type information. The rules scan the full source text in native
+code, and the JS plugin caches diagnostics per source/config so all enabled
+rules share a single N-API call.
+
+```ts
+import { corsaStylisticPlugin } from "corsa-oxlint/stylistic";
+
+export default [
+  {
+    settings: {
+      corsaStylistic: {
+        rules: {
+          "eol-last": ["always"],
+          "linebreak-style": ["unix"],
+          "no-multiple-empty-lines": [{ max: 1, maxBOF: 0, maxEOF: 1 }],
+          "no-tabs": [{ allowIndentationTabs: false }],
+          "no-trailing-spaces": [{ skipBlankLines: false }],
+          quotes: ["single", { avoidEscape: true }],
+          "unicode-bom": ["never"],
+        },
+      },
+    },
+    plugins: { stylistic: corsaStylisticPlugin },
+    rules: {
+      "stylistic/eol-last": "error",
+      "stylistic/linebreak-style": "error",
+      "stylistic/quotes": "error",
+    },
+  },
+];
+```
+
+Options can be supplied directly in `rules` (for example
+`"stylistic/quotes": ["error", "single"]`). For the fastest multi-rule path,
+put the same option payloads in `settings.corsaStylistic.rules` so the bridge
+batches every configured stylistic rule into one Rust source scan.
+
+## Testing rules with `RuleTester`
+
+`corsa-oxlint` ships a `RuleTester` that injects a temporary project and the
+type-aware config for you:
+
+```ts
+import { RuleTester } from "corsa-oxlint";
+import { noStringPlusNumber } from "./no-string-plus-number.ts";
+
+const tester = new RuleTester();
+
+tester.run("no-string-plus-number", noStringPlusNumber, {
+  valid: [{ code: 'const text = "a" + "b";', settings }],
+  invalid: [
+    {
+      code: 'const broken = "value" + 1;',
+      errors: [{ messageId: "unexpected" }],
+      settings,
+    },
+  ],
+});
+```
+
+`RuleTester.describe` / `RuleTester.it` can be wired to your test runner. See
+the runnable `examples/corsa_oxlint/rule_tester.ts` and
+`native_rule_tester.ts` samples for end-to-end usage against the real pinned
+Corsa binary.
+
+## How the Rust lane works
+
+General-purpose built-in rules are implemented in Rust yet still ship as Oxlint
+JS plugin rules. The bridge is:
+
+1. Oxlint visits the ESTree node in JS.
+2. `corsa-oxlint` collects compact node facts and type texts.
+3. `@corsa-bind/napi` calls `corsa::lint::RustLintRule`.
+4. Rust returns Oxlint-shaped diagnostics, suggestions, and fixes.
+5. The JS rule reports them through `context.report()`.
+
+This keeps the public integration point aligned with Oxlint's JS plugin API
+while leaving room for Rust-authored rule crates. Project-specific rules stay
+in JS/TS via `RuleCreator()`; hot, shared rules can move deeper into Rust as
+the bridge grows.
+
+## Development
+
+```bash
+vp install
+vp run -w build_corsa_oxlint
+vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/**/*.test.ts
+vp test bench --config ./vite.config.ts bench/src/corsa_oxlint.bench.ts
+vp test bench --config ./vite.config.ts bench/src/corsa_oxlint_rules.bench.ts
+```
+
+## See also
+
+- [Node.js binding](./nodejs_binding.md) — the underlying client and runtime controls
+- [Getting started](./getting_started.md) — the quickest first rule
+- [Examples](https://github.com/ubugeeei/corsa-bind/tree/main/examples) — custom-rule, plugin, and native-rules samples

--- a/docs/project_guide.md
+++ b/docs/project_guide.md
@@ -25,6 +25,27 @@ The key idea is simple:
 
 That systems layer is where most of the repository's value lives.
 
+## A Note on the Name
+
+`corsa-bind` is the repository and distribution name for bindings around the
+Corsa effort: the native TypeScript 7 implementation line tracked here in the
+`typescript-go` codebase. The TypeScript roadmap describes this as the JS-based
+TypeScript 6 line versus the native TypeScript 7 line, and it uses `Strada` for
+the original TypeScript codename and `Corsa` for this effort
+([TypeScript Native Port: Versioning Roadmap](https://devblogs.microsoft.com/typescript/typescript-native-port/#versioning-roadmap)).
+
+We keep `corsa` for crate, binary, and upstream-facing labels where that matches
+the implementation surface, instead of the more generic `tsc` or `tsgo` labels
+that are easy to misread in docs, code, and release notes. In practice that
+means:
+
+- use Corsa through the interfaces it already intends consumers to use
+- track upstream by exact commit so behavior is reproducible and auditable
+- never maintain a fork and never carry local patches against Corsa upstream
+- implement hot paths in Rust, keep them zero-cost and high-performance, and
+  expose them to JS through `napi-rs` so end users can author custom plugins
+  and custom rules in JS/TS
+
 ## Non-Negotiable Constraints
 
 Several decisions in the codebase look unusual until you read them through the repository's constraints.


### PR DESCRIPTION
## Summary

Make the docs more comprehensive, add a project logo, and slim the README to a landing page.

### Logo (`assets/`)
- New SVG logo — a speed/chevron mark (`[ »» ]`: code brackets + double chevron) with a monospace wordmark, matched to the zinc monochrome docs theme.
- Three variants: `logo.svg` (light lockup), `logo-dark.svg` (dark backgrounds), `logo-mark.svg` (square mark, `currentColor`).
- The docs site brand mark now renders the SVG instead of the `cb` text placeholder.

### New guides (`docs/`)
User-facing docs were thin; added four written against the real APIs, examples, and CI:
- **Getting started** — clean checkout → first program in Rust, Node.js, and Oxlint → running against the real pinned Corsa.
- **Node.js binding** — full `@corsa-bind/napi` surface: spawn options, sync vs. async, snapshots/handles, query methods, raw calls, virtual documents, runtime support.
- **Language bindings** — the `corsa_ffi` C ABI and per-language setup for C, C++, Go, Zig, C#, Swift, and MoonBit.
- **Type-aware Oxlint** — `corsa-oxlint` rule authoring, `settings.corsaOxlint`, native rules, stylistic rules, and `RuleTester`.

These are surfaced in the docs nav (new **Use** group in `docs/build/html.ts`) and in `docs/index.md`.

### README
Trimmed from ~396 to ~110 lines: logo, tagline, the two policy callouts, a minimal quick start, a documentation table, and status. Detailed sections moved into the guides; the naming rationale now lives in the Architecture guide so no information is lost.

## Verification
- `vp run -w docs_build` builds all pages, including the four new guides.
- `vp fmt` and `vp lint` pass (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)