### PR TITLE
ci: enforce rustdoc warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,35 @@ jobs:
       - name: Lint Rust
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+  rust-docs:
+    name: Rust Docs
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Mount Blacksmith sticky caches
+        uses: ./.github/actions/blacksmith-sticky-cache
+        with:
+          suffix: ci-rust-docs
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-targets: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Check Rust documentation
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --workspace --no-deps
+
   build:
     name: Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -312,6 +341,7 @@ jobs:
       - js-lint-types
       - rust-format
       - rust-lint
+      - rust-docs
       - build
       - test
       - public-facade
@@ -324,6 +354,7 @@ jobs:
           JS_LINT_TYPES: ${{ needs['js-lint-types'].result }}
           RUST_FORMAT: ${{ needs['rust-format'].result }}
           RUST_LINT: ${{ needs['rust-lint'].result }}
+          RUST_DOCS: ${{ needs['rust-docs'].result }}
           BUILD: ${{ needs.build.result }}
           TEST: ${{ needs.test.result }}
           PUBLIC_FACADE: ${{ needs['public-facade'].result }}
@@ -335,6 +366,7 @@ jobs:
             "JS_LINT_TYPES=$JS_LINT_TYPES" \
             "RUST_FORMAT=$RUST_FORMAT" \
             "RUST_LINT=$RUST_LINT" \
+            "RUST_DOCS=$RUST_DOCS" \
             "BUILD=$BUILD" \
             "TEST=$TEST" \
             "PUBLIC_FACADE=$PUBLIC_FACADE" \
@@ -343,7 +375,7 @@ jobs:
             result="${check#*=}"
             echo "$name: $result"
             # main 限定ジョブが PR で skipped になっても落とさないが、
-            # ここで集計する 8 ジョブは PR/push 双方で実行されるため success 必須。
+            # ここで集計するジョブは PR/push 双方で実行されるため success 必須。
             if [ "$result" != "success" ]; then
               failed=1
             fi

--- a/src/core/corsa_client/src/api/methods_relations.rs
+++ b/src/core/corsa_client/src/api/methods_relations.rs
@@ -330,8 +330,7 @@ impl ApiClient {
     ///
     /// Missing server data is normalized to an empty vector. A stale type
     /// handle that the server has dropped from its snapshot registry is also
-    /// treated as "no type arguments" so callers can keep analyzing the type;
-    /// see [`ApiClient::is_stale_handle_error`].
+    /// treated as "no type arguments" so callers can keep analyzing the type.
     pub async fn get_type_arguments(
         &self,
         snapshot: SnapshotHandle,


### PR DESCRIPTION
## Summary

- add a dedicated CI job for `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- include the new Rust Docs job in the aggregate Quality gate
- fix an existing public rustdoc link that pointed at a private helper

## Validation

- `cargo fmt --all --check`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- GitHub Actions are the source of truth for full validation on this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782831056&installation_id=136613492&pr_number=256&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F256&signature=54ec18179a39e048391ab20d616afee8babf375f6c08f8b28da682d21dd87355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->