### PR TITLE
ci: add blacksmith benchmark testbox

### DIFF
--- a/.github/workflows/blacksmith-testbox.yml
+++ b/.github/workflows/blacksmith-testbox.yml
@@ -1,0 +1,74 @@
+name: Blacksmith Testbox
+
+on:
+  workflow_dispatch:
+    inputs:
+      testbox_id:
+        description: Blacksmith Testbox session ID
+        required: false
+        type: string
+      api_url:
+        description: Blacksmith API URL override
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: blacksmith-testbox-${{ github.workflow }}-${{ github.ref }}-${{ inputs.testbox_id || github.run_id }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bench:
+    name: Benchmark Testbox
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 120
+    steps:
+      - name: Begin Blacksmith Testbox
+        uses: useblacksmith/begin-testbox@233448af4bfdc6fca509a7f0974411ac6d8a8043 # v2
+        with:
+          testbox_id: ${{ inputs.testbox_id }}
+          api_url: ${{ inputs.api_url }}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Sync pinned Corsa ref
+        run: cargo run -p corsa_ref --target-dir .cache/corsa-ref-target -- sync
+
+      - name: Setup Go for pinned Corsa ref
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: ref/corsa-upstream/go.mod
+          cache: false
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version: "24"
+          cache: true
+          run-install: true
+
+      - name: Hydrate benchmark build outputs
+        run: |
+          vp run -w build_corsa
+          vp run -w build_corsa_oxlint
+
+      - name: Install tooling benchmark dependencies
+        run: vp run -w bench_tooling_setup
+
+      - name: Run Blacksmith Testbox
+        if: ${{ always() }}
+        uses: useblacksmith/run-testbox@5ca05834db1d3813554d1dd109e5f2087a8d7cbc # v2

--- a/bench/src/publish_workflows.test.ts
+++ b/bench/src/publish_workflows.test.ts
@@ -70,4 +70,17 @@ describe("publish workflows", () => {
     );
     expect(workflow).toContain("node --strip-types ./scripts/pr_benchmark_report.ts comment");
   });
+
+  it("hydrates a Blacksmith Testbox for benchmark work", () => {
+    const workflow = readWorkflow(".github/workflows/blacksmith-testbox.yml");
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("testbox_id:");
+    expect(workflow).toContain("runs-on: blacksmith-32vcpu-ubuntu-2404");
+    expect(workflow).toMatch(/uses: useblacksmith\/begin-testbox@[a-f0-9]{40} # v2/);
+    expect(workflow).toMatch(/uses: useblacksmith\/run-testbox@[a-f0-9]{40} # v2/);
+    expect(workflow).toContain("vp run -w build_corsa");
+    expect(workflow).toContain("vp run -w build_corsa_oxlint");
+    expect(workflow).toContain("vp run -w bench_tooling_setup");
+    expect(workflow).not.toContain("vp run -w bench_verify");
+  });
 });

--- a/docs/ci_guide.md
+++ b/docs/ci_guide.md
@@ -54,6 +54,12 @@ The workflow uploads the four benchmark reports as artifacts, then updates one
 sticky PR comment with faster, slower, and stable rows. Rows within 3% are marked
 stable to avoid treating benchmark noise as a regression.
 
+The Blacksmith Testbox workflow lives in
+[`../.github/workflows/blacksmith-testbox.yml`](../.github/workflows/blacksmith-testbox.yml).
+It is `workflow_dispatch`-only and hydrates the benchmark environment on a
+`blacksmith-32vcpu-ubuntu-2404` runner without running timed benchmarks during
+warmup.
+
 ## `quality`
 
 The `quality` job answers:
@@ -155,6 +161,46 @@ nix develop -c sh -c 'vp run -w bench_verify'
 
 Using `sh -c` instead of a login shell matters here.
 It makes the tool resolution deterministic, especially for `go`, which would otherwise be shadowed by a preexisting shell profile on some machines.
+
+## Blacksmith Testbox
+
+Blacksmith Testbox is the CI-parity path for broad Linux checks and benchmark
+work from a local worktree. The workflow sets up Rust, Go, Node `24`, Vite+,
+the pinned Corsa ref, the native Corsa binary, the `corsa-oxlint` package, and
+tooling benchmark dependencies. It intentionally stops before `bench_verify` or
+`bench_tooling_compare`; those measured commands should be run through the warm
+testbox so their output belongs to the current local diff.
+
+Warm a benchmark testbox from the repository root:
+
+```bash
+blacksmith testbox warmup blacksmith-testbox.yml --job bench --idle-timeout 90
+```
+
+For the first rollout, the workflow file must exist on the default branch before
+GitHub exposes it through `workflow_dispatch`.
+Blacksmith resolves the repository from the local git remote, so `origin` must
+point at a repository in the authenticated Blacksmith org.
+
+Then reuse the returned ID for benchmark commands:
+
+```bash
+blacksmith testbox run --id <tbx_id> "vp run -w bench_verify"
+blacksmith testbox run --id <tbx_id> "vp run -w bench_tooling_compare"
+```
+
+If dependency manifests or benchmark setup changed after warmup, run the setup
+inside the same box before measuring:
+
+```bash
+blacksmith testbox run --id <tbx_id> "vp run -w bench_tooling_setup"
+```
+
+Stop the box when it is no longer needed:
+
+```bash
+blacksmith testbox stop --id <tbx_id>
+```
 
 ## Reproducing the Full Workflow
 

--- a/nix/flake-outputs.nix
+++ b/nix/flake-outputs.nix
@@ -29,6 +29,24 @@ in
             runHook postInstall
           '';
         };
+      # Blacksmith CLI (testbox / sticky disk). Distributed as a single Go
+      # binary; pinned to the `latest` channel like moonbit above. The CLI's
+      # background auto-update can't write into the read-only Nix store, so it
+      # degrades to a warning and keeps running — bump the hash to upgrade.
+      blacksmith = pkgs.stdenvNoCC.mkDerivation {
+        pname = "blacksmith";
+        version = "latest";
+        src = pkgs.fetchurl {
+          url = "https://clireleases.blacksmith.sh/cli/latest/darwin/arm64/blacksmith";
+          hash = "sha256-ozZ6tBUbEqTqdxUVwxSg1ItiKUwLZxMl1Ccx8r6XP2Y=";
+        };
+        dontUnpack = true;
+        installPhase = ''
+          runHook preInstall
+          install -Dm755 $src $out/bin/blacksmith
+          runHook postInstall
+        '';
+      };
       vitePlusRuntimePnpmDeps = pkgs.fetchPnpmDeps {
         pname = "vite-plus-runtime";
         version = vitePlusVersion;
@@ -93,6 +111,7 @@ in
       default = vitePlus;
       moonbit = moonbit;
       vite-plus = vitePlus;
+      blacksmith = blacksmith;
     });
 
   devShells = forAllSystems (system:
@@ -100,6 +119,7 @@ in
       pkgs = import nixpkgs { inherit system; };
       vitePlus = self.packages.${system}.vite-plus;
       moonPkg = self.packages.${system}.moonbit;
+      blacksmithPkg = self.packages.${system}.blacksmith;
       swiftPkg = pkgs.swift;
       dotnetPkg = pkgs.dotnet-sdk_9;
       tnixCli = tnix.packages.${system}.tnix;
@@ -108,6 +128,7 @@ in
         pkgs.libiconv
       ];
       toolchainPath = lib.makeBinPath [
+        blacksmithPkg
         pkgs.cargo
         pkgs.clang
         pkgs.clippy
@@ -116,7 +137,9 @@ in
         pkgs.go_1_26
         pkgs.gnugrep
         moonPkg
+        pkgs.openssh
         pkgs.pkg-config
+        pkgs.rsync
         pkgs.rustc
         pkgs.rustfmt
         swiftPkg
@@ -129,6 +152,7 @@ in
       default = pkgs.mkShell {
         packages = [
           vitePlus
+          blacksmithPkg
           pkgs.cargo
           pkgs.clang
           pkgs.clippy
@@ -138,7 +162,9 @@ in
           pkgs.gnugrep
           pkgs.libiconv
           moonPkg
+          pkgs.openssh
           pkgs.pkg-config
+          pkgs.rsync
           pkgs.rustc
           pkgs.rustfmt
           swiftPkg


### PR DESCRIPTION
## Summary

- add a workflow_dispatch-only Blacksmith Testbox workflow for benchmark warmup on the 32 vCPU Ubuntu runner
- hydrate Rust, Go, Node 24, Vite+, the pinned Corsa ref, native build outputs, and tooling benchmark dependencies before the box becomes ready
- document the benchmark Testbox flow, default-branch bootstrap note, and git remote/org requirement
- add a workflow regression test for the Testbox setup

## Verification

- `vp fmt --check`
- `vp test run --config ./vite.config.ts bench/src/publish_workflows.test.ts`
- `git diff --check`
- `ruby -e 'require "psych"; Psych.parse_file(".github/workflows/blacksmith-testbox.yml"); puts "yaml ok"'`
- `actrun lint .github/workflows/blacksmith-testbox.yml --online` was attempted, but this actrun version rejects `workflow_dispatch` workflows with `only push and workflow_call triggers are supported in MVP`.
