### PR TITLE
fix: resolve generic base types

### DIFF
--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -13,7 +13,7 @@ use napi::{
     bindgen_prelude::{AsyncTask, Buffer, Unknown},
 };
 use napi_derive::napi;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::util::{
@@ -31,6 +31,15 @@ struct SnapshotState<'a> {
     projects: &'a [corsa::api::ProjectResponse],
     #[serde(skip_serializing_if = "Option::is_none")]
     changes: &'a Option<corsa::api::SnapshotChanges>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TypeProjectParams {
+    snapshot: String,
+    project: String,
+    #[serde(rename = "type")]
+    type_handle: String,
 }
 
 type SnapshotStore = Arc<Mutex<FastMap<CompactString, ManagedSnapshot>>>;
@@ -275,10 +284,7 @@ impl<'task> ScopedTask<'task> for JsonApiTask {
                 Ok(Value::String(text))
             }
             JsonTaskKind::CallJson { method, params } => {
-                let params = optional_value(params.take());
-                let response = block_on(self.client.raw_json_request(method.as_str(), params))
-                    .map_err(into_napi_error)?;
-                Ok(response)
+                call_json_blocking(&self.client, method.as_str(), params.take())
             }
         }
     }
@@ -806,10 +812,7 @@ impl CorsaApiClient {
     /// Sends an arbitrary JSON endpoint request.
     #[napi]
     pub fn call_json(&self, method: String, params: Option<Value>) -> Result<Value> {
-        let params = optional_value(params);
-        let response = block_on(self.inner.raw_json_request(method.as_str(), params))
-            .map_err(into_napi_error)?;
-        Ok(response)
+        call_json_blocking(&self.inner, method.as_str(), params)
     }
 
     /// Sends an arbitrary JSON endpoint request on a libuv worker thread.
@@ -892,4 +895,22 @@ impl CorsaApiClient {
             },
         })
     }
+}
+
+fn call_json_blocking(client: &ApiClient, method: &str, params: Option<Value>) -> Result<Value> {
+    if method == "getBaseTypes" {
+        let params = params.ok_or_else(|| into_napi_error("getBaseTypes requires params"))?;
+        let params = from_value::<TypeProjectParams>(params)?;
+        let response = block_on(client.get_base_types(
+            SnapshotHandle::from(params.snapshot.as_str()),
+            ProjectHandle::from(params.project.as_str()),
+            TypeHandle::from(params.type_handle.as_str()),
+        ))
+        .map_err(into_napi_error)?;
+        return to_value(&response);
+    }
+
+    let response = block_on(client.raw_json_request(method, optional_value(params)))
+        .map_err(into_napi_error)?;
+    Ok(response)
 }

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -157,6 +157,71 @@ describe("corsa oxlint type locations", () => {
     expect(seen.usage).toBe("Foo");
   });
 
+  integrationCase("falls back for instantiated generic base types", () => {
+    const seen: Record<string, readonly string[] | undefined> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "generic-base-types",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise generic base type fallback lookups",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          TSPropertySignature(node: any) {
+            if (node.key?.name !== "pet") {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node);
+            seen.pet = type
+              ? checker.getBaseTypes(type).map((base) => checker.typeToString(base))
+              : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("generic-base-types", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Animal {}",
+            "class Dog<T extends string> extends Animal {",
+            "  readonly breed!: T;",
+            "}",
+            "interface Container {",
+            '  pet: Dog<"corgi">;',
+            "}",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.pet).toEqual(["Animal"]);
+  });
+
   integrationCase("resolves symbol and node handles exposed by signatures and types", () => {
     const seen: Record<string, unknown> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);

--- a/src/core/corsa_client/src/api/methods_relations.rs
+++ b/src/core/corsa_client/src/api/methods_relations.rs
@@ -85,16 +85,70 @@ impl ApiClient {
         project: ProjectHandle,
         r#type: TypeHandle,
     ) -> Result<Vec<TypeResponse>> {
-        self.call::<Option<Vec<TypeResponse>>, _>(
-            "getBaseTypes",
-            TypeProjectRequest {
-                snapshot,
-                project,
-                r#type,
-            },
-        )
-        .await
-        .map(|items| items.unwrap_or_default())
+        let bases = self
+            .get_base_types_direct(snapshot.clone(), project.clone(), r#type.clone())
+            .await?;
+        if !bases.is_empty() {
+            return Ok(bases);
+        }
+
+        if let Some(target) = self
+            .get_target_of_type_or_none(snapshot.clone(), r#type.clone())
+            .await?
+            .filter(|target| target.id != r#type)
+        {
+            let target_bases = self
+                .get_base_types_direct(snapshot, project, target.id)
+                .await?;
+            if !target_bases.is_empty() {
+                return Ok(target_bases);
+            }
+        }
+
+        Ok(Vec::new())
+    }
+
+    async fn get_base_types_direct(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Vec<TypeResponse>> {
+        match self
+            .call::<Option<Vec<TypeResponse>>, _>(
+                "getBaseTypes",
+                TypeProjectRequest {
+                    snapshot,
+                    project,
+                    r#type,
+                },
+            )
+            .await
+        {
+            Ok(items) => Ok(items.unwrap_or_default()),
+            Err(error)
+                if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
+            {
+                Ok(Vec::new())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn get_target_of_type_or_none(
+        &self,
+        snapshot: SnapshotHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        match self.get_target_of_type(snapshot, r#type).await {
+            Ok(target) => Ok(target),
+            Err(error)
+                if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
     }
 
     /// Returns the properties exposed by a type.
@@ -352,103 +406,6 @@ impl ApiClient {
             }
             Err(error) => Err(error),
         }
-    }
-
-    async fn fallback_type_arguments_from_text(
-        &self,
-        snapshot: SnapshotHandle,
-        project: ProjectHandle,
-        r#type: TypeHandle,
-    ) -> Result<Vec<TypeResponse>> {
-        let text = match self
-            .type_to_string(snapshot, project, r#type.clone(), None, None)
-            .await
-        {
-            Ok(text) => text,
-            Err(error)
-                if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
-            {
-                return Ok(Vec::new());
-            }
-            Err(error) => return Err(error),
-        };
-        let Some(arguments) = generic_argument_text(&text) else {
-            return Ok(Vec::new());
-        };
-        Ok(split_top_level_type_text(arguments, ',')
-            .into_iter()
-            .enumerate()
-            .map(|(index, text)| synthetic_type_response(r#type.as_str(), index, text))
-            .collect())
-    }
-}
-
-fn generic_argument_text(text: &str) -> Option<&str> {
-    let text = text.trim();
-    let mut angle_depth = 0usize;
-    let mut square_depth = 0usize;
-    let mut paren_depth = 0usize;
-    let mut brace_depth = 0usize;
-    let mut quote = None;
-    let mut open = None;
-    for (index, ch) in text.char_indices() {
-        if let Some(active_quote) = quote {
-            if ch == active_quote {
-                quote = None;
-            }
-            continue;
-        }
-        match ch {
-            '\'' | '"' | '`' => quote = Some(ch),
-            '<' if angle_depth == 0
-                && square_depth == 0
-                && paren_depth == 0
-                && brace_depth == 0 =>
-            {
-                open.get_or_insert(index);
-                angle_depth += 1;
-            }
-            '<' => angle_depth += 1,
-            '>' if angle_depth > 0 => angle_depth -= 1,
-            '[' => square_depth += 1,
-            ']' if square_depth > 0 => square_depth -= 1,
-            '(' => paren_depth += 1,
-            ')' if paren_depth > 0 => paren_depth -= 1,
-            '{' => brace_depth += 1,
-            '}' if brace_depth > 0 => brace_depth -= 1,
-            _ => {}
-        }
-    }
-    let open = open?;
-    if angle_depth != 0 || !text.ends_with('>') {
-        return None;
-    }
-    Some(&text[open + 1..text.len() - 1])
-}
-
-fn synthetic_type_response(source_type: &str, index: usize, text: String) -> TypeResponse {
-    TypeResponse {
-        id: TypeHandle::from(format!(
-            "synthetic-type-argument:{source_type}:{index}:{text}"
-        )),
-        flags: 0,
-        object_flags: None,
-        value: None,
-        target: None,
-        type_parameters: Vec::new(),
-        outer_type_parameters: Vec::new(),
-        local_type_parameters: Vec::new(),
-        element_flags: Vec::new(),
-        fixed_length: None,
-        readonly: None,
-        object_type: None,
-        index_type: None,
-        check_type: None,
-        extends_type: None,
-        base_type: None,
-        subst_constraint: None,
-        texts: vec![text],
-        symbol: None,
     }
 
     async fn fallback_type_arguments_from_text(


### PR DESCRIPTION
## Summary
- route getBaseTypes through the Rust relation helper for Node callers
- fall back from instantiated generic types to their target base types
- add an integration regression for Dog<"corgi"> extending Animal

Fixes #239

## Checks
- cargo check -p corsa_client -p corsa_node
- vp run -w build_node_debug
- vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts -t "generic base"
- vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/type_arguments.test.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782823851&installation_id=136613492&pr_number=248&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F248&signature=e14c9b9fa1e1d9ec519fae7b37bebab61cf1e0bf7c038f9848194d19cd56c91a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->