### PR TITLE
fix(oxlint): preserve mapped utility type argument handles

### DIFF
--- a/src/bindings/c/corsa_ffi/src/api_client.rs
+++ b/src/bindings/c/corsa_ffi/src/api_client.rs
@@ -41,6 +41,7 @@ pub struct CorsaApiClient {
 }
 
 const OBJECT_FLAGS_REFERENCE: u32 = 1 << 2;
+const OBJECT_FLAGS_MAPPED: u32 = 1 << 5;
 
 fn build_spawn_config(options: SpawnOptions) -> Result<ApiSpawnConfig, String> {
     let mut config = ApiSpawnConfig::new(options.executable);
@@ -441,7 +442,7 @@ pub unsafe extern "C" fn corsa_api_client_get_type_arguments_json(
     let Some(type_handle) = read_required_text(type_handle, "type_handle") else {
         return CorsaString::default();
     };
-    if object_flags & OBJECT_FLAGS_REFERENCE == 0 {
+    if object_flags & (OBJECT_FLAGS_REFERENCE | OBJECT_FLAGS_MAPPED) == 0 {
         return take_json(&Vec::<corsa_client::TypeResponse>::new());
     }
     match block_on(client.inner.get_type_arguments(

--- a/src/bindings/nodejs/corsa_node/index.d.ts
+++ b/src/bindings/nodejs/corsa_node/index.d.ts
@@ -34,7 +34,7 @@ export declare class CorsaApiClient {
   /** Resolves the checker symbol visible at a file position. */
   getSymbolAtPosition(snapshot: string, project: string, file: string, position: number): any
   getSymbolAtPositionAsync(snapshot: string, project: string, file: string, position: number): Promise<unknown>
-  /** Resolves type arguments for type-reference objects and returns [] otherwise. */
+  /** Resolves type arguments for type-reference and mapped objects, and returns [] otherwise. */
   getTypeArguments(snapshot: string, project: string, typeHandle: string, objectFlags?: number | undefined | null): any
   getTypeArgumentsAsync(snapshot: string, project: string, typeHandle: string, objectFlags?: number | undefined | null): Promise<unknown>
   /** Resolves a type constraint using Corsa relation endpoints. */

--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -734,7 +734,7 @@ impl CorsaApiClient {
         })
     }
 
-    /// Resolves type arguments for type-reference objects and returns [] otherwise.
+    /// Resolves type arguments for type-reference and mapped objects, and returns [] otherwise.
     #[napi]
     pub fn get_type_arguments(
         &self,

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_arguments.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_arguments.test.ts
@@ -151,4 +151,101 @@ describe("corsa oxlint type arguments", () => {
     expect(seen.partialFoo).toEqual(["{ a: number; b: string; }"]);
     expect(seen.wrap2).toEqual(["{ a: number; }"]);
   });
+
+  integrationCase("returns structural handles for mapped utility type arguments", () => {
+    const seen: Record<
+      string,
+      | {
+          readonly argument: string;
+          readonly bases: readonly string[];
+          readonly implemented: readonly string[];
+        }
+      | undefined
+    > = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "mapped-utility-type-argument-structure",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise mapped utility type argument handles",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          TSPropertySignature(node: any) {
+            const keyName = node.key?.name;
+            if (!keyName) {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node);
+            const argument = type ? checker.getTypeArguments(type)[0] : undefined;
+            seen[keyName] = argument
+              ? {
+                  argument: checker.typeToString(argument),
+                  bases: checker.getBaseTypes(argument).map((base) => checker.typeToString(base)),
+                  implemented: checker
+                    .getImplementedTypesOfType(argument)
+                    .map((implemented) => checker.typeToString(implemented)),
+                }
+              : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("mapped-utility-type-argument-structure", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Animal {}",
+            "interface IDog {",
+            "  name: string;",
+            "}",
+            "class Dog extends Animal implements IDog {",
+            '  readonly name = "Rex";',
+            "}",
+            "interface Box<T> {",
+            "  value: T;",
+            "}",
+            "interface Props {",
+            "  boxed: Box<Dog>;",
+            "  readonlyDog: Readonly<Dog>;",
+            "  partialDog: Partial<Dog>;",
+            "  requiredDog: Required<Dog>;",
+            "}",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    const expected = {
+      argument: "Dog",
+      bases: ["Animal"],
+      implemented: ["IDog"],
+    };
+    expect(seen.boxed).toEqual(expected);
+    expect(seen.readonlyDog).toEqual(expected);
+    expect(seen.partialDog).toEqual(expected);
+    expect(seen.requiredDog).toEqual(expected);
+  });
 });

--- a/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
@@ -14,6 +14,10 @@ use std::{
 /// integration tests can drive the stale-handle degradation path in
 /// `getTypeArguments`.
 const STALE_TYPE_HANDLE: &str = "t00000000000000ff";
+const MAPPED_UTILITY_TYPE_HANDLE: &str = "t00000000000000ee";
+const MAPPED_UTILITY_ARGUMENT_SYMBOL: &str = "s00000000000000ee";
+const MAPPED_UTILITY_SPARSE_ARGUMENT: &str = "t00000000000000e1";
+const MAPPED_UTILITY_STRUCTURAL_ARGUMENT: &str = "t00000000000000e2";
 static RELEASE_FAILURE_USED: AtomicBool = AtomicBool::new(false);
 
 pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
@@ -80,6 +84,11 @@ pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
             "getSymbolsAtPositions" | "getSymbolsAtLocations" => {
                 Some(json!([common::symbol("value"), Value::Null]))
             }
+            "getDeclaredTypeOfSymbol"
+                if symbol_param(&params) == Some(MAPPED_UTILITY_ARGUMENT_SYMBOL) =>
+            {
+                Some(mapped_utility_argument(MAPPED_UTILITY_STRUCTURAL_ARGUMENT))
+            }
             "getTypeOfSymbol"
             | "getDeclaredTypeOfSymbol"
             | "getTypeAtLocation"
@@ -115,8 +124,11 @@ pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
                         .collect(),
                 ))
             }
-            "getBaseTypes"
-            | "getTypeArguments"
+            "getBaseTypes" => Some(json!([common::type_response("t0000000000000001")])),
+            "getTypeArguments" if type_param(&params) == Some(MAPPED_UTILITY_TYPE_HANDLE) => Some(
+                json!([mapped_utility_argument(MAPPED_UTILITY_SPARSE_ARGUMENT,)]),
+            ),
+            "getTypeArguments"
             | "getTypesOfType"
             | "getTypeParametersOfType"
             | "getOuterTypeParametersOfType"
@@ -183,6 +195,24 @@ fn stale_handle_error(method: &str, params: &Value) -> Option<RpcResponseError> 
         )
         .into(),
         data: None,
+    })
+}
+
+fn type_param(params: &Value) -> Option<&str> {
+    params.get("type").and_then(Value::as_str)
+}
+
+fn symbol_param(params: &Value) -> Option<&str> {
+    params.get("symbol").and_then(Value::as_str)
+}
+
+fn mapped_utility_argument(id: &str) -> Value {
+    json!({
+        "id": id,
+        "flags": 524288,
+        "objectFlags": 3,
+        "symbol": MAPPED_UTILITY_ARGUMENT_SYMBOL,
+        "texts": ["Dog"],
     })
 }
 

--- a/src/bindings/rust/corsa/tests/api_async.rs
+++ b/src/bindings/rust/corsa/tests/api_async.rs
@@ -574,6 +574,39 @@ fn get_type_arguments_degrades_stale_handle_to_empty() {
     });
 }
 
+#[test]
+fn get_type_arguments_hydrates_symbol_backed_arguments() {
+    block_on(async {
+        let client = ApiClient::spawn(support::api_config(ApiMode::AsyncJsonRpcStdio))
+            .await
+            .unwrap();
+        let snapshot = client
+            .update_snapshot(UpdateSnapshotParams {
+                open_project: Some("/workspace/tsconfig.json".into()),
+                file_changes: None,
+                overlay_changes: None,
+            })
+            .await
+            .unwrap();
+        let project = snapshot.projects[0].id.clone();
+
+        let arguments = client
+            .get_type_arguments(
+                snapshot.handle.clone(),
+                project,
+                corsa::api::TypeHandle::from("t00000000000000ee"),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(arguments.len(), 1);
+        assert_eq!(arguments[0].id.as_str(), "t00000000000000e2");
+        assert_eq!(arguments[0].texts, ["Dog"]);
+
+        client.close().await.unwrap();
+    });
+}
+
 fn count_lines(path: impl AsRef<std::path::Path>) -> usize {
     fs::read_to_string(path)
         .map(|text| text.lines().count())

--- a/src/core/corsa_client/src/api/methods_relations.rs
+++ b/src/core/corsa_client/src/api/methods_relations.rs
@@ -4,7 +4,7 @@
 //! to each other after the checker has already identified them.
 
 use super::{
-    ApiClient, IndexInfo, ProjectHandle, SignatureHandle, SnapshotHandle, TypeHandle,
+    ApiClient, IndexInfo, ProjectHandle, SignatureHandle, SnapshotHandle, SymbolHandle, TypeHandle,
     TypePredicateResponse, TypeResponse,
     requests_symbols::{SignatureOnlyRequest, TypeOnlyRequest, TypeProjectRequest},
 };
@@ -348,7 +348,10 @@ impl ApiClient {
             )
             .await
         {
-            Ok(Some(items)) if !items.is_empty() => Ok(items),
+            Ok(Some(items)) if !items.is_empty() => {
+                self.structural_type_arguments_from_symbols(snapshot, project, items)
+                    .await
+            }
             Ok(_) => {
                 self.fallback_type_arguments_from_text(snapshot, project, r#type)
                     .await
@@ -358,6 +361,123 @@ impl ApiClient {
             {
                 self.fallback_type_arguments_from_text(snapshot, project, r#type)
                     .await
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn structural_type_arguments_from_symbols(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        items: Vec<TypeResponse>,
+    ) -> Result<Vec<TypeResponse>> {
+        let mut structural = Vec::with_capacity(items.len());
+        for item in items {
+            let Some(symbol) = item.symbol.clone() else {
+                structural.push(item);
+                continue;
+            };
+            let Some(candidate) = self
+                .symbol_type_or_none(snapshot.clone(), project.clone(), symbol)
+                .await?
+            else {
+                structural.push(item);
+                continue;
+            };
+            if self
+                .same_type_text(snapshot.clone(), project.clone(), &item, &candidate)
+                .await?
+            {
+                structural.push(candidate);
+            } else {
+                structural.push(item);
+            }
+        }
+        Ok(structural)
+    }
+
+    async fn symbol_type_or_none(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        symbol: SymbolHandle,
+    ) -> Result<Option<TypeResponse>> {
+        match self
+            .get_declared_type_of_symbol(snapshot.clone(), project.clone(), symbol.clone())
+            .await
+        {
+            Ok(Some(r#type)) => Ok(Some(r#type)),
+            Ok(None) => self.type_of_symbol_or_none(snapshot, project, symbol).await,
+            Err(error)
+                if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn type_of_symbol_or_none(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        symbol: SymbolHandle,
+    ) -> Result<Option<TypeResponse>> {
+        match self.get_type_of_symbol(snapshot, project, symbol).await {
+            Ok(r#type) => Ok(r#type),
+            Err(error)
+                if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn same_type_text(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        left: &TypeResponse,
+        right: &TypeResponse,
+    ) -> Result<bool> {
+        if left.id == right.id || type_response_texts_overlap(left, right) {
+            return Ok(true);
+        }
+        let Some(left_text) = self
+            .type_response_text_or_none(snapshot.clone(), project.clone(), left)
+            .await?
+        else {
+            return Ok(false);
+        };
+        let Some(right_text) = self
+            .type_response_text_or_none(snapshot, project, right)
+            .await?
+        else {
+            return Ok(false);
+        };
+        Ok(left_text == right_text)
+    }
+
+    async fn type_response_text_or_none(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: &TypeResponse,
+    ) -> Result<Option<String>> {
+        if let Some(text) = r#type.texts.iter().find(|text| !text.is_empty()) {
+            return Ok(Some(text.clone()));
+        }
+        match self
+            .type_to_string(snapshot, project, r#type.id.clone(), None, None)
+            .await
+        {
+            Ok(text) => Ok(Some(text)),
+            Err(error)
+                if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
+            {
+                Ok(None)
             }
             Err(error) => Err(error),
         }
@@ -596,6 +716,13 @@ fn append_unique_types(target: &mut Vec<TypeResponse>, source: Vec<TypeResponse>
         }
         target.push(item);
     }
+}
+
+fn type_response_texts_overlap(left: &TypeResponse, right: &TypeResponse) -> bool {
+    left.texts
+        .iter()
+        .filter(|text| !text.is_empty())
+        .any(|left_text| right.texts.iter().any(|right_text| left_text == right_text))
 }
 
 fn fallback_intersection_parts_from_type_texts(


### PR DESCRIPTION
## Summary

- Hydrate symbol-backed type arguments in `corsa_client::ApiClient::get_type_arguments` by replacing sparse handles with the declared symbol type when the rendered type text matches.
- Keep fallback behavior for stale or missing type-argument handles.
- Allow mapped object flags through the C ABI type-argument helper and update the Node API docs.
- Add Rust mock coverage plus an oxlint regression for `Readonly<Dog>`, `Partial<Dog>`, and `Required<Dog>` exposing base and implemented types.

Fixes #261.

## Validation

- `cargo test -p corsa --test api_async get_type_arguments`
- Full validation is left to GitHub Actions for the rebuilt native bindings.
