### PR TITLE
fix(docs): disable iOS Safari text autosizing in code blocks

### DIFF
--- a/docs/build/site.css
+++ b/docs/build/site.css
@@ -22,6 +22,14 @@ html {
   background: var(--page);
   color-scheme: light;
   scroll-behavior: smooth;
+  /*
+   * Disable iOS Safari's text autosizing. Without this, Safari "boosts" the
+   * font of code/pre blocks (especially after orientation change or when the
+   * block is wider than the viewport), making code suddenly render larger
+   * than the 14px we pin below.
+   */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 body {


### PR DESCRIPTION
## Summary
- iOS Safari boosts the font of `pre` / `code` blocks (especially after orientation change, or when a fenced block is wider than the viewport), so code rendered "suddenly larger" than the 14px pin added in #223.
- Set `-webkit-text-size-adjust: 100%` and the standard `text-size-adjust: 100%` on `html` in `docs/build/site.css` so Safari honors the theme's explicit sizing.

## Test plan
- [ ] Open the deployed docs on iOS Safari (portrait and landscape) and confirm fenced code blocks stay at 14px after orientation changes
- [ ] Re-check a page with both language-tagged and bare fenced blocks (e.g. `docs/index.md`) — both should match

🤖 Generated with [Claude Code](https://claude.com/claude-code)