### PR TITLE
fix: remove unused OG site constant

### DIFF
--- a/scripts/build_og.mjs
+++ b/scripts/build_og.mjs
@@ -17,7 +17,6 @@ const docsDir = join(root, "docs");
 const outDir = join(root, "assets", "og");
 const tmpDir = join(root, ".cache", "og-tmp");
 
-const SITE = "corsa-bind";
 const URL = "github.com/ubugeeei/corsa-bind";
 
 /** Finds the Chromium headless shell that Playwright installs. */


### PR DESCRIPTION
## Summary

- Remove the unused `SITE` constant from `scripts/build_og.mjs`.
- Keep the OG image generation output unchanged.

## Root Cause

`SITE` was declared but never referenced; the script uses literal branding text in the SVG and the `URL` constant for the footer.

## Validation

- `pnpm exec vp check --no-fmt`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782835666&installation_id=136613492&pr_number=263&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F263&signature=aea597e57ca300bd37f15ddf28d0e269295b705e4ca15187146a2a5b9b3a9837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->