### PR TITLE
fix(docs): redesign the landing hero into a two-column intro

### DIFF
--- a/docs/build/html.ts
+++ b/docs/build/html.ts
@@ -104,9 +104,7 @@ export function renderHtml(
   const pageUrl = `${SITE_URL}/${page.route === "index.html" ? "" : page.route}`;
   const ogImage = `${SITE_URL}${ogImagePath}`;
   const isHome = page.route === "index.html";
-  const mainContent = isHome
-    ? `${renderHero(description)}${rewriteMarkdownLinks(compiled.html)}`
-    : rewriteMarkdownLinks(compiled.html);
+  const body = rewriteMarkdownLinks(compiled.html);
   return `<!doctype html>
 <html lang="en" data-theme="light">
 <head>
@@ -144,8 +142,9 @@ export function renderHtml(
       </a>
       <nav aria-label="Documentation">${renderNav(nav, page.route)}</nav>
     </aside>
-    <div class="content-shell">
-      <main class="void-md${isHome ? " is-home" : ""}">${mainContent}</main>
+    <div class="content-shell${isHome ? " is-home-shell" : ""}">
+      ${isHome ? renderHero(description) : ""}
+      <main class="void-md${isHome ? " is-home" : ""}">${body}</main>
       ${renderPager(nav, page.route)}
     </div>
   </div>
@@ -153,23 +152,42 @@ export function renderHtml(
 </html>`;
 }
 
-/** The landing-page hero rendered above the Markdown overview content. */
-function renderHero(description: string): string {
+/** The landing-page hero: a two-column intro with a live code sample. */
+function renderHero(_description: string): string {
   const mark = `<svg viewBox="0 0 64 64" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"><path d="M20 15 H13 V49 H20"/><path d="M44 15 H51 V49 H44"/><path d="M24 24 L32 32 L24 40"/><path d="M33 24 L41 32 L33 40"/></svg>`;
+  const k = (text: string) => `<span class="tk-k">${text}</span>`;
+  const s = (text: string) => `<span class="tk-s">${escapeHtml(text)}</span>`;
+  const p = (text: string) => `<span class="tk-p">${escapeHtml(text)}</span>`;
+  const code = [
+    `${k("import")} { corsaStylisticPlugin } ${k("from")} ${s('"corsa-oxlint/stylistic"')}${p(";")}`,
+    ``,
+    `${k("export")} ${k("default")} ${p("[{")}`,
+    `  plugins${p(":")} { stylistic${p(":")} corsaStylisticPlugin }${p(",")}`,
+    `  rules${p(":")} ${p("{")}`,
+    `    ${s('"stylistic/quotes"')}${p(":")} ${p("[")}${s('"error"')}${p(",")} ${s('"single"')}${p("],")}`,
+    `    ${s('"stylistic/comma-dangle"')}${p(":")} ${p("[")}${s('"error"')}${p(",")} ${s('"always-multiline"')}${p("],")}`,
+    `  ${p("},")}`,
+    `${p("}];")}`,
+  ].join("\n");
   return `<header class="hero">
-    <span class="hero-mark" aria-hidden="true">${mark}</span>
-    <h1 class="hero-title"><span>corsa</span><span class="hero-title-dim">-bind</span></h1>
-    <p class="hero-tagline">${escapeHtml(description)}</p>
-    <div class="hero-actions">
-      <a class="hero-button primary" href="/getting_started/">Get started</a>
-      <a class="hero-button" href="https://github.com/ubugeeei/corsa-bind">GitHub ↗</a>
+    <div class="hero-copy">
+      <span class="hero-eyebrow"><span class="hero-mark" aria-hidden="true">${mark}</span>Rust · Node · C ABI</span>
+      <h1 class="hero-title"><span>corsa</span><span class="hero-title-dim">-bind</span></h1>
+      <p class="hero-tagline">Type-aware Oxlint, a stdio API&nbsp;+ LSP, and zero-cost hot paths for the <strong>Corsa</strong> TypeScript checker — no forks, no patches.</p>
+      <div class="hero-actions">
+        <a class="hero-button primary" href="/getting_started/">Get started</a>
+        <a class="hero-button" href="https://github.com/ubugeeei/corsa-bind">GitHub<span class="hero-arrow" aria-hidden="true">↗</span></a>
+      </div>
+      <ul class="hero-badges" aria-label="Highlights">
+        <li>42 native stylistic rules</li>
+        <li>~20× faster than @stylistic</li>
+        <li>type-aware lint in Rust</li>
+      </ul>
     </div>
-    <ul class="hero-badges" aria-label="Highlights">
-      <li>type-aware Oxlint</li>
-      <li>stdio API + LSP</li>
-      <li>zero-cost hot paths</li>
-      <li>no forks, no patches</li>
-    </ul>
+    <figure class="hero-code" aria-label="corsa-oxlint stylistic config example">
+      <figcaption class="hero-code-bar"><span></span><span></span><span></span><em>eslint.config.js</em></figcaption>
+      <pre><code>${code}</code></pre>
+    </figure>
   </header>`;
 }
 

--- a/docs/build/site.css
+++ b/docs/build/site.css
@@ -512,38 +512,55 @@ nav a[aria-current="page"] {
  * Landing hero
  * ------------------------------------------------------------------------- */
 
+/* The home page widens the content column so the hero can run two-up. */
+.content-shell.is-home-shell {
+  width: min(100%, 1200px);
+}
+
 .hero {
-  margin: 4px 0 56px;
-  padding-bottom: 44px;
+  display: grid;
+  grid-template-columns: minmax(0, 0.82fr) minmax(0, 1fr);
+  align-items: center;
+  gap: 48px;
+  margin: 0 0 56px;
+  padding: 8px 0 56px;
   border-bottom: 1px solid var(--border);
-  text-align: center;
+}
+
+.hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 11px;
+  font-family: var(--vmd-font-mono, ui-monospace, Menlo, monospace);
+  font-size: 13px;
+  letter-spacing: 0.3px;
+  color: var(--muted);
 }
 
 .hero-mark {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 76px;
-  height: 76px;
-  margin-bottom: 26px;
+  width: 32px;
+  height: 32px;
   color: var(--ink);
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 18px;
+  border-radius: 9px;
   box-shadow: 0 1px 2px rgb(24 24 27 / 6%);
 }
 
 .hero-mark svg {
-  width: 38px;
-  height: 38px;
+  width: 17px;
+  height: 17px;
 }
 
 .hero-title {
-  margin: 0;
+  margin: 22px 0 0;
   font-family: var(--vmd-font-mono, ui-monospace, Menlo, monospace);
-  font-size: 64px;
+  font-size: clamp(46px, 5.4vw, 66px);
   font-weight: 700;
-  letter-spacing: -2px;
+  letter-spacing: -2.5px;
   line-height: 1;
   color: var(--ink);
 }
@@ -554,19 +571,23 @@ nav a[aria-current="page"] {
 }
 
 .hero-tagline {
-  max-width: 600px;
-  margin: 22px auto 0;
+  max-width: 30em;
+  margin: 22px 0 0;
   color: var(--ink-soft);
-  font-size: 20px;
-  line-height: 1.55;
+  font-size: 18px;
+  line-height: 1.6;
+}
+
+.hero-tagline strong {
+  color: var(--ink);
+  font-weight: 600;
 }
 
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  justify-content: center;
-  margin-top: 32px;
+  margin-top: 30px;
 }
 
 .hero-button {
@@ -597,24 +618,93 @@ nav a[aria-current="page"] {
   background: var(--accent-hover);
 }
 
+.hero-arrow {
+  margin-left: 7px;
+  color: var(--faint);
+}
+
+.hero-button.primary .hero-arrow {
+  color: rgb(255 255 255 / 60%);
+}
+
 .hero-badges {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  justify-content: center;
-  margin: 36px 0 0;
+  margin: 30px 0 0;
   padding: 0;
   list-style: none;
 }
 
 .hero-badges li {
-  padding: 6px 14px;
+  padding: 6px 13px;
   border: 1px solid var(--border);
   border-radius: 999px;
   background: var(--surface-muted);
   color: var(--muted);
   font-family: var(--vmd-font-mono, ui-monospace, Menlo, monospace);
+  font-size: 12.5px;
+}
+
+/* Code sample card */
+.hero-code {
+  margin: 0;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface);
+  overflow: hidden;
+  box-shadow: 0 24px 48px -28px rgb(24 24 27 / 22%);
+}
+
+.hero-code-bar {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 12px 16px;
+  background: var(--surface-muted);
+  border-bottom: 1px solid var(--border);
+}
+
+.hero-code-bar span {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--border-strong);
+}
+
+.hero-code-bar em {
+  margin-left: 9px;
+  font-style: normal;
+  font-family: var(--vmd-font-mono, ui-monospace, Menlo, monospace);
+  font-size: 12.5px;
+  color: var(--muted);
+}
+
+.hero-code pre {
+  margin: 0;
+  padding: 20px 22px;
+  overflow-x: auto;
+}
+
+.hero-code code {
+  font-family: var(--vmd-font-mono, ui-monospace, Menlo, monospace);
   font-size: 13px;
+  line-height: 1.75;
+  color: var(--ink);
+  white-space: pre;
+}
+
+.hero-code .tk-k {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.hero-code .tk-s {
+  color: var(--muted);
+}
+
+.hero-code .tk-p {
+  color: var(--faint);
 }
 
 /* The hero already states the title and tagline, so drop the Markdown
@@ -624,12 +714,23 @@ nav a[aria-current="page"] {
   display: none;
 }
 
+@media (max-width: 1080px) {
+  .hero {
+    grid-template-columns: 1fr;
+    gap: 36px;
+  }
+
+  .hero-code {
+    max-width: 640px;
+  }
+}
+
 @media (max-width: 640px) {
-  .hero-title {
-    font-size: 46px;
+  .hero {
+    padding-bottom: 40px;
   }
 
   .hero-tagline {
-    font-size: 17px;
+    font-size: 16.5px;
   }
 }


### PR DESCRIPTION
## Summary

The landing hero was a single **cramped, centered column** crammed inside the 760px reading width — flat and generic. This reworks it into a proper dev-tool landing.

- The hero now renders as a **sibling of the Markdown body** (not inside the 760px column), and the home content shell widens to ~1200px so it can run **two-up**.
- **Left column:** an eyebrow with the brand mark (`Rust · Node · C ABI`), the `corsa-bind` wordmark, a tagline, primary + secondary CTAs, and highlight chips (`42 native stylistic rules`, `~20× faster than @stylistic`, `type-aware lint in Rust`).
- **Right column:** a windowed **code card** (`eslint.config.js`) showing a real `corsa-oxlint/stylistic` config, with subtle monochrome token coloring (keywords / strings / punctuation).
- Collapses to a single stacked column under 1080px.

Only `docs/build/html.ts` + `docs/build/site.css` change.

## Verification

The docs site build (`@void/md`) isn't available in the authoring environment, so the hero was verified by rasterizing it with the headless Chromium shell at wide and narrow widths — the two-column layout fits with no code overflow, and the stacked layout reflows cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)