### PR TITLE
docs: render Mermaid diagrams client-side

### DIFF
--- a/docs/build/html.ts
+++ b/docs/build/html.ts
@@ -148,8 +148,35 @@ export function renderHtml(
       ${renderPager(nav, page.route)}
     </div>
   </div>
+  ${mermaidScript()}
 </body>
 </html>`;
+}
+
+/**
+ * Client-side Mermaid renderer. The static pipeline emits ```mermaid fences as
+ * ordinary `language-mermaid` code blocks; this turns them into rendered SVG in
+ * the browser. Mermaid is only fetched on pages that actually contain a
+ * diagram, and the source is read from the inner `<code>` so the language label
+ * and copy button never leak into the graph definition.
+ */
+function mermaidScript(): string {
+  return `<script type="module">
+  const wrappers = [...document.querySelectorAll('[class*="language-mermaid"]')]
+    .filter((el) => !(el.parentElement && el.parentElement.closest('[class*="language-mermaid"]')));
+  if (wrappers.length) {
+    const mermaid = (await import('https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs')).default;
+    mermaid.initialize({ startOnLoad: false, theme: 'neutral', securityLevel: 'strict' });
+    for (const wrapper of wrappers) {
+      const code = wrapper.querySelector('code') ?? wrapper;
+      const pre = document.createElement('pre');
+      pre.className = 'mermaid';
+      pre.textContent = code.textContent.replace(/\\n+$/, '');
+      wrapper.replaceWith(pre);
+    }
+    await mermaid.run({ querySelector: 'pre.mermaid' });
+  }
+</script>`;
 }
 
 /** The landing-page hero: a two-column intro with a live code sample. */

--- a/docs/build/site.css
+++ b/docs/build/site.css
@@ -334,6 +334,21 @@ nav a[aria-current="page"] {
   font-size: 0.9em;
 }
 
+/* Mermaid diagrams, rendered client-side from `language-mermaid` blocks. */
+.void-md .mermaid {
+  margin: 26px 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  text-align: center;
+  line-height: 0;
+}
+
+.void-md .mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+
 .void-md table {
   display: block;
   width: 100%;


### PR DESCRIPTION
## Summary

The architecture `flowchart` in `project_guide.md` showed as a **raw code block** — the static docs pipeline emits ```mermaid fences as ordinary `language-mermaid` blocks and nothing rendered them.

This adds a small module script (in `html.ts`) that:
- finds `language-mermaid` blocks and reads the diagram source from the inner `<code>` (so the `mermaid` language label and **Copy** button never leak into the definition),
- replaces each with `<pre class="mermaid">`,
- dynamically imports **Mermaid 11** from jsDelivr and runs it — **only on pages that actually contain a diagram** (no fetch otherwise),
- uses `theme: 'neutral'` + `securityLevel: 'strict'`.

A `.mermaid` CSS rule centers the rendered SVG, makes it responsive, and drops the code-block chrome.

## Verification

The docs build (`@void/md`) isn't available in the authoring environment, so the fix was verified by rasterizing the rendered page (the `project_guide` flowchart) with the headless Chromium shell — the diagram renders centered within the normal page layout, and the label/copy chrome does not corrupt it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)