### PR TITLE
release: v0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "corsa"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "base64",
  "corsa_client",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_client"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "base64",
  "corsa_core",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "base64",
  "bumpalo",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_ffi"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "corsa_client",
  "corsa_core",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_jsonrpc"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "corsa_core",
  "corsa_runtime",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_lsp"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "corsa_core",
  "corsa_jsonrpc",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_node"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "corsa",
  "lsp-types",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_orchestrator"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "corsa_client",
  "corsa_core",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_ref"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "corsa_core",
  "serde",
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_runtime"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "smallvec",
 ]

--- a/src/bindings/c/corsa_ffi/Cargo.toml
+++ b/src/bindings/c/corsa_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_ffi"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 description = "C ABI for corsa utils, intended as the shared base for multi-language bindings"
 publish = false
@@ -15,10 +15,10 @@ rust-version.workspace = true
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-corsa_client = { version = "0.27.0", path = "../../../core/corsa_client" }
-corsa_core = { version = "0.27.0", path = "../../../core/corsa_core" }
-corsa_lsp = { version = "0.27.0", path = "../../../core/corsa_lsp" }
-corsa_runtime = { version = "0.27.0", path = "../../../core/corsa_runtime" }
+corsa_client = { version = "0.28.0", path = "../../../core/corsa_client" }
+corsa_core = { version = "0.28.0", path = "../../../core/corsa_core" }
+corsa_lsp = { version = "0.28.0", path = "../../../core/corsa_lsp" }
+corsa_runtime = { version = "0.28.0", path = "../../../core/corsa_runtime" }
 lsp-types = "0.97"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/bindings/nodejs/corsa_node/Cargo.toml
+++ b/src/bindings/nodejs/corsa_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_node"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 license.workspace = true
 publish = false
@@ -22,7 +22,7 @@ napi = { version = "3", default-features = false, features = [
 napi-derive = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-corsa = { version = "0.27.0", path = "../../rust/corsa", features = ["experimental-distributed"] }
+corsa = { version = "0.28.0", path = "../../rust/corsa", features = ["experimental-distributed"] }
 
 [build-dependencies]
 napi-build = "2"

--- a/src/bindings/nodejs/corsa_node/package.json
+++ b/src/bindings/nodejs/corsa_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsa-bind/napi",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Native JS runtime bindings for Corsa stdio workflows",
   "homepage": "https://github.com/ubugeeei-prod/corsa-bind/tree/main/src/bindings/nodejs/corsa_node",
   "bugs": {

--- a/src/bindings/nodejs/corsa_oxlint/package.json
+++ b/src/bindings/nodejs/corsa_oxlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsa-oxlint",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Type-aware Oxlint helpers powered by Corsa",
   "homepage": "https://github.com/ubugeeei-prod/corsa-bind/tree/main/src/bindings/nodejs/corsa_oxlint",
   "bugs": {

--- a/src/bindings/rust/corsa/Cargo.toml
+++ b/src/bindings/rust/corsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 description = "Production-oriented Rust bindings, orchestration layers, and Node integration for Corsa"
 publish = ["crates-io"]
@@ -80,12 +80,12 @@ required-features = ["experimental-distributed"]
 base64 = "0.22"
 lsp-types = "0.97"
 serde_json = "1"
-corsa_client = { version = "0.27.0", path = "../../../core/corsa_client" }
-corsa_core = { version = "0.27.0", path = "../../../core/corsa_core" }
-corsa_jsonrpc = { version = "0.27.0", path = "../../../core/corsa_jsonrpc" }
-corsa_lsp = { version = "0.27.0", path = "../../../core/corsa_lsp" }
-corsa_orchestrator = { version = "0.27.0", path = "../../../core/corsa_orchestrator" }
-corsa_runtime = { version = "0.27.0", path = "../../../core/corsa_runtime" }
+corsa_client = { version = "0.28.0", path = "../../../core/corsa_client" }
+corsa_core = { version = "0.28.0", path = "../../../core/corsa_core" }
+corsa_jsonrpc = { version = "0.28.0", path = "../../../core/corsa_jsonrpc" }
+corsa_lsp = { version = "0.28.0", path = "../../../core/corsa_lsp" }
+corsa_orchestrator = { version = "0.28.0", path = "../../../core/corsa_orchestrator" }
+corsa_runtime = { version = "0.28.0", path = "../../../core/corsa_runtime" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/core/corsa_client/Cargo.toml
+++ b/src/core/corsa_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_client"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 description = "Typed stdio API client bindings for Corsa"
 publish = ["crates-io"]
@@ -23,6 +23,6 @@ parking_lot = "0.12"
 phf = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-corsa_core = { version = "0.27.0", path = "../corsa_core" }
-corsa_jsonrpc = { version = "0.27.0", path = "../corsa_jsonrpc" }
-corsa_runtime = { version = "0.27.0", path = "../corsa_runtime" }
+corsa_core = { version = "0.28.0", path = "../corsa_core" }
+corsa_jsonrpc = { version = "0.28.0", path = "../corsa_jsonrpc" }
+corsa_runtime = { version = "0.28.0", path = "../corsa_runtime" }

--- a/src/core/corsa_core/Cargo.toml
+++ b/src/core/corsa_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_core"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 description = "Shared errors, process lifecycle helpers, and fast-path primitives for corsa"
 publish = ["crates-io"]

--- a/src/core/corsa_jsonrpc/Cargo.toml
+++ b/src/core/corsa_jsonrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_jsonrpc"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 description = "JSON-RPC framing and thread-backed transport helpers for corsa"
 publish = ["crates-io"]
@@ -20,5 +20,5 @@ log = { workspace = true }
 parking_lot = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-corsa_core = { version = "0.27.0", path = "../corsa_core" }
-corsa_runtime = { version = "0.27.0", path = "../corsa_runtime" }
+corsa_core = { version = "0.28.0", path = "../corsa_core" }
+corsa_runtime = { version = "0.28.0", path = "../corsa_runtime" }

--- a/src/core/corsa_lsp/Cargo.toml
+++ b/src/core/corsa_lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_lsp"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 description = "LSP-focused clients, overlays, and virtual documents for Corsa"
 publish = ["crates-io"]
@@ -20,6 +20,6 @@ log = { workspace = true }
 lsp-types = "0.97"
 parking_lot = "0.12"
 serde = { version = "1", features = ["derive"] }
-corsa_core = { version = "0.27.0", path = "../corsa_core" }
-corsa_jsonrpc = { version = "0.27.0", path = "../corsa_jsonrpc" }
-corsa_runtime = { version = "0.27.0", path = "../corsa_runtime" }
+corsa_core = { version = "0.28.0", path = "../corsa_core" }
+corsa_jsonrpc = { version = "0.28.0", path = "../corsa_jsonrpc" }
+corsa_runtime = { version = "0.28.0", path = "../corsa_runtime" }

--- a/src/core/corsa_orchestrator/Cargo.toml
+++ b/src/core/corsa_orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_orchestrator"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 description = "Worker pooling, caching, and experimental replicated orchestration for corsa"
 publish = ["crates-io"]
@@ -25,7 +25,7 @@ lsp-types = "0.97"
 parking_lot = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-corsa_client = { version = "0.27.0", path = "../corsa_client" }
-corsa_core = { version = "0.27.0", path = "../corsa_core" }
-corsa_lsp = { version = "0.27.0", path = "../corsa_lsp" }
-corsa_runtime = { version = "0.27.0", path = "../corsa_runtime" }
+corsa_client = { version = "0.28.0", path = "../corsa_client" }
+corsa_core = { version = "0.28.0", path = "../corsa_core" }
+corsa_lsp = { version = "0.28.0", path = "../corsa_lsp" }
+corsa_runtime = { version = "0.28.0", path = "../corsa_runtime" }

--- a/src/core/corsa_ref/Cargo.toml
+++ b/src/core/corsa_ref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_ref"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 description = "Pinned upstream ref management and verification tooling for corsa"
 publish = false
@@ -22,7 +22,7 @@ path = "src/main.rs"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 toml = "1.1"
-corsa_core = { version = "0.27.0", path = "../corsa_core" }
+corsa_core = { version = "0.28.0", path = "../corsa_core" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/core/corsa_runtime/Cargo.toml
+++ b/src/core/corsa_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_runtime"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 description = "Small executor, task primitives, and broadcast channels for corsa"
 publish = ["crates-io"]


### PR DESCRIPTION
## Summary

Minor version bump **0.27.0 → 0.28.0** across all crate manifests, the Node package manifests, and `Cargo.lock` (13 files, the same shape as the prior `release: v0.27.0` commit — version fields only).

This release carries:
- the native `@stylistic` engine — **7 → 42 rules** with a differential conformance harness against the real `@stylistic` plugin (#228), and
- the stylistic-vs-upstream throughput benchmark (#229, ~20× faster).

## Release runbook (after this and #229 are merged)

Versions are already bumped here, so do **not** run `vp run -w release minor` (it would re-bump to 0.29.0). Instead:

1. Merge #229, then this PR, into `main`.
2. Tag the merge commit and push the tag to trigger publishing:
   ```bash
   git fetch && git checkout main && git pull
   git tag v0.28.0
   git push <release-remote> v0.28.0      # triggers publish-npm.yml + publish-rust.yml
   ```
   `publish-npm.yml` asserts the tag matches the workspace version (0.28.0 == 0.28.0) before publishing `@corsa-bind/napi` + `corsa-oxlint`; `github-release.yml` then drafts the GitHub release.
3. Deploy the docs (needs `@void/md` + void credentials):
   ```bash
   vp install
   vp run -w docs_build
   vp run -w docs_deploy
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)