### PR TITLE
fix(api): retry failed snapshot releases

### DIFF
--- a/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
@@ -6,6 +6,7 @@ use std::{
     fs::{OpenOptions, create_dir_all},
     io::{BufReader, BufWriter, Write as _},
     path::Path,
+    sync::atomic::{AtomicBool, Ordering},
     time::Duration,
 };
 
@@ -13,6 +14,7 @@ use std::{
 /// integration tests can drive the stale-handle degradation path in
 /// `getTypeArguments`.
 const STALE_TYPE_HANDLE: &str = "t00000000000000ff";
+static RELEASE_FAILURE_USED: AtomicBool = AtomicBool::new(false);
 
 pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
     let stdin = std::io::stdin();
@@ -30,6 +32,10 @@ pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
         record_params(method.as_str(), &params);
         if let (Some(id), Some(error)) = (id.clone(), stale_handle_error(method.as_str(), &params))
         {
+            jsonrpc::write_message(&mut writer, &RawMessage::error(id, error))?;
+            continue;
+        }
+        if let (Some(id), Some(error)) = (id.clone(), release_error(method.as_str())) {
             jsonrpc::write_message(&mut writer, &RawMessage::error(id, error))?;
             continue;
         }
@@ -146,6 +152,20 @@ pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
             jsonrpc::write_message(&mut writer, &RawMessage::response(id, response))?;
         }
     }
+}
+
+fn release_error(method: &str) -> Option<RpcResponseError> {
+    if method != "release" || std::env::var_os("CORSA_MOCK_FAIL_RELEASE_ONCE").is_none() {
+        return None;
+    }
+    if RELEASE_FAILURE_USED.swap(true, Ordering::SeqCst) {
+        return None;
+    }
+    Some(RpcResponseError {
+        code: -32000,
+        message: "mock release failure".into(),
+        data: None,
+    })
 }
 
 fn stale_handle_error(method: &str, params: &Value) -> Option<RpcResponseError> {

--- a/src/bindings/rust/corsa/tests/api_async.rs
+++ b/src/bindings/rust/corsa/tests/api_async.rs
@@ -214,6 +214,42 @@ fn dropping_many_snapshots_uses_bounded_release_queue() {
 }
 
 #[test]
+fn failed_explicit_snapshot_release_is_retried_on_drop() {
+    let count_dir = tempfile::tempdir().unwrap();
+    block_on(async {
+        let client = ApiClient::spawn(
+            support::api_config(ApiMode::AsyncJsonRpcStdio)
+                .with_env(
+                    "CORSA_MOCK_COUNT_DIR",
+                    count_dir.path().display().to_string(),
+                )
+                .with_env("CORSA_MOCK_FAIL_RELEASE_ONCE", "1")
+                .with_shutdown_timeout(Duration::from_secs(10)),
+        )
+        .await
+        .unwrap();
+        let snapshot = client
+            .update_snapshot(UpdateSnapshotParams {
+                open_project: Some("/workspace/tsconfig.json".into()),
+                file_changes: None,
+                overlay_changes: None,
+            })
+            .await
+            .unwrap();
+
+        let error = snapshot.release().await.unwrap_err();
+        assert!(matches!(
+            error,
+            corsa::CorsaError::Rpc(error) if error.message.contains("mock release failure")
+        ));
+
+        drop(snapshot);
+        client.close().await.unwrap();
+    });
+    assert_eq!(count_lines(count_dir.path().join("release.count")), 2);
+}
+
+#[test]
 fn async_api_full_surface_methods() {
     block_on(async {
         let client = ApiClient::spawn(support::api_config(ApiMode::AsyncJsonRpcStdio))

--- a/src/core/corsa_client/src/api/snapshot.rs
+++ b/src/core/corsa_client/src/api/snapshot.rs
@@ -201,7 +201,13 @@ impl ManagedSnapshot {
         if self.released.swap(true, Ordering::SeqCst) {
             return Ok(());
         }
-        self.client.release_handle(self.handle.as_str()).await
+        match self.client.release_handle(self.handle.as_str()).await {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                self.released.store(false, Ordering::SeqCst);
+                Err(error)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- keep `ManagedSnapshot::release()` retryable when the remote release request fails
- allow drop-based cleanup to run after an explicit release failure instead of treating the handle as already released
- add a mock-server regression case that fails the first release and verifies drop retries it

## Validation

- `cargo fmt --all --check`
- `cargo test -p corsa --test api_async failed_explicit_snapshot_release_is_retried_on_drop`
- GitHub Actions are the source of truth for full validation on this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782830955&installation_id=136613492&pr_number=255&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F255&signature=33addc4d23b83bd8668ca2e26c835df4c54a2bde865151202b6a11ef2bed806f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->