### PR TITLE
feat(runtime): expose fallible task spawning

### DIFF
--- a/src/core/corsa_runtime/src/task.rs
+++ b/src/core/corsa_runtime/src/task.rs
@@ -1,5 +1,5 @@
 use crate::block_on;
-use std::{future::Future, thread};
+use std::{future::Future, io, thread};
 
 /// Join handle returned by [`spawn`].
 ///
@@ -14,6 +14,9 @@ pub struct JoinHandle<T> {
 /// The spawned thread immediately runs [`crate::block_on`] on the provided
 /// future and exits when the future resolves.
 ///
+/// Use [`try_spawn`] when the caller needs to handle operating-system thread
+/// creation failures instead of panicking.
+///
 /// # Examples
 ///
 /// ```
@@ -27,9 +30,21 @@ where
     F: Future + Send + 'static,
     F::Output: Send + 'static,
 {
-    JoinHandle {
-        inner: thread::spawn(move || block_on(future)),
-    }
+    try_spawn(future).expect("failed to spawn corsa runtime task")
+}
+
+/// Tries to spawn a future onto a dedicated worker thread.
+///
+/// The returned error is the operating-system thread creation failure reported
+/// by [`std::thread::Builder::spawn`].
+pub fn try_spawn<F>(future: F) -> io::Result<JoinHandle<F::Output>>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    thread::Builder::new()
+        .spawn(move || block_on(future))
+        .map(|inner| JoinHandle { inner })
 }
 
 impl<T> JoinHandle<T> {
@@ -45,10 +60,17 @@ impl<T> JoinHandle<T> {
 #[cfg(test)]
 mod tests {
     use super::spawn;
+    use super::try_spawn;
 
     #[test]
     fn spawn_runs_future_on_worker_thread() {
         let handle = spawn(async { 5_u32 + 7 });
         assert_eq!(handle.join().unwrap(), 12);
+    }
+
+    #[test]
+    fn try_spawn_reports_successful_worker_thread() {
+        let handle = try_spawn(async { 11_u32 + 31 }).unwrap();
+        assert_eq!(handle.join().unwrap(), 42);
     }
 }


### PR DESCRIPTION
## Summary

- add `corsa_runtime::try_spawn` for callers that need to handle OS thread creation failures
- keep the existing `spawn` convenience API, now layered on the fallible implementation
- cover both the new fallible path and the existing infallible wrapper with focused runtime tests

## Validation

- `cargo fmt --all --check`
- `cargo test -p corsa_runtime task::tests::try_spawn_reports_successful_worker_thread`
- `cargo test -p corsa_runtime task::tests::spawn_runs_future_on_worker_thread`
- GitHub Actions are the source of truth for full validation on this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782831165&installation_id=136613492&pr_number=257&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F257&signature=d67eab7fc1f4c0ccdc4a52bee482b73ff4968098879094c8c4ea27f712701955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->