### PR TITLE
fix(jsonrpc): harden local handler failures

### DIFF
--- a/src/core/corsa_core/src/observability.rs
+++ b/src/core/corsa_core/src/observability.rs
@@ -18,6 +18,11 @@ pub enum CorsaEvent {
     },
     /// The JSON-RPC writer queue rejected a message because it was full.
     JsonRpcOutboundQueueFull,
+    /// A locally registered JSON-RPC handler panicked while processing a peer message.
+    JsonRpcLocalHandlerPanicked {
+        /// JSON-RPC method name whose local handler panicked.
+        method: CompactString,
+    },
     /// Pending JSON-RPC requests were failed because the transport broke.
     JsonRpcPendingRequestsFailed {
         /// Transport error propagated to pending callers.

--- a/src/core/corsa_jsonrpc/src/jsonrpc/connection.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/connection.rs
@@ -25,6 +25,8 @@ use super::{
 };
 
 const DEFAULT_READER_JOIN_TIMEOUT: Duration = Duration::from_millis(250);
+const JSONRPC_METHOD_NOT_FOUND: i64 = -32601;
+const JSONRPC_INTERNAL_ERROR: i64 = -32603;
 type ReaderResult = thread::Result<()>;
 
 /// Locally registered callback for a JSON-RPC method.
@@ -250,7 +252,7 @@ impl JsonRpcConnection {
                 let panic_inner = Arc::clone(&read_inner);
                 let result = catch_unwind(AssertUnwindSafe(|| read_inner.read_loop(reader)));
                 if result.is_err() {
-                    panic_inner.fail_pending(CorsaError::Join(CompactString::from(
+                    panic_inner.fail_transport(CorsaError::Join(CompactString::from(
                         "jsonrpc reader thread panicked",
                     )));
                 }
@@ -365,11 +367,10 @@ impl JsonRpcConnection {
 
     /// Signals writer shutdown and fails outstanding requests without waiting for the reader.
     pub fn begin_close(&self) -> Result<()> {
-        if self.inner.closed.swap(true, Ordering::SeqCst) {
-            return Ok(());
+        if !self.inner.closed.swap(true, Ordering::SeqCst) {
+            self.inner
+                .fail_pending(CorsaError::Closed("jsonrpc connection"));
         }
-        self.inner
-            .fail_pending(CorsaError::Closed("jsonrpc connection"));
         self.inner.outbound.lock().take();
         if let Some(task) = self.inner.write_task.lock().take() {
             let _ = task.join();
@@ -419,14 +420,14 @@ impl Inner {
             let payload = match read_frame(&mut reader) {
                 Ok(payload) => payload,
                 Err(err) => {
-                    self.fail_pending(err);
+                    self.fail_transport(err);
                     return;
                 }
             };
             let message: RawMessage = match serde_json::from_slice(&payload) {
                 Ok(message) => message,
                 Err(err) => {
-                    self.fail_pending(err.into());
+                    self.fail_transport(err.into());
                     return;
                 }
             };
@@ -441,21 +442,27 @@ impl Inner {
                 }
                 Ok(MessageKind::Request { id, method, params }) => {
                     if let Some(handler) = self.handlers.get(method.as_str()) {
-                        let response = (handler)(params);
+                        let response = self.invoke_handler(method.as_str(), handler, params);
                         let message = match response {
                             Ok(value) => RawMessage::response(id, value),
                             Err(error) => RawMessage::error(id, error),
                         };
                         let _ = self.send_outbound(message);
                     } else {
-                        let _ = self
-                            .events
-                            .send(InboundEvent::Request { id, method, params });
+                        let delivered = self.events.send(InboundEvent::Request {
+                            id: id.clone(),
+                            method: method.clone(),
+                            params,
+                        });
+                        if delivered == 0 {
+                            let _ = self
+                                .send_outbound(RawMessage::error(id, method_not_found(&method)));
+                        }
                     }
                 }
                 Ok(MessageKind::Notification { method, params }) => {
                     if let Some(handler) = self.handlers.get(method.as_str()) {
-                        let _ = (handler)(params);
+                        let _ = self.invoke_handler(method.as_str(), handler, params);
                     } else {
                         let _ = self
                             .events
@@ -463,7 +470,7 @@ impl Inner {
                     }
                 }
                 Err(err) => {
-                    self.fail_pending(err);
+                    self.fail_transport(err);
                     return;
                 }
             }
@@ -478,12 +485,12 @@ impl Inner {
             let body = match serde_json::to_vec(&message) {
                 Ok(body) => body,
                 Err(err) => {
-                    self.fail_pending(err.into());
+                    self.fail_transport(err.into());
                     return;
                 }
             };
             if let Err(err) = write_frame(&mut writer, &body) {
-                self.fail_pending(err);
+                self.fail_transport(err);
                 return;
             }
         }
@@ -508,6 +515,33 @@ impl Inner {
         }
     }
 
+    fn invoke_handler(
+        &self,
+        method: &str,
+        handler: &RpcHandler,
+        params: Value,
+    ) -> std::result::Result<Value, RpcResponseError> {
+        match catch_unwind(AssertUnwindSafe(|| (handler)(params))) {
+            Ok(result) => result,
+            Err(_) => {
+                warn!("jsonrpc local handler `{method}` panicked");
+                observe(
+                    self.observer.as_ref(),
+                    CorsaEvent::JsonRpcLocalHandlerPanicked {
+                        method: CompactString::from(method),
+                    },
+                );
+                Err(handler_panic_error(method))
+            }
+        }
+    }
+
+    fn fail_transport(&self, error: CorsaError) {
+        self.closed.store(true, Ordering::SeqCst);
+        self.outbound.lock().take();
+        self.fail_pending(error);
+    }
+
     fn fail_pending(&self, error: CorsaError) {
         if !matches!(error, CorsaError::Closed(_)) {
             warn!("jsonrpc transport failing pending requests: {error}");
@@ -526,5 +560,21 @@ impl Inner {
         for (_, tx) in pending.drain() {
             let _ = tx.send(Err(error.clone_for_pending()));
         }
+    }
+}
+
+fn method_not_found(method: &str) -> RpcResponseError {
+    RpcResponseError {
+        code: JSONRPC_METHOD_NOT_FOUND,
+        message: compact_format(format_args!("method not found: {method}")),
+        data: None,
+    }
+}
+
+fn handler_panic_error(method: &str) -> RpcResponseError {
+    RpcResponseError {
+        code: JSONRPC_INTERNAL_ERROR,
+        message: compact_format(format_args!("local JSON-RPC handler `{method}` panicked")),
+        data: None,
     }
 }

--- a/src/core/corsa_jsonrpc/src/jsonrpc/connection_tests.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/connection_tests.rs
@@ -77,6 +77,36 @@ fn request_times_out_when_no_response_arrives() {
 }
 
 #[test]
+fn unhandled_request_without_subscriber_returns_method_not_found() {
+    let (client_socket, server_socket) = UnixStream::pair().unwrap();
+    let client = JsonRpcConnection::try_spawn_with_options(
+        BufReader::new(client_socket.try_clone().unwrap()),
+        client_socket,
+        RpcHandlerMap::default(),
+        JsonRpcConnectionOptions::new().with_request_timeout(Some(Duration::from_secs(5))),
+    )
+    .unwrap();
+    let server = JsonRpcConnection::try_spawn(
+        BufReader::new(server_socket.try_clone().unwrap()),
+        server_socket,
+        RpcHandlerMap::default(),
+    )
+    .unwrap();
+
+    let error =
+        corsa_runtime::block_on(server.request_value("missing", json!({"value": 1}))).unwrap_err();
+
+    assert!(matches!(
+        error,
+        crate::CorsaError::Rpc(error)
+            if error.code == -32601 && error.message.contains("method not found: missing")
+    ));
+
+    let _ = corsa_runtime::block_on(client.close());
+    let _ = corsa_runtime::block_on(server.close());
+}
+
+#[test]
 fn close_joins_reader_after_peer_closes() {
     let (client_socket, server_socket) = UnixStream::pair().unwrap();
     let client = JsonRpcConnection::try_spawn(
@@ -107,7 +137,60 @@ fn close_uses_bounded_reader_join_when_peer_stays_open() {
 }
 
 #[test]
-fn reader_panic_fails_pending_requests() {
+fn request_handler_panic_returns_error_and_keeps_connection_alive() {
+    let (client_socket, server_socket) = UnixStream::pair().unwrap();
+    let observer = Arc::new(EventCollector::default());
+    let mut handlers = RpcHandlerMap::default();
+    handlers.insert(
+        "boom".into(),
+        Arc::new(
+            |_| -> std::result::Result<serde_json::Value, crate::RpcResponseError> {
+                panic!("jsonrpc test handler panic");
+            },
+        ),
+    );
+    handlers.insert("echo".into(), Arc::new(Ok));
+    let client = JsonRpcConnection::try_spawn_with_options(
+        BufReader::new(client_socket.try_clone().unwrap()),
+        client_socket,
+        handlers,
+        JsonRpcConnectionOptions::new()
+            .with_request_timeout(Some(Duration::from_secs(5)))
+            .with_observer(observer.clone()),
+    )
+    .unwrap();
+    let server = JsonRpcConnection::try_spawn(
+        BufReader::new(server_socket.try_clone().unwrap()),
+        server_socket,
+        RpcHandlerMap::default(),
+    )
+    .unwrap();
+
+    let error =
+        corsa_runtime::block_on(server.request_value("boom", json!({"value": 1}))).unwrap_err();
+    assert!(matches!(
+        error,
+        crate::CorsaError::Rpc(error)
+            if error.code == -32603
+                && error.message.contains("local JSON-RPC handler `boom` panicked")
+    ));
+
+    let response: serde_json::Value =
+        corsa_runtime::block_on(server.request_value("echo", json!({"value": 2}))).unwrap();
+    assert_eq!(response, json!({"value": 2}));
+    assert_eq!(
+        observer.events.lock().unwrap().as_slice(),
+        &[CorsaEvent::JsonRpcLocalHandlerPanicked {
+            method: "boom".into(),
+        }]
+    );
+
+    let _ = corsa_runtime::block_on(client.close());
+    let _ = corsa_runtime::block_on(server.close());
+}
+
+#[test]
+fn notification_handler_panic_does_not_fail_pending_requests() {
     let (client_socket, server_socket) = UnixStream::pair().unwrap();
     let mut handlers = RpcHandlerMap::default();
     handlers.insert(
@@ -137,23 +220,20 @@ fn reader_panic_fails_pending_requests() {
         corsa_runtime::block_on(pending_client.request_value("never", json!({})))
     });
 
-    match server_events
+    let id = match server_events
         .recv_timeout(Duration::from_secs(1))
         .expect("server should receive pending request")
     {
-        InboundEvent::Request { method, .. } => assert_eq!(method.as_str(), "never"),
+        InboundEvent::Request { id, method, .. } => {
+            assert_eq!(method.as_str(), "never");
+            id
+        }
         _ => panic!("unexpected event"),
-    }
+    };
 
-    let started = std::time::Instant::now();
     server.notify("boom", json!({})).unwrap();
-    let error = waiter.join().unwrap().unwrap_err();
-
-    assert!(started.elapsed() < Duration::from_secs(1));
-    assert!(matches!(
-        error,
-        crate::CorsaError::Join(message) if message.contains("jsonrpc reader thread panicked")
-    ));
+    server.respond(id, json!({"ok": true})).unwrap();
+    assert_eq!(waiter.join().unwrap().unwrap(), json!({"ok": true}));
 
     let _ = corsa_runtime::block_on(client.close());
     let _ = corsa_runtime::block_on(server.close());


### PR DESCRIPTION
## Summary

- return a JSON-RPC method-not-found error when an inbound request has no local handler and no subscriber
- isolate panicking local handlers so a bad callback returns an RPC error instead of tearing down the transport
- mark fatal transport failures as closed and cover the new failure modes with regression tests

## Validation

- `cargo fmt --all --check`
- `cargo test -p corsa_jsonrpc`
- GitHub Actions are the source of truth for full validation on this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782830766&installation_id=136613492&pr_number=254&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F254&signature=189e37ed105a822cf0e3f663e23e18cce436434ac62b36658a9697e0bc4eb63c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->