### PR TITLE
chore(deps): update corsa upstream

### DIFF
--- a/corsa_ref.lock.toml
+++ b/corsa_ref.lock.toml
@@ -3,8 +3,8 @@ version = 1
 [corsa_upstream]
 path = "ref/corsa-upstream"
 repository = "https://github.com/microsoft/typescript-go.git"
-commit = "f4a1d2a1d0d5df4333f2440500e3a6c4b4702d9a"
-tree = "db15a071b5981d71e41c086859133cb15ef67cb3"
-committer_date = "2026-05-15T23:24:59Z"
-author = "navya9singh"
-subject = "Adding signature help tooltip coloring support for VS (#3821)"
+commit = "73868c8588924d4d972782c9ea102b322d7f3212"
+tree = "81355a169abb605dec5355169fb30ab15677b357"
+committer_date = "2026-05-30T19:52:40Z"
+author = "Anders Hejlsberg"
+subject = "Fix grammar checking for `in` and `out` modifiers in `@template` tags (#4100)"


### PR DESCRIPTION
## Summary

- Update the pinned Corsa upstream checkout from `f4a1d2a1d0d5df4333f2440500e3a6c4b4702d9a` to `73868c8588924d4d972782c9ea102b322d7f3212`.
- Refresh the recorded tree, committer date, author, and subject in `corsa_ref.lock.toml`.

## Validation

- `cargo run -p corsa_ref --target-dir .cache/corsa-ref-target -- verify`
- `cargo test -p corsa_ref`
- `nix develop -c sh -c 'vp run -w build_corsa'`
- `nix develop -c sh -c 'cargo test -p corsa --no-default-features --test real_corsa_regression --test real_corsa_typecheck'`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782833992&installation_id=136613492&pr_number=260&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F260&signature=3ca0413bd54f53a9f1e1363ad301cfb26c03e8006e6f8dd2ecfe9d6deef034b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->