### PR TITLE
fix: resolve static member expression types

### DIFF
--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -1112,6 +1112,13 @@ fn fallback_type_lookup_positions(
                 class_name_before(source_text, start_byte),
             );
         }
+        "MemberExpression" => {
+            push_utf16_position(
+                &mut positions,
+                source_text,
+                member_property_offset(slice).map(|offset| start_byte + offset),
+            );
+        }
         "MethodDefinition" => {
             let member_name = first_member_name_range(slice);
             if member_name
@@ -1224,6 +1231,25 @@ fn class_name_before(source_text: &str, body_start: usize) -> Option<usize> {
         index += char_len_at(prefix, index)?;
     }
     candidate
+}
+
+fn member_property_offset(text: &str) -> Option<usize> {
+    let mut index = 0usize;
+    let mut scanner = SourceScanner::default();
+    let mut last_dot = None;
+    while index < text.len() {
+        let next = scanner.skip(text, index);
+        if next > index {
+            index = next;
+            continue;
+        }
+        let ch = char_at(text, index)?;
+        if ch == '.' {
+            last_dot = Some(index);
+        }
+        index += ch.len_utf8();
+    }
+    first_identifier_after(text, last_dot? + 1)
 }
 
 fn first_member_name_range(text: &str) -> Option<(usize, usize)> {

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -271,6 +271,71 @@ describe("corsa oxlint type locations", () => {
     expect(seen.oldCast).toBe("Bar");
   });
 
+  integrationCase("resolves static member expression types from the property", () => {
+    const seen: Record<string, string | undefined> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "static-member-expression-type",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise static member expression type lookup",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          MemberExpression(node: any) {
+            if (node.property?.name !== "STATIC_FIELD") {
+              return;
+            }
+            const whole = checker.getTypeAtLocation(node);
+            const property = checker.getTypeAtLocation(node.property);
+            const object = checker.getTypeAtLocation(node.object);
+            seen.whole = whole ? checker.typeToString(whole) : undefined;
+            seen.property = property ? checker.typeToString(property) : undefined;
+            seen.object = object ? checker.typeToString(object) : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("static-member-expression-type", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Foo {",
+            '  static STATIC_FIELD: string = "x";',
+            "}",
+            "const sUse = Foo.STATIC_FIELD;",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.whole).toBe("string");
+    expect(seen.property).toBe("string");
+    expect(seen.object).toBe("typeof Foo");
+  });
+
   integrationCase("falls back for instantiated generic base types", () => {
     const seen: Record<string, readonly string[] | undefined> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);


### PR DESCRIPTION
Fixes #244.

Summary:
- Route native source-range lookups for MemberExpression through the property identifier.
- Add regression coverage for static class member expressions returning the property type.

Tests:
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- vp run -w build_node_debug
- vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts -t "static member expression"
- vp check --no-fmt (existing scripts/build_og.mjs unused SITE warning)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782826022&installation_id=136613492&pr_number=252&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F252&signature=c702171274be956f4e2685b71c2232dcd5aa2a3085a8e438eab6db87b444bcb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->