### PR TITLE
fix(lint): satisfy clippy 1.96 collapsible_if (unblock release publish)

### DIFF
--- a/src/core/corsa_core/src/lint/rules/no_confusing_void_expression.rs
+++ b/src/core/corsa_core/src/lint/rules/no_confusing_void_expression.rs
@@ -233,12 +233,11 @@ fn find_invalid_ancestor(chain: &[Ancestor<'_>], opts: Options) -> Option<usize>
                     return None;
                 }
             }
-            "UnaryExpression" => {
+            "UnaryExpression"
                 // The TS-ESTree representation of the `void` operator.
-                if parent.operator() == Some("void") && opts.ignore_void_operator {
+                if parent.operator() == Some("void") && opts.ignore_void_operator => {
                     return None;
                 }
-            }
             _ => {}
         }
         break;

--- a/src/core/corsa_core/src/lint/rules/no_misused_promises.rs
+++ b/src/core/corsa_core/src/lint/rules/no_misused_promises.rs
@@ -202,10 +202,8 @@ impl RustLintRule for NoMisusedPromisesRule {
             }
 
             // ---- checksSpreads ----
-            "SpreadElement" => {
-                if opts.checks_spreads {
-                    check_spread(ctx, node);
-                }
+            "SpreadElement" if opts.checks_spreads => {
+                check_spread(ctx, node);
             }
             _ => {}
         }

--- a/src/core/corsa_core/src/lint/rules/prefer_nullish_coalescing.rs
+++ b/src/core/corsa_core/src/lint/rules/prefer_nullish_coalescing.rs
@@ -86,10 +86,8 @@ impl RustLintRule for PreferNullishCoalescingRule {
                     check_ternary(ctx, node, &opts);
                 }
             }
-            "IfStatement" => {
-                if !opts.ignore_if_statements {
-                    check_if_statement(ctx, node, &opts);
-                }
+            "IfStatement" if !opts.ignore_if_statements => {
+                check_if_statement(ctx, node, &opts);
             }
             _ => {}
         }

--- a/src/core/corsa_core/src/lint/rules/require_await.rs
+++ b/src/core/corsa_core/src/lint/rules/require_await.rs
@@ -116,14 +116,13 @@ fn scope_has_await(node: &LintNode) -> bool {
                 found = true;
             }
             // `return <thenable>` inside an async function counts as await.
-            "ReturnStatement" => {
+            "ReturnStatement"
                 if candidate
                     .child("argument")
                     .map(strip_chain_expression)
-                    .is_some_and(is_thenable_expression)
-                {
-                    found = true;
-                }
+                    .is_some_and(is_thenable_expression) =>
+            {
+                found = true;
             }
             _ => {}
         }


### PR DESCRIPTION
Linear-history rebase of #224 (which carried a merge commit and was blocked by the linear-history policy).

## Summary

The v0.27.0 release **Publish npm** and **Publish Rust** jobs failed at `Release Gates → Lint Rust`: Rust 1.96's clippy denies `collapsible_if`/`collapsible_match` under `-D warnings`. Collapses the inner `if` guards into their `match` arms in `no_confusing_void_expression`, `no_misused_promises`, `prefer_nullish_coalescing`, and `require_await`.

## Verification (stable 1.96.0)
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test -p corsa_core --lib`: 377 passed
- `cargo fmt --check`: clean

Unblocks a v0.27.1 release (v0.27.0 publish never completed).