### PR TITLE
fix(c): retry failed snapshot releases

### DIFF
--- a/src/bindings/c/corsa_ffi/src/api_client.rs
+++ b/src/bindings/c/corsa_ffi/src/api_client.rs
@@ -22,6 +22,7 @@ struct SpawnOptions {
     request_timeout_ms: Option<u64>,
     shutdown_timeout_ms: Option<u64>,
     outbound_capacity: Option<usize>,
+    env: Option<HashMap<String, String>>,
     allow_unstable_upstream_calls: Option<bool>,
 }
 
@@ -57,6 +58,11 @@ fn build_spawn_config(options: SpawnOptions) -> Result<ApiSpawnConfig, String> {
     }
     if let Some(capacity) = options.outbound_capacity {
         config = config.with_outbound_capacity(capacity);
+    }
+    if let Some(env) = options.env {
+        for (key, value) in env {
+            config = config.with_env(key, value);
+        }
     }
     if let Some(allow) = options.allow_unstable_upstream_calls {
         config = config.with_allow_unstable_upstream_calls(allow);
@@ -165,10 +171,19 @@ fn close_client(client: &CorsaApiClient) -> Result<(), String> {
             .lock()
             .map_err(|_| "corsa api client state poisoned".to_owned())?,
     );
+    let mut first_error = None;
     for snapshot in snapshots.into_values() {
-        block_on(snapshot.release()).map_err(|error| error.to_string())?;
+        if let Err(error) = block_on(snapshot.release()) {
+            first_error.get_or_insert_with(|| error.to_string());
+        }
     }
-    block_on(client.inner.close()).map_err(|error| error.to_string())
+    if let Err(error) = block_on(client.inner.close()) {
+        first_error.get_or_insert_with(|| error.to_string());
+    }
+    match first_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
 }
 
 #[unsafe(no_mangle)]
@@ -614,22 +629,22 @@ pub unsafe extern "C" fn corsa_api_client_release_handle(
     let Some(handle) = read_required_text(handle, "handle") else {
         return false;
     };
-    let snapshot = {
+    {
         let Ok(mut snapshots) = client.snapshots.lock() else {
             set_last_error("corsa api client state poisoned");
             return false;
         };
-        snapshots.remove(handle.as_str())
-    };
-    if let Some(snapshot) = snapshot {
-        match block_on(snapshot.release()) {
-            Ok(()) => {
-                clear_last_error();
-                return true;
-            }
-            Err(error) => {
-                set_last_error(error);
-                return false;
+        if let Some(snapshot) = snapshots.get(handle.as_str()) {
+            match block_on(snapshot.release()) {
+                Ok(()) => {
+                    snapshots.remove(handle.as_str());
+                    clear_last_error();
+                    return true;
+                }
+                Err(error) => {
+                    set_last_error(error);
+                    return false;
+                }
             }
         }
     }

--- a/src/bindings/c/corsa_ffi/src/tests.rs
+++ b/src/bindings/c/corsa_ffi/src/tests.rs
@@ -6,7 +6,8 @@ use crate::{
         corsa_api_client_get_declared_type_of_symbol_json, corsa_api_client_get_string_type_json,
         corsa_api_client_get_symbol_at_position_json, corsa_api_client_get_type_arguments_json,
         corsa_api_client_get_type_at_position_json, corsa_api_client_get_type_of_symbol_json,
-        corsa_api_client_spawn, corsa_api_client_update_snapshot_json,
+        corsa_api_client_release_handle, corsa_api_client_spawn,
+        corsa_api_client_update_snapshot_json,
     },
     error::corsa_error_message_take,
     types::{
@@ -447,6 +448,42 @@ fn resolves_type_arguments_over_ffi() {
     });
     let reference_arguments: serde_json::Value = serde_json::from_str(&reference_json).unwrap();
     assert_eq!(reference_arguments[0]["id"], "t0000000000000001");
+
+    assert!(unsafe { corsa_api_client_close(client) });
+    unsafe {
+        corsa_api_client_free(client);
+    }
+}
+
+#[test]
+fn retries_failed_snapshot_release_over_ffi() {
+    let Some(binary) = mock_corsa_binary() else {
+        return;
+    };
+    let options = serde_json::json!({
+        "executable": binary.display().to_string(),
+        "cwd": workspace_root().display().to_string(),
+        "mode": "jsonrpc",
+        "env": {
+            "CORSA_MOCK_FAIL_RELEASE_ONCE": "1"
+        },
+    })
+    .to_string();
+    let client = unsafe { corsa_api_client_spawn(text_ref(&options)) };
+    assert!(!client.is_null());
+
+    let snapshot_json = take_string(unsafe {
+        corsa_api_client_update_snapshot_json(
+            client,
+            text_ref(r#"{"openProject":"/workspace/tsconfig.json"}"#),
+        )
+    });
+    let snapshot: serde_json::Value = serde_json::from_str(&snapshot_json).unwrap();
+    let snapshot_id = snapshot["snapshot"].as_str().unwrap();
+
+    assert!(!unsafe { corsa_api_client_release_handle(client, text_ref(snapshot_id)) });
+    assert!(take_string(corsa_error_message_take()).contains("mock release failure"));
+    assert!(unsafe { corsa_api_client_release_handle(client, text_ref(snapshot_id)) });
 
     assert!(unsafe { corsa_api_client_close(client) });
     unsafe {


### PR DESCRIPTION
## Summary
- keep C FFI managed snapshots registered when explicit release fails so callers can retry the same handle
- continue closing the underlying client even if best-effort snapshot release reports an error
- allow C FFI spawn options to pass child process environment variables for deterministic integration tests

## Validation
- cargo fmt --all --check
- cargo test -p corsa_ffi retries_failed_snapshot_release_over_ffi
- RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps
- cargo clippy -p corsa_ffi --all-targets -- -D warnings

Stacked on #258 so CI includes the rustdoc gate fix already validated there.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782832795&installation_id=136613492&pr_number=259&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F259&signature=182561a849067f4d70d1cebf462e06787f184073eb4ef6b3f1bfa9fcdecaf1df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->