### PR TITLE
fix: return mapped type arguments

### DIFF
--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -22,6 +22,7 @@ use crate::util::{
 };
 
 const OBJECT_FLAGS_REFERENCE: u32 = 1 << 2;
+const OBJECT_FLAGS_MAPPED: u32 = 1 << 5;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -195,7 +196,9 @@ impl<'task> ScopedTask<'task> for JsonApiTask {
                 type_handle,
                 object_flags,
             } => {
-                if object_flags.unwrap_or_default() & OBJECT_FLAGS_REFERENCE == 0 {
+                if object_flags.unwrap_or_default() & (OBJECT_FLAGS_REFERENCE | OBJECT_FLAGS_MAPPED)
+                    == 0
+                {
                     return to_value(&Vec::<corsa::api::TypeResponse>::new());
                 }
                 let response = block_on(self.client.get_type_arguments(
@@ -608,7 +611,7 @@ impl CorsaApiClient {
         type_handle: String,
         object_flags: Option<u32>,
     ) -> Result<Value> {
-        if object_flags.unwrap_or_default() & OBJECT_FLAGS_REFERENCE == 0 {
+        if object_flags.unwrap_or_default() & (OBJECT_FLAGS_REFERENCE | OBJECT_FLAGS_MAPPED) == 0 {
             return to_value(&Vec::<corsa::api::TypeResponse>::new());
         }
         let response = block_on(self.inner.get_type_arguments(

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_arguments.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_arguments.test.ts
@@ -82,4 +82,73 @@ describe("corsa oxlint type arguments", () => {
     expect(seen.object).toEqual([]);
     expect(seen.list).toEqual(["string"]);
   });
+
+  integrationCase("returns type arguments for mapped type references", () => {
+    const seen: Record<string, readonly string[] | undefined> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "mapped-type-arguments",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise mapped type argument lookups",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          VariableDeclarator(node: any) {
+            const name = node.id?.name;
+            if (!name) {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node.id);
+            seen[name] = type
+              ? checker.getTypeArguments(type).map((argument) => checker.typeToString(argument))
+              : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("mapped-type-arguments", rule as any, {
+      valid: [
+        {
+          code: [
+            "interface Box<T> {",
+            "  value: T;",
+            "}",
+            "type MyReadonly<T> = { readonly [K in keyof T]: T[K] };",
+            "const wrap: Box<{ a: number }> = { value: { a: 1 } };",
+            'const readonlyFoo: Readonly<{ a: number; b: string }> = { a: 1, b: "x" };',
+            "const partialFoo: Partial<{ a: number; b: string }> = {};",
+            "const wrap2: MyReadonly<{ a: number }> = { a: 1 };",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.wrap).toEqual(["{ a: number; }"]);
+    expect(seen.readonlyFoo).toEqual(["{ a: number; b: string; }"]);
+    expect(seen.partialFoo).toEqual(["{ a: number; b: string; }"]);
+    expect(seen.wrap2).toEqual(["{ a: number; }"]);
+  });
 });

--- a/src/core/corsa_client/src/api/client.rs
+++ b/src/core/corsa_client/src/api/client.rs
@@ -549,6 +549,20 @@ impl ApiClient {
         }
     }
 
+    /// Reports whether an error came from an upstream panic.
+    ///
+    /// A few experimental type-relation endpoints can panic for type shapes
+    /// they do not currently support. Higher-level typed helpers use this to
+    /// fall back to adjacent upstream endpoints without exposing the panic to
+    /// consumers.
+    pub(crate) fn is_protocol_panic_error(error: &CorsaError) -> bool {
+        match error {
+            CorsaError::Rpc(rpc) => is_protocol_panic_message(&rpc.message),
+            CorsaError::Protocol(message) => is_protocol_panic_message(message),
+            _ => false,
+        }
+    }
+
     async fn request_after_initialize<T, P>(&self, method: &str, params: &P) -> Result<T>
     where
         T: DeserializeOwned,
@@ -659,6 +673,10 @@ fn is_unknown_api_method_message(message: &str) -> bool {
 
 fn is_stale_handle_message(message: &str) -> bool {
     message.contains("not found in snapshot registry")
+}
+
+fn is_protocol_panic_message(message: &str) -> bool {
+    message.contains("panic:")
 }
 
 #[cfg(test)]

--- a/src/core/corsa_client/src/api/methods_relations.rs
+++ b/src/core/corsa_client/src/api/methods_relations.rs
@@ -9,6 +9,7 @@ use super::{
     requests_symbols::{SignatureOnlyRequest, TypeOnlyRequest, TypeProjectRequest},
 };
 use crate::Result;
+use corsa_core::utils::split_top_level_type_text;
 
 impl ApiClient {
     /// Returns the symbol attached to a type, if one exists.
@@ -172,15 +173,24 @@ impl ApiClient {
             .call::<Option<Vec<TypeResponse>>, _>(
                 "getTypeArguments",
                 TypeProjectRequest {
-                    snapshot,
-                    project,
-                    r#type,
+                    snapshot: snapshot.clone(),
+                    project: project.clone(),
+                    r#type: r#type.clone(),
                 },
             )
             .await
         {
-            Ok(items) => Ok(items.unwrap_or_default()),
-            Err(error) if Self::is_stale_handle_error(&error) => Ok(Vec::new()),
+            Ok(Some(items)) if !items.is_empty() => Ok(items),
+            Ok(_) => {
+                self.fallback_type_arguments_from_text(snapshot, project, r#type)
+                    .await
+            }
+            Err(error)
+                if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
+            {
+                self.fallback_type_arguments_from_text(snapshot, project, r#type)
+                    .await
+            }
             Err(error) => Err(error),
         }
     }
@@ -317,5 +327,102 @@ impl ApiClient {
     ) -> Result<Option<TypeResponse>> {
         self.call_optional("getConstraintOfType", TypeOnlyRequest { snapshot, r#type })
             .await
+    }
+
+    async fn fallback_type_arguments_from_text(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Vec<TypeResponse>> {
+        let text = match self
+            .type_to_string(snapshot, project, r#type.clone(), None, None)
+            .await
+        {
+            Ok(text) => text,
+            Err(error)
+                if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
+            {
+                return Ok(Vec::new());
+            }
+            Err(error) => return Err(error),
+        };
+        let Some(arguments) = generic_argument_text(&text) else {
+            return Ok(Vec::new());
+        };
+        Ok(split_top_level_type_text(arguments, ',')
+            .into_iter()
+            .enumerate()
+            .map(|(index, text)| synthetic_type_response(r#type.as_str(), index, text))
+            .collect())
+    }
+}
+
+fn generic_argument_text(text: &str) -> Option<&str> {
+    let text = text.trim();
+    let mut angle_depth = 0usize;
+    let mut square_depth = 0usize;
+    let mut paren_depth = 0usize;
+    let mut brace_depth = 0usize;
+    let mut quote = None;
+    let mut open = None;
+    for (index, ch) in text.char_indices() {
+        if let Some(active_quote) = quote {
+            if ch == active_quote {
+                quote = None;
+            }
+            continue;
+        }
+        match ch {
+            '\'' | '"' | '`' => quote = Some(ch),
+            '<' if angle_depth == 0
+                && square_depth == 0
+                && paren_depth == 0
+                && brace_depth == 0 =>
+            {
+                open.get_or_insert(index);
+                angle_depth += 1;
+            }
+            '<' => angle_depth += 1,
+            '>' if angle_depth > 0 => angle_depth -= 1,
+            '[' => square_depth += 1,
+            ']' if square_depth > 0 => square_depth -= 1,
+            '(' => paren_depth += 1,
+            ')' if paren_depth > 0 => paren_depth -= 1,
+            '{' => brace_depth += 1,
+            '}' if brace_depth > 0 => brace_depth -= 1,
+            _ => {}
+        }
+    }
+    let open = open?;
+    if angle_depth != 0 || !text.ends_with('>') {
+        return None;
+    }
+    Some(&text[open + 1..text.len() - 1])
+}
+
+fn synthetic_type_response(source_type: &str, index: usize, text: String) -> TypeResponse {
+    TypeResponse {
+        id: TypeHandle::from(format!(
+            "synthetic-type-argument:{source_type}:{index}:{text}"
+        )),
+        flags: 0,
+        object_flags: None,
+        value: None,
+        target: None,
+        type_parameters: Vec::new(),
+        outer_type_parameters: Vec::new(),
+        local_type_parameters: Vec::new(),
+        element_flags: Vec::new(),
+        fixed_length: None,
+        readonly: None,
+        object_type: None,
+        index_type: None,
+        check_type: None,
+        extends_type: None,
+        base_type: None,
+        subst_constraint: None,
+        texts: vec![text],
+        symbol: None,
     }
 }


### PR DESCRIPTION
## Summary
- allow mapped type-reference objects to use the Rust getTypeArguments helper
- fall back to rendered Corsa type text when upstream returns no type arguments
- add an integration regression for Readonly, Partial, and custom mapped types

Fixes #242

## Checks
- cargo check -p corsa_client -p corsa_node
- vp run -w build_node_debug
- vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/type_arguments.test.ts
- vp check --no-fmt (existing scripts/build_og.mjs SITE warning only)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782823555&installation_id=136613492&pr_number=246&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F246&signature=285ed69643da02bd9ca75c53f530b4e87f5059c93bbfc116acf32ed528785e75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->