### PR TITLE
fix: resolve non-instance base types

### DIFF
--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -40,6 +40,16 @@ struct TypeProjectParams {
     project: String,
     #[serde(rename = "type")]
     type_handle: String,
+    #[serde(default)]
+    texts: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TypeOnlyParams {
+    snapshot: String,
+    #[serde(rename = "type")]
+    type_handle: String,
 }
 
 type SnapshotStore = Arc<Mutex<FastMap<CompactString, ManagedSnapshot>>>;
@@ -901,9 +911,20 @@ fn call_json_blocking(client: &ApiClient, method: &str, params: Option<Value>) -
     if method == "getBaseTypes" {
         let params = params.ok_or_else(|| into_napi_error("getBaseTypes requires params"))?;
         let params = from_value::<TypeProjectParams>(params)?;
-        let response = block_on(client.get_base_types(
+        let response = block_on(client.get_base_types_with_texts(
             SnapshotHandle::from(params.snapshot.as_str()),
             ProjectHandle::from(params.project.as_str()),
+            TypeHandle::from(params.type_handle.as_str()),
+            params.texts.as_slice(),
+        ))
+        .map_err(into_napi_error)?;
+        return to_value(&response);
+    }
+    if method == "getTypesOfType" {
+        let params = params.ok_or_else(|| into_napi_error("getTypesOfType requires params"))?;
+        let params = from_value::<TypeOnlyParams>(params)?;
+        let response = block_on(client.get_types_of_type(
+            SnapshotHandle::from(params.snapshot.as_str()),
             TypeHandle::from(params.type_handle.as_str()),
         ))
         .map_err(into_napi_error)?;

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -290,6 +290,7 @@ export class CorsaProjectSession {
           snapshot: this.#snapshot,
           project: this.projectId(),
           type: type.id,
+          texts: this.typeTexts(type),
         }) ?? [],
       );
     } catch (error) {
@@ -511,6 +512,14 @@ export class CorsaProjectSession {
     } catch {
       // Some upstream handles are only renderable before a later relation query.
     }
+  }
+
+  private typeTexts(type: CorsaType): readonly string[] {
+    if (Array.isArray(type.texts) && type.texts.length > 0) {
+      return type.texts;
+    }
+    const cached = this.#typeTextById.get(type.id);
+    return cached === undefined ? [] : [cached];
   }
 
   private rememberSymbol<T extends CorsaSymbol | undefined>(symbol: T): T {

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -222,6 +222,86 @@ describe("corsa oxlint type locations", () => {
     expect(seen.pet).toEqual(["Animal"]);
   });
 
+  integrationCase("falls back for constructor and intersection base types", () => {
+    const seen: Record<string, readonly string[] | undefined> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "non-instance-base-types",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise non-instance base type fallback lookups",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          VariableDeclarator(node: any) {
+            if (node.id?.name !== "ctor") {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node.id);
+            seen.constructorBases = type
+              ? checker.getBaseTypes(type).map((base) => checker.typeToString(base))
+              : undefined;
+          },
+          ClassDeclaration(node: any) {
+            if (node.id?.name !== "MixedFoo") {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node.id);
+            const directBases = type ? checker.getBaseTypes(type) : [];
+            seen.mixedBases = directBases.map((base) => checker.typeToString(base));
+            seen.intersectionBases = directBases.flatMap((base) =>
+              checker.getBaseTypes(base).map((nestedBase) => checker.typeToString(nestedBase)),
+            );
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("non-instance-base-types", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Animal {}",
+            "class Dog extends Animal {}",
+            "const ctor = Dog;",
+            "function Mixin<T extends new (...args: any[]) => {}>(Base: T) {",
+            "  return class extends Base {",
+            "    readonly mixed = true;",
+            "  };",
+            "}",
+            "class MixedFoo extends Mixin(Animal) {}",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.constructorBases).toContain("Animal");
+    expect(seen.mixedBases?.[0]).toContain("Animal");
+    expect(seen.intersectionBases).toContain("Animal");
+  });
+
   integrationCase("resolves symbol and node handles exposed by signatures and types", () => {
     const seen: Record<string, unknown> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);

--- a/src/core/corsa_client/src/api/methods_relations.rs
+++ b/src/core/corsa_client/src/api/methods_relations.rs
@@ -85,6 +85,19 @@ impl ApiClient {
         project: ProjectHandle,
         r#type: TypeHandle,
     ) -> Result<Vec<TypeResponse>> {
+        self.get_base_types_with_texts(snapshot, project, r#type, &[])
+            .await
+    }
+
+    /// Returns the immediate base types of a type, using already-rendered type
+    /// text as a fallback when the upstream handle can no longer be rendered.
+    pub async fn get_base_types_with_texts(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+        type_texts: &[String],
+    ) -> Result<Vec<TypeResponse>> {
         let bases = self
             .get_base_types_direct(snapshot.clone(), project.clone(), r#type.clone())
             .await?;
@@ -98,11 +111,72 @@ impl ApiClient {
             .filter(|target| target.id != r#type)
         {
             let target_bases = self
-                .get_base_types_direct(snapshot, project, target.id)
+                .get_base_types_direct(snapshot.clone(), project.clone(), target.id)
                 .await?;
             if !target_bases.is_empty() {
                 return Ok(target_bases);
             }
+        }
+
+        let mut construct_return_bases = Vec::new();
+        let construct_signatures = self
+            .get_signatures_of_type_or_empty(snapshot.clone(), project.clone(), r#type.clone(), 1)
+            .await?;
+        for signature in construct_signatures {
+            let Some(return_type) = self
+                .get_return_type_of_signature_or_none(
+                    snapshot.clone(),
+                    project.clone(),
+                    signature.id,
+                )
+                .await?
+                .filter(|return_type| return_type.id != r#type)
+            else {
+                continue;
+            };
+            let mut return_bases = self
+                .get_base_types_direct(snapshot.clone(), project.clone(), return_type.id.clone())
+                .await?;
+            if return_bases.is_empty() {
+                if let Some(target) = self
+                    .get_target_of_type_or_none(snapshot.clone(), return_type.id.clone())
+                    .await?
+                    .filter(|target| target.id != return_type.id)
+                {
+                    return_bases = self
+                        .get_base_types_direct(snapshot.clone(), project.clone(), target.id)
+                        .await?;
+                }
+            }
+            if return_bases.is_empty() {
+                return_bases = self
+                    .get_types_of_type(snapshot.clone(), return_type.id)
+                    .await?;
+            }
+            append_unique_types(&mut construct_return_bases, return_bases);
+        }
+        if !construct_return_bases.is_empty() {
+            return Ok(construct_return_bases);
+        }
+
+        let intersection_parts = self
+            .get_types_of_type(snapshot.clone(), r#type.clone())
+            .await?;
+        if !intersection_parts.is_empty() {
+            return Ok(intersection_parts);
+        }
+
+        let text_parts = self
+            .fallback_intersection_parts_from_text(snapshot, project, r#type.clone())
+            .await?;
+        if !text_parts.is_empty() {
+            return Ok(text_parts);
+        }
+
+        let hinted_text_parts =
+            fallback_intersection_parts_from_type_texts(r#type.as_str(), type_texts);
+        if !hinted_text_parts.is_empty() {
+            return Ok(hinted_text_parts);
         }
 
         Ok(Vec::new())
@@ -142,6 +216,47 @@ impl ApiClient {
     ) -> Result<Option<TypeResponse>> {
         match self.get_target_of_type(snapshot, r#type).await {
             Ok(target) => Ok(target),
+            Err(error)
+                if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn get_signatures_of_type_or_empty(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+        kind: i32,
+    ) -> Result<Vec<super::SignatureResponse>> {
+        match self
+            .get_signatures_of_type(snapshot, project, r#type, kind)
+            .await
+        {
+            Ok(signatures) => Ok(signatures),
+            Err(error)
+                if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
+            {
+                Ok(Vec::new())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn get_return_type_of_signature_or_none(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        signature: SignatureHandle,
+    ) -> Result<Option<TypeResponse>> {
+        match self
+            .get_return_type_of_signature(snapshot, project, signature)
+            .await
+        {
+            Ok(return_type) => Ok(return_type),
             Err(error)
                 if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
             {
@@ -267,12 +382,21 @@ impl ApiClient {
         snapshot: SnapshotHandle,
         r#type: TypeHandle,
     ) -> Result<Vec<TypeResponse>> {
-        self.call::<Option<Vec<TypeResponse>>, _>(
-            "getTypesOfType",
-            TypeOnlyRequest { snapshot, r#type },
-        )
-        .await
-        .map(|items| items.unwrap_or_default())
+        match self
+            .call::<Option<Vec<TypeResponse>>, _>(
+                "getTypesOfType",
+                TypeOnlyRequest { snapshot, r#type },
+            )
+            .await
+        {
+            Ok(items) => Ok(items.unwrap_or_default()),
+            Err(error)
+                if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
+            {
+                Ok(Vec::new())
+            }
+            Err(error) => Err(error),
+        }
     }
 
     /// Returns the direct type parameters declared on a type.
@@ -435,6 +559,62 @@ impl ApiClient {
             .map(|(index, text)| synthetic_type_response(r#type.as_str(), index, text))
             .collect())
     }
+
+    async fn fallback_intersection_parts_from_text(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Vec<TypeResponse>> {
+        let text = match self
+            .type_to_string(snapshot, project, r#type.clone(), None, None)
+            .await
+        {
+            Ok(text) => text,
+            Err(error)
+                if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
+            {
+                return Ok(Vec::new());
+            }
+            Err(error) => return Err(error),
+        };
+        let parts = split_top_level_type_text(text.as_str(), '&');
+        if parts.len() <= 1 {
+            return Ok(Vec::new());
+        }
+        Ok(parts
+            .into_iter()
+            .enumerate()
+            .map(|(index, text)| synthetic_type_response(r#type.as_str(), index, text))
+            .collect())
+    }
+}
+
+fn append_unique_types(target: &mut Vec<TypeResponse>, source: Vec<TypeResponse>) {
+    for item in source {
+        if target.iter().any(|existing| existing.id == item.id) {
+            continue;
+        }
+        target.push(item);
+    }
+}
+
+fn fallback_intersection_parts_from_type_texts(
+    source_type: &str,
+    type_texts: &[String],
+) -> Vec<TypeResponse> {
+    for text in type_texts {
+        let parts = split_top_level_type_text(text.as_str(), '&');
+        if parts.len() <= 1 {
+            continue;
+        }
+        return parts
+            .into_iter()
+            .enumerate()
+            .map(|(index, text)| synthetic_type_response(source_type, index, text))
+            .collect();
+    }
+    Vec::new()
 }
 
 fn generic_argument_text(text: &str) -> Option<&str> {


### PR DESCRIPTION
## Summary
- extend the Rust base-type helper to inspect construct signatures and intersection constituents
- normalize upstream relation panics to empty intermediate data so fallback paths can continue
- use already-rendered type text as a Rust-side intersection fallback when handles cannot be rendered later

Fixes #240

## Checks
- cargo check -p corsa_client -p corsa_node
- vp run -w build_node_debug
- vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts -t "constructor and intersection"
- vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/type_arguments.test.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782824037&installation_id=136613492&pr_number=249&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F249&signature=77405eaf8b0bbd2be73084fb24a1a9b206ab7ae43517bd5d55e21728a9848bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->