### PR TITLE
ci: add Blacksmith sticky disk caches

### DIFF
--- a/.github/actions/blacksmith-sticky-cache/action.yml
+++ b/.github/actions/blacksmith-sticky-cache/action.yml
@@ -1,0 +1,65 @@
+name: Blacksmith Sticky Cache
+description: Mount hot CI caches on Blacksmith sticky disks.
+
+inputs:
+  suffix:
+    description: Stable job-specific suffix for sticky disk keys.
+    required: true
+  cargo-target:
+    description: Mount the Rust target directory.
+    required: false
+    default: "true"
+  corsa-ref-target:
+    description: Mount the cargo target directory used by the corsa_ref helper.
+    required: false
+    default: "false"
+  go-build:
+    description: Mount the repo-local Go build cache.
+    required: false
+    default: "false"
+  npm-cache:
+    description: Mount the npm package cache.
+    required: false
+    default: "false"
+  pnpm-store:
+    description: Mount the pnpm package store.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Mount Cargo target sticky disk
+      if: ${{ runner.os == 'Linux' && inputs.cargo-target == 'true' }}
+      uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+      with:
+        key: ${{ github.repository }}-${{ inputs.suffix }}-${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.lock') }}
+        path: target
+
+    - name: Mount corsa_ref target sticky disk
+      if: ${{ runner.os == 'Linux' && inputs.corsa-ref-target == 'true' }}
+      uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+      with:
+        key: ${{ github.repository }}-${{ inputs.suffix }}-${{ runner.os }}-corsa-ref-target-${{ hashFiles('Cargo.lock', 'corsa_ref.lock.toml') }}
+        path: .cache/corsa-ref-target
+
+    - name: Mount Go build sticky disk
+      if: ${{ runner.os == 'Linux' && inputs.go-build == 'true' }}
+      uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+      with:
+        key: ${{ github.repository }}-${{ inputs.suffix }}-${{ runner.os }}-go-build-${{ hashFiles('corsa_ref.lock.toml') }}
+        path: .cache/go-build
+
+    - name: Mount npm cache sticky disk
+      if: ${{ runner.os == 'Linux' && inputs.npm-cache == 'true' }}
+      uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+      with:
+        key: ${{ github.repository }}-${{ inputs.suffix }}-${{ runner.os }}-npm-cache-${{ hashFiles('ref/corsa-upstream/package-lock.json', 'bench/cli_compare/package-lock.json') }}
+        path: ~/.npm
+
+    - name: Mount pnpm store sticky disk
+      if: ${{ runner.os == 'Linux' && inputs.pnpm-store == 'true' }}
+      uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+      with:
+        key: ${{ github.repository }}-${{ inputs.suffix }}-${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+        path: ~/.local/share/pnpm/store

--- a/.github/workflows/blacksmith-testbox.yml
+++ b/.github/workflows/blacksmith-testbox.yml
@@ -39,11 +39,22 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mount Blacksmith sticky caches
+        uses: ./.github/actions/blacksmith-sticky-cache
+        with:
+          suffix: blacksmith-testbox-bench
+          corsa-ref-target: "true"
+          go-build: "true"
+          npm-cache: "true"
+          pnpm-store: "true"
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-targets: false
 
       - name: Sync pinned Corsa ref
         run: cargo run -p corsa_ref --target-dir .cache/corsa-ref-target -- sync
@@ -58,7 +69,7 @@ jobs:
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
-          cache: true
+          cache: ${{ runner.os != 'Linux' }}
           run-install: true
 
       - name: Hydrate benchmark build outputs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mount Blacksmith sticky caches
+        uses: ./.github/actions/blacksmith-sticky-cache
+        with:
+          suffix: ci-js-format
+          cargo-target: "false"
+          pnpm-store: "true"
+
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
-          cache: true
+          cache: ${{ runner.os != 'Linux' }}
           run-install: true
 
       - name: Check JS and TS formatting
@@ -48,11 +55,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mount Blacksmith sticky caches
+        uses: ./.github/actions/blacksmith-sticky-cache
+        with:
+          suffix: ci-js-lint-types
+          cargo-target: "false"
+          pnpm-store: "true"
+
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
-          cache: true
+          cache: ${{ runner.os != 'Linux' }}
           run-install: true
 
       - name: Check JS and TS lint and types
@@ -86,6 +100,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mount Blacksmith sticky caches
+        uses: ./.github/actions/blacksmith-sticky-cache
+        with:
+          suffix: ci-rust-lint
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
@@ -94,6 +113,7 @@ jobs:
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Lint Rust
@@ -113,12 +133,19 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mount Blacksmith sticky caches
+        uses: ./.github/actions/blacksmith-sticky-cache
+        with:
+          suffix: ci-build-${{ matrix.os }}
+          pnpm-store: "true"
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-targets: ${{ runner.os != 'Linux' }}
           shared-key: workspace
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
@@ -126,7 +153,7 @@ jobs:
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
-          cache: true
+          cache: ${{ runner.os != 'Linux' }}
           run-install: true
 
       - name: Setup Deno
@@ -159,12 +186,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mount Blacksmith sticky caches
+        uses: ./.github/actions/blacksmith-sticky-cache
+        with:
+          suffix: ci-test-${{ matrix.os }}
+          corsa-ref-target: "true"
+          pnpm-store: "true"
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-targets: ${{ runner.os != 'Linux' }}
           shared-key: workspace
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
@@ -172,7 +207,7 @@ jobs:
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
-          cache: true
+          cache: ${{ runner.os != 'Linux' }}
           run-install: true
 
       - name: Test workspace
@@ -188,12 +223,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mount Blacksmith sticky caches
+        uses: ./.github/actions/blacksmith-sticky-cache
+        with:
+          suffix: ci-public-facade
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build mock Corsa binary
@@ -212,12 +253,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mount Blacksmith sticky caches
+        uses: ./.github/actions/blacksmith-sticky-cache
+        with:
+          suffix: ci-non-node-bindings
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup Go for Go binding
@@ -321,12 +368,21 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mount Blacksmith sticky caches
+        uses: ./.github/actions/blacksmith-sticky-cache
+        with:
+          suffix: ci-real-corsa-smoke-${{ matrix.os }}
+          corsa-ref-target: "true"
+          go-build: "true"
+          pnpm-store: "true"
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-targets: ${{ runner.os != 'Linux' }}
           shared-key: corsa-ref
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
@@ -345,7 +401,7 @@ jobs:
           node-version: "24"
           # Windows can fail inside setup-vp's dependency cache resolver after
           # the managed Corsa upstream checkout has been materialized.
-          cache: ${{ runner.os != 'Windows' }}
+          cache: ${{ runner.os != 'Linux' && runner.os != 'Windows' }}
           run-install: true
 
       - name: Build pinned Corsa binary

--- a/.github/workflows/pr-performance.yml
+++ b/.github/workflows/pr-performance.yml
@@ -64,14 +64,45 @@ jobs:
           ref: ${{ steps.bench-ref.outputs.sha }}
           persist-credentials: false
 
+      - name: Mount Cargo target sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-pr-performance-${{ matrix.ref-role }}-ts${{ matrix.typescript.channel }}-${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.lock') }}
+          path: target
+
+      - name: Mount corsa_ref target sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-pr-performance-${{ matrix.ref-role }}-ts${{ matrix.typescript.channel }}-${{ runner.os }}-corsa-ref-target-${{ hashFiles('Cargo.lock', 'corsa_ref.lock.toml') }}
+          path: .cache/corsa-ref-target
+
+      - name: Mount Go build sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-pr-performance-${{ matrix.ref-role }}-ts${{ matrix.typescript.channel }}-${{ runner.os }}-go-build-${{ hashFiles('corsa_ref.lock.toml') }}
+          path: .cache/go-build
+
+      - name: Mount npm cache sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-pr-performance-${{ matrix.ref-role }}-ts${{ matrix.typescript.channel }}-${{ runner.os }}-npm-cache-${{ hashFiles('ref/corsa-upstream/package-lock.json', 'bench/cli_compare/package-lock.json') }}
+          path: ~/.npm
+
+      - name: Mount pnpm store sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-pr-performance-${{ matrix.ref-role }}-ts${{ matrix.typescript.channel }}-${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          path: ~/.local/share/pnpm/store
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          # main の real-corsa-smoke が温めた corsa ビルドキャッシュを復元し、
-          # PR ごとのコールドビルドを避ける(PR では保存せず汚染を防ぐ)。
+          cache-targets: false
+          # Sticky Disk owns target/ on Blacksmith; rust-cache keeps Cargo
+          # registry/git data warm without saving PR build outputs.
           shared-key: corsa-ref
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
@@ -105,7 +136,7 @@ jobs:
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
-          cache: true
+          cache: ${{ runner.os != 'Linux' }}
           run-install: true
 
       - name: Build pinned Corsa binary

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -46,6 +46,30 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           persist-credentials: false
 
+      - name: Mount Cargo target sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-publish-npm-release-gates-${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.lock') }}
+          path: target
+
+      - name: Mount corsa_ref target sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-publish-npm-release-gates-${{ runner.os }}-corsa-ref-target-${{ hashFiles('Cargo.lock', 'corsa_ref.lock.toml') }}
+          path: .cache/corsa-ref-target
+
+      - name: Mount Go build sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-publish-npm-release-gates-${{ runner.os }}-go-build-${{ hashFiles('corsa_ref.lock.toml') }}
+          path: .cache/go-build
+
+      - name: Mount pnpm store sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-publish-npm-release-gates-${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          path: ~/.local/share/pnpm/store
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
@@ -53,6 +77,8 @@ jobs:
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-targets: false
 
       - name: Sync pinned Corsa ref
         run: cargo run -p corsa_ref --target-dir .cache/corsa-ref-target -- sync
@@ -67,7 +93,7 @@ jobs:
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
-          cache: true
+          cache: ${{ runner.os != 'Linux' }}
           run-install: true
 
       - name: Validate release tag
@@ -143,6 +169,20 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           persist-credentials: false
 
+      - name: Mount Cargo target sticky disk
+        if: ${{ runner.os == 'Linux' }}
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-publish-npm-native-${{ matrix.target }}-${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.lock') }}
+          path: target
+
+      - name: Mount pnpm store sticky disk
+        if: ${{ runner.os == 'Linux' }}
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-publish-npm-native-${{ matrix.target }}-${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          path: ~/.local/share/pnpm/store
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
@@ -150,12 +190,14 @@ jobs:
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-targets: ${{ runner.os != 'Linux' }}
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
-          cache: true
+          cache: ${{ runner.os != 'Linux' }}
           run-install: true
 
       - name: Setup Zig for musl cross-builds
@@ -219,11 +261,25 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
           persist-credentials: false
 
+      - name: Mount Cargo target sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-publish-npm-publish-${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.lock') }}
+          path: target
+
+      - name: Mount pnpm store sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-publish-npm-publish-${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          path: ~/.local/share/pnpm/store
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-targets: false
 
       - name: Setup Node.js for npm trusted publishing
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -235,7 +291,7 @@ jobs:
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
-          cache: true
+          cache: ${{ runner.os != 'Linux' }}
           run-install: true
 
       - name: Download native binding artifacts

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -41,6 +41,30 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mount Cargo target sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-publish-rust-release-gates-${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.lock') }}
+          path: target
+
+      - name: Mount corsa_ref target sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-publish-rust-release-gates-${{ runner.os }}-corsa-ref-target-${{ hashFiles('Cargo.lock', 'corsa_ref.lock.toml') }}
+          path: .cache/corsa-ref-target
+
+      - name: Mount Go build sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-publish-rust-release-gates-${{ runner.os }}-go-build-${{ hashFiles('corsa_ref.lock.toml') }}
+          path: .cache/go-build
+
+      - name: Mount pnpm store sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-publish-rust-release-gates-${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          path: ~/.local/share/pnpm/store
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
@@ -48,6 +72,8 @@ jobs:
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-targets: false
 
       - name: Sync pinned Corsa ref
         run: cargo run -p corsa_ref --target-dir .cache/corsa-ref-target -- sync
@@ -62,7 +88,7 @@ jobs:
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
-          cache: true
+          cache: ${{ runner.os != 'Linux' }}
           run-install: true
 
       - name: Validate release tag
@@ -110,6 +136,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mount Cargo target sticky disk
+        uses: useblacksmith/stickydisk@13af8883542ca949a717e70fef89d15edbb29d88 # v1.2.0
+        with:
+          key: ${{ github.repository }}-publish-rust-publish-${{ runner.os }}-cargo-target-${{ hashFiles('Cargo.lock') }}
+          path: target
+
       - name: Setup Node.js for release scripts
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -120,6 +152,8 @@ jobs:
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-targets: false
 
       - name: Generate Rust SBOM
         run: node --strip-types ./scripts/generate_sbom.ts --target rust --out .cache/sbom/rust.spdx.json

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -27,19 +27,27 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Mount Blacksmith sticky caches
+        uses: ./.github/actions/blacksmith-sticky-cache
+        with:
+          suffix: release-dry-run
+          corsa-ref-target: "true"
+          pnpm-store: "true"
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version: "24"
-          cache: true
+          cache: ${{ runner.os != 'Linux' }}
           run-install: true
 
       - name: Verify upstream ref


### PR DESCRIPTION
## Summary
- Add a reusable Blacksmith Sticky Cache composite action for Linux Blacksmith jobs.
- Mount Sticky Disk caches for Cargo target output, corsa_ref target output, Go build output, npm cache, and pnpm store on the heavy CI, PR performance, testbox, and release workflows.
- Disable duplicate Rust target/setup-vp dependency cache work on Linux while preserving existing macOS and Windows cache behavior.

## Validation
- `git diff --check`
- YAML parse for `.github/workflows/*.yml` and `.github/actions/blacksmith-sticky-cache/action.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "blacksmith-[^\"]+" is unknown' -ignore 'github\\.event\\.pull_request\\.head\\.ref'`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782820128&installation_id=136613492&pr_number=245&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F245&signature=b8a90fa361925104743cf11e90f717bafacd733dea4779a72f0ebd01764f46aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->