### PR TITLE
fix: resolve type reference handles

### DIFF
--- a/src/bindings/nodejs/corsa_node/index.d.ts
+++ b/src/bindings/nodejs/corsa_node/index.d.ts
@@ -36,7 +36,10 @@ export declare class CorsaApiClient {
   getSymbolAtPositionAsync(snapshot: string, project: string, file: string, position: number): Promise<unknown>
   /** Resolves type arguments for type-reference and mapped objects, and returns [] otherwise. */
   getTypeArguments(snapshot: string, project: string, typeHandle: string, objectFlags?: number | undefined | null): any
+  /** Resolves type arguments and prefers structural handles from source locations when available. */
+  getTypeArgumentsAtSourceRange(snapshot: string, project: string, typeHandle: string, objectFlags: number | undefined | null, file: string, start: number, end: number, sourceText: string): any
   getTypeArgumentsAsync(snapshot: string, project: string, typeHandle: string, objectFlags?: number | undefined | null): Promise<unknown>
+  getTypeArgumentsAtSourceRangeAsync(snapshot: string, project: string, typeHandle: string, objectFlags: number | undefined | null, file: string, start: number, end: number, sourceText: string): Promise<unknown>
   /** Resolves a type constraint using Corsa relation endpoints. */
   getConstraintOfType(snapshot: string, project: string, typeHandle: string): any
   getConstraintOfTypeAsync(snapshot: string, project: string, typeHandle: string): Promise<unknown>

--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use corsa::{
+    CorsaError,
     api::{
         ApiClient, ManagedSnapshot, ProjectHandle, SnapshotHandle, SymbolHandle, TypeHandle,
         TypeResponse, UpdateSnapshotParams,
@@ -60,6 +61,17 @@ struct SourceRangeLookup {
     end: u32,
     source_text: String,
     kind: Option<String>,
+}
+
+struct TypeArgumentsSourceRangeLookup {
+    snapshot: SnapshotHandle,
+    project: ProjectHandle,
+    type_handle: TypeHandle,
+    object_flags: Option<u32>,
+    file: String,
+    start: u32,
+    end: u32,
+    source_text: String,
 }
 
 type SnapshotStore = Arc<Mutex<FastMap<CompactString, ManagedSnapshot>>>;
@@ -130,6 +142,16 @@ enum JsonTaskKind {
         project: String,
         type_handle: String,
         object_flags: Option<u32>,
+    },
+    GetTypeArgumentsAtSourceRange {
+        snapshot: String,
+        project: String,
+        type_handle: String,
+        object_flags: Option<u32>,
+        file: String,
+        start: u32,
+        end: u32,
+        source_text: String,
     },
     GetTypeOfSymbol {
         snapshot: String,
@@ -272,6 +294,32 @@ impl<'task> ScopedTask<'task> for JsonApiTask {
                     SnapshotHandle::from(snapshot.as_str()),
                     ProjectHandle::from(project.as_str()),
                     TypeHandle::from(type_handle.as_str()),
+                ))
+                .map_err(into_napi_error)?;
+                to_value(&response)
+            }
+            JsonTaskKind::GetTypeArgumentsAtSourceRange {
+                snapshot,
+                project,
+                type_handle,
+                object_flags,
+                file,
+                start,
+                end,
+                source_text,
+            } => {
+                let response = block_on(get_type_arguments_at_source_range(
+                    &self.client,
+                    TypeArgumentsSourceRangeLookup {
+                        snapshot: SnapshotHandle::from(snapshot.as_str()),
+                        project: ProjectHandle::from(project.as_str()),
+                        type_handle: TypeHandle::from(type_handle.as_str()),
+                        object_flags: *object_flags,
+                        file: file.clone(),
+                        start: *start,
+                        end: *end,
+                        source_text: source_text.clone(),
+                    },
                 ))
                 .map_err(into_napi_error)?;
                 to_value(&response)
@@ -755,6 +803,37 @@ impl CorsaApiClient {
         to_value(&response)
     }
 
+    /// Resolves type arguments and prefers structural handles from source locations when available.
+    #[allow(clippy::too_many_arguments)]
+    #[napi]
+    pub fn get_type_arguments_at_source_range(
+        &self,
+        snapshot: String,
+        project: String,
+        type_handle: String,
+        object_flags: Option<u32>,
+        file: String,
+        start: u32,
+        end: u32,
+        source_text: String,
+    ) -> Result<Value> {
+        let response = block_on(get_type_arguments_at_source_range(
+            &self.inner,
+            TypeArgumentsSourceRangeLookup {
+                snapshot: SnapshotHandle::from(snapshot.as_str()),
+                project: ProjectHandle::from(project.as_str()),
+                type_handle: TypeHandle::from(type_handle.as_str()),
+                object_flags,
+                file,
+                start,
+                end,
+                source_text,
+            },
+        ))
+        .map_err(into_napi_error)?;
+        to_value(&response)
+    }
+
     #[napi]
     pub fn get_type_arguments_async(
         &self,
@@ -770,6 +849,34 @@ impl CorsaApiClient {
                 project,
                 type_handle,
                 object_flags,
+            },
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[napi]
+    pub fn get_type_arguments_at_source_range_async(
+        &self,
+        snapshot: String,
+        project: String,
+        type_handle: String,
+        object_flags: Option<u32>,
+        file: String,
+        start: u32,
+        end: u32,
+        source_text: String,
+    ) -> AsyncTask<JsonApiTask> {
+        AsyncTask::new(JsonApiTask {
+            client: self.inner.clone(),
+            kind: JsonTaskKind::GetTypeArgumentsAtSourceRange {
+                snapshot,
+                project,
+                type_handle,
+                object_flags,
+                file,
+                start,
+                end,
+                source_text,
             },
         })
     }
@@ -1018,13 +1125,17 @@ async fn get_type_at_source_range(
         )
         .await?;
 
+    let direct_is_specific = direct
+        .as_ref()
+        .map(|r#type| !is_any_type(r#type))
+        .unwrap_or(false);
     for position in fallback_type_lookup_positions(
         params.kind.as_deref(),
         params.start,
         params.end,
         params.source_text.as_str(),
     ) {
-        if position == params.start {
+        if position == params.start && direct_is_specific {
             continue;
         }
         let candidate = get_type_or_symbol_type_at_position(
@@ -1041,6 +1152,124 @@ async fn get_type_at_source_range(
     }
 
     Ok(direct)
+}
+
+async fn get_type_arguments_at_source_range(
+    client: &ApiClient,
+    params: TypeArgumentsSourceRangeLookup,
+) -> corsa::Result<Vec<TypeResponse>> {
+    if params.object_flags.unwrap_or_default() & (OBJECT_FLAGS_REFERENCE | OBJECT_FLAGS_MAPPED) == 0
+    {
+        return Ok(Vec::new());
+    }
+
+    let arguments_from_api = client
+        .get_type_arguments(
+            params.snapshot.clone(),
+            params.project.clone(),
+            params.type_handle.clone(),
+        )
+        .await?;
+    let arguments_from_source = type_arguments_from_source_range(client, &params).await?;
+    if arguments_from_source.is_empty() {
+        return Ok(arguments_from_api);
+    }
+    if arguments_from_api.is_empty() {
+        return Ok(arguments_from_source);
+    }
+    if arguments_from_api.len() != arguments_from_source.len() {
+        return Ok(arguments_from_api);
+    }
+
+    let mut structural = Vec::with_capacity(arguments_from_api.len());
+    for (api_argument, source_argument) in arguments_from_api.into_iter().zip(arguments_from_source)
+    {
+        if same_type_text_for_source_argument(
+            client,
+            params.snapshot.clone(),
+            params.project.clone(),
+            &api_argument,
+            &source_argument,
+        )
+        .await?
+        {
+            structural.push(source_argument);
+        } else {
+            structural.push(api_argument);
+        }
+    }
+    Ok(structural)
+}
+
+async fn type_arguments_from_source_range(
+    client: &ApiClient,
+    params: &TypeArgumentsSourceRangeLookup,
+) -> corsa::Result<Vec<TypeResponse>> {
+    let positions =
+        type_argument_positions_for_source_range(params.start, params.end, &params.source_text);
+    let mut arguments = Vec::with_capacity(positions.len());
+    for position in positions {
+        if let Some(argument) = get_type_or_symbol_type_at_position(
+            client,
+            params.snapshot.clone(),
+            params.project.clone(),
+            params.file.clone(),
+            position,
+        )
+        .await?
+        {
+            arguments.push(argument);
+        }
+    }
+    Ok(arguments)
+}
+
+async fn same_type_text_for_source_argument(
+    client: &ApiClient,
+    snapshot: SnapshotHandle,
+    project: ProjectHandle,
+    left: &TypeResponse,
+    right: &TypeResponse,
+) -> corsa::Result<bool> {
+    if left.id == right.id || type_response_texts_overlap(left, right) {
+        return Ok(true);
+    }
+    let Some(left_text) =
+        type_response_text_or_none(client, snapshot.clone(), project.clone(), left).await?
+    else {
+        return Ok(false);
+    };
+    let Some(right_text) = type_response_text_or_none(client, snapshot, project, right).await?
+    else {
+        return Ok(false);
+    };
+    Ok(left_text == right_text)
+}
+
+async fn type_response_text_or_none(
+    client: &ApiClient,
+    snapshot: SnapshotHandle,
+    project: ProjectHandle,
+    r#type: &TypeResponse,
+) -> corsa::Result<Option<String>> {
+    if let Some(text) = r#type.texts.iter().find(|text| !text.is_empty()) {
+        return Ok(Some(text.clone()));
+    }
+    match client
+        .type_to_string(snapshot, project, r#type.id.clone(), None, None)
+        .await
+    {
+        Ok(text) => Ok(Some(text)),
+        Err(error) if is_stale_handle_error(&error) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn type_response_texts_overlap(left: &TypeResponse, right: &TypeResponse) -> bool {
+    left.texts
+        .iter()
+        .filter(|text| !text.is_empty())
+        .any(|left_text| right.texts.iter().any(|right_text| left_text == right_text))
 }
 
 async fn get_type_or_symbol_type_at_position(
@@ -1159,9 +1388,192 @@ fn fallback_type_lookup_positions(
                 type_assertion_angle_offset(slice).map(|offset| start_byte + offset),
             );
         }
+        "TSTypeReference" => {
+            push_utf16_position(
+                &mut positions,
+                source_text,
+                first_identifier_after(slice, 0).map(|offset| start_byte + offset),
+            );
+        }
+        "Identifier" if identifier_looks_like_type_reference_name(source_text, start_byte) => {
+            push_utf16_position(&mut positions, source_text, Some(start_byte));
+        }
         _ => {}
     }
     positions
+}
+
+fn identifier_looks_like_type_reference_name(source_text: &str, start_byte: usize) -> bool {
+    previous_non_whitespace(source_text, start_byte)
+        .map(|ch| matches!(ch, ':' | '<' | '|' | '&' | ','))
+        .unwrap_or(false)
+}
+
+fn previous_non_whitespace(text: &str, index: usize) -> Option<char> {
+    text.get(..index)?
+        .chars()
+        .rev()
+        .find(|ch| !ch.is_whitespace())
+}
+
+fn type_argument_positions_for_source_range(start: u32, end: u32, source_text: &str) -> Vec<u32> {
+    let Some((start_byte, end_byte)) = utf16_byte_range(source_text, start, end) else {
+        return Vec::new();
+    };
+    if start_byte >= end_byte {
+        return Vec::new();
+    }
+    let slice = &source_text[start_byte..end_byte];
+    let type_start = first_top_level_index_of_any(slice, &[':', '='])
+        .and_then(|index| char_len_at(slice, index).map(|len| index + len))
+        .unwrap_or(0);
+    let Some(open_in_type) = first_top_level_opening_angle(&slice[type_start..]) else {
+        return Vec::new();
+    };
+    let open = type_start + open_in_type;
+    let Some(close) = matching_angle_close(slice, open) else {
+        return Vec::new();
+    };
+    let arguments_text = &slice[open + 1..close];
+    let mut positions = Vec::new();
+    for range in split_top_level_ranges(arguments_text, ',') {
+        let raw = &arguments_text[range.start..range.end];
+        let Some(leading) = first_non_whitespace(raw) else {
+            continue;
+        };
+        push_utf16_position(
+            &mut positions,
+            source_text,
+            Some(start_byte + open + 1 + range.start + leading),
+        );
+    }
+    positions
+}
+
+fn first_top_level_index_of_any(text: &str, needles: &[char]) -> Option<usize> {
+    let mut angle_depth = 0usize;
+    let mut paren_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+    let mut index = 0usize;
+    let mut scanner = SourceScanner::default();
+    while index < text.len() {
+        let next = scanner.skip(text, index);
+        if next > index {
+            index = next;
+            continue;
+        }
+        let ch = char_at(text, index)?;
+        match ch {
+            '<' => angle_depth += 1,
+            '>' => angle_depth = angle_depth.saturating_sub(1),
+            '(' => paren_depth += 1,
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '{' => brace_depth += 1,
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            _ if needles.contains(&ch)
+                && angle_depth == 0
+                && paren_depth == 0
+                && bracket_depth == 0
+                && brace_depth == 0 =>
+            {
+                return Some(index);
+            }
+            _ => {}
+        }
+        index += ch.len_utf8();
+    }
+    None
+}
+
+fn first_top_level_opening_angle(text: &str) -> Option<usize> {
+    let mut paren_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+    let mut index = 0usize;
+    let mut scanner = SourceScanner::default();
+    while index < text.len() {
+        let next = scanner.skip(text, index);
+        if next > index {
+            index = next;
+            continue;
+        }
+        let ch = char_at(text, index)?;
+        match ch {
+            '(' => paren_depth += 1,
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '{' => brace_depth += 1,
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            '<' if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 => {
+                return Some(index);
+            }
+            _ => {}
+        }
+        index += ch.len_utf8();
+    }
+    None
+}
+
+struct ByteRange {
+    start: usize,
+    end: usize,
+}
+
+fn split_top_level_ranges(text: &str, delimiter: char) -> Vec<ByteRange> {
+    let mut ranges = Vec::new();
+    let mut angle_depth = 0usize;
+    let mut paren_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+    let mut start = 0usize;
+    let mut index = 0usize;
+    let mut scanner = SourceScanner::default();
+    while index < text.len() {
+        let next = scanner.skip(text, index);
+        if next > index {
+            index = next;
+            continue;
+        }
+        let Some(ch) = char_at(text, index) else {
+            break;
+        };
+        match ch {
+            '<' => angle_depth += 1,
+            '>' => angle_depth = angle_depth.saturating_sub(1),
+            '(' => paren_depth += 1,
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '{' => brace_depth += 1,
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            _ if ch == delimiter
+                && angle_depth == 0
+                && paren_depth == 0
+                && bracket_depth == 0
+                && brace_depth == 0 =>
+            {
+                ranges.push(ByteRange { start, end: index });
+                start = index + ch.len_utf8();
+            }
+            _ => {}
+        }
+        index += ch.len_utf8();
+    }
+    ranges.push(ByteRange {
+        start,
+        end: text.len(),
+    });
+    ranges
+}
+
+fn first_non_whitespace(text: &str) -> Option<usize> {
+    text.char_indices()
+        .find(|(_, ch)| !ch.is_whitespace())
+        .map(|(index, _)| index)
 }
 
 fn push_utf16_position(positions: &mut Vec<u32>, source_text: &str, byte_offset: Option<usize>) {
@@ -1410,6 +1822,18 @@ fn char_at(text: &str, index: usize) -> Option<char> {
 
 fn char_len_at(text: &str, index: usize) -> Option<usize> {
     Some(char_at(text, index)?.len_utf8())
+}
+
+fn is_stale_handle_error(error: &CorsaError) -> bool {
+    match error {
+        CorsaError::Rpc(rpc) => is_stale_handle_message(&rpc.message),
+        CorsaError::Protocol(message) => is_stale_handle_message(message),
+        _ => false,
+    }
+}
+
+fn is_stale_handle_message(message: &str) -> bool {
+    message.contains("not found in snapshot registry")
 }
 
 #[derive(Default)]

--- a/src/bindings/nodejs/corsa_node/ts/index.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.ts
@@ -86,11 +86,31 @@ export interface CorsaApiClient {
     typeHandle: string,
     objectFlags?: number,
   ): TypeResponse[];
+  getTypeArgumentsAtSourceRange(
+    snapshot: string,
+    project: string,
+    typeHandle: string,
+    objectFlags: number | undefined | null,
+    file: string,
+    start: number,
+    end: number,
+    sourceText: string,
+  ): TypeResponse[];
   getTypeArgumentsAsync(
     snapshot: string,
     project: string,
     typeHandle: string,
     objectFlags?: number,
+  ): Promise<TypeResponse[]>;
+  getTypeArgumentsAtSourceRangeAsync(
+    snapshot: string,
+    project: string,
+    typeHandle: string,
+    objectFlags: number | undefined | null,
+    file: string,
+    start: number,
+    end: number,
+    sourceText: string,
   ): Promise<TypeResponse[]>;
   getConstraintOfType(snapshot: string, project: string, typeHandle: string): TypeResponse | null;
   getConstraintOfTypeAsync(

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -43,10 +43,6 @@ type ParameterInfo = {
   node: CorsaNode;
 };
 
-type TypeArgumentInfo = {
-  pos: number;
-};
-
 const typeFlags = {
   object: 1 << 20,
   index: 1 << 21,
@@ -341,15 +337,26 @@ export class CorsaProjectSession {
   }
 
   getTypeArguments(type: CorsaType): readonly CorsaType[] {
-    const argumentsFromApi = this.rememberTypes(
-      this.client().getTypeArguments(
-        this.#snapshot!,
-        this.projectId(),
-        type.id,
-        type.objectFlags,
-      ) as unknown as readonly CorsaType[],
+    const source = this.sourceSliceForType(type);
+    return this.rememberTypes(
+      source
+        ? (this.client().getTypeArgumentsAtSourceRange(
+            this.#snapshot!,
+            this.projectId(),
+            type.id,
+            type.objectFlags,
+            source.node.fileName,
+            source.node.pos,
+            source.node.end,
+            this.sourceTextForPath(source.node.fileName) ?? "",
+          ) as unknown as readonly CorsaType[])
+        : (this.client().getTypeArguments(
+            this.#snapshot!,
+            this.projectId(),
+            type.id,
+            type.objectFlags,
+          ) as unknown as readonly CorsaType[]),
     );
-    return argumentsFromApi.length > 0 ? argumentsFromApi : this.fallbackTypeArguments(type);
   }
 
   getTypesOfType(type: CorsaType): readonly CorsaType[] {
@@ -465,25 +472,6 @@ export class CorsaProjectSession {
     } catch {
       return undefined;
     }
-  }
-
-  private fallbackTypeArguments(type: CorsaType): readonly CorsaType[] {
-    const source = this.sourceSliceForType(type);
-    if (!source) {
-      return [];
-    }
-    return typeArgumentInfosForSource(source)
-      .map((argument) => {
-        const symbol = this.getSymbolAtPosition(
-          source.node.fileName,
-          argument.pos,
-          this.sourceTextForPath(source.node.fileName),
-        );
-        return symbol
-          ? (this.getDeclaredTypeOfSymbol(symbol) ?? this.getTypeOfSymbol(symbol))
-          : undefined;
-      })
-      .filter((argument): argument is CorsaType => argument !== undefined);
   }
 
   private sourceSliceForType(type: CorsaType): SourceSlice | undefined {
@@ -1060,33 +1048,6 @@ function parameterNameForText(text: string): string | undefined {
   return left.split(/\s+/).at(-1);
 }
 
-function typeArgumentInfosForSource(source: SourceSlice): readonly TypeArgumentInfo[] {
-  const annotationMarker = firstTopLevelIndexOfAny(source.text, [":", "="]);
-  const typeStart = annotationMarker >= 0 ? annotationMarker + 1 : 0;
-  const openInType = firstTopLevelOpeningAngle(source.text.slice(typeStart));
-  if (openInType < 0) {
-    return [];
-  }
-  const open = typeStart + openInType;
-  const close = matchingCloseAngle(source.text, open);
-  if (close < 0) {
-    return [];
-  }
-  const argumentsText = source.text.slice(open + 1, close);
-  return splitTopLevelRanges(argumentsText, ",")
-    .map((range) => {
-      const raw = argumentsText.slice(range.start, range.end);
-      const leading = raw.search(/\S/);
-      if (leading < 0) {
-        return undefined;
-      }
-      return {
-        pos: source.node.pos + open + 1 + range.start + leading,
-      };
-    })
-    .filter((argument): argument is TypeArgumentInfo => argument !== undefined);
-}
-
 function matchingCloseParen(text: string, open: number): number {
   let depth = 0;
   const scanner = createScanner();
@@ -1098,26 +1059,6 @@ function matchingCloseParen(text: string, open: number): number {
     if (char === "(") {
       depth += 1;
     } else if (char === ")") {
-      depth -= 1;
-      if (depth === 0) {
-        return index;
-      }
-    }
-  }
-  return -1;
-}
-
-function matchingCloseAngle(text: string, open: number): number {
-  let depth = 0;
-  const scanner = createScanner();
-  for (let index = open; index < text.length; index += 1) {
-    const char = text[index];
-    if (scanner.inQuote(char)) {
-      continue;
-    }
-    if (char === "<") {
-      depth += 1;
-    } else if (char === ">") {
       depth -= 1;
       if (depth === 0) {
         return index;
@@ -1192,29 +1133,6 @@ function firstTopLevelIndexOfAny(text: string, needles: readonly string[]): numb
       bracketDepth === 0 &&
       braceDepth === 0
     ) {
-      return index;
-    }
-  }
-  return -1;
-}
-
-function firstTopLevelOpeningAngle(text: string): number {
-  const scanner = createScanner();
-  let parenDepth = 0;
-  let bracketDepth = 0;
-  let braceDepth = 0;
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
-    if (scanner.inQuote(char)) {
-      continue;
-    }
-    if (char === "(") parenDepth += 1;
-    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
-    else if (char === "[") bracketDepth += 1;
-    else if (char === "]") bracketDepth = Math.max(0, bracketDepth - 1);
-    else if (char === "{") braceDepth += 1;
-    else if (char === "}") braceDepth = Math.max(0, braceDepth - 1);
-    else if (char === "<" && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
       return index;
     }
   }

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -87,6 +87,94 @@ describe("corsa oxlint type locations", () => {
     expect(seen.classFromNode).toBe(seen.classFromId);
   });
 
+  integrationCase("resolves declared types for type reference nodes", () => {
+    const seen: {
+      readonly name: string;
+      readonly whole?: string;
+      readonly inner?: string;
+      readonly declared?: string;
+    }[] = [];
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "type-reference-node-types",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise type reference type lookup",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          TSTypeReference(node: any) {
+            if (node.typeName?.type !== "Identifier") {
+              return;
+            }
+            const whole = checker.getTypeAtLocation(node);
+            const inner = checker.getTypeAtLocation(node.typeName);
+            const symbol = checker.getSymbolAtLocation(node.typeName);
+            const declared = symbol
+              ? (checker.getDeclaredTypeOfSymbol(symbol) ?? checker.getTypeOfSymbol(symbol))
+              : undefined;
+            seen.push({
+              name: node.typeName.name,
+              whole: whole ? checker.typeToString(whole) : undefined,
+              inner: inner ? checker.typeToString(inner) : undefined,
+              declared: declared ? checker.typeToString(declared) : undefined,
+            });
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("type-reference-node-types", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Foo {",
+            '  readonly name: string = "";',
+            "}",
+            "interface IBar {",
+            "  id: number;",
+            "}",
+            "interface Props {",
+            "  foo: Foo;",
+            "  bar: IBar;",
+            "}",
+            "function takesFoo(value: Foo): Foo {",
+            "  return value;",
+            "}",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen).toEqual([
+      { name: "Foo", whole: "Foo", inner: "Foo", declared: "Foo" },
+      { name: "IBar", whole: "IBar", inner: "IBar", declared: "IBar" },
+      { name: "Foo", whole: "Foo", inner: "Foo", declared: "Foo" },
+      { name: "Foo", whole: "Foo", inner: "Foo", declared: "Foo" },
+    ]);
+  });
+
   integrationCase("returns constraints for bounded type parameters", () => {
     const seen: Record<string, string | undefined> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);


### PR DESCRIPTION
## Summary
- Move type-reference fallback into the Rust N-API lookup path so `TSTypeReference` nodes and their inner identifiers resolve declared symbol types when direct lookup returns `any`.
- Add a Rust source-range aware `getTypeArgumentsAtSourceRange` binding that normalizes mapped/reference type arguments against source positions, preserving structural handles for utility types such as `Readonly<T>`.
- Keep the TS session as a thin source-range caller, with regression coverage for named type references.

Fixes #264
Fixes #265

## Verification
- `cargo check -p corsa_node`
- `cargo clippy -p corsa_node --all-targets -- -D warnings`
- `pnpm exec vp run -w build_node_debug`
- `pnpm exec vitest run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/type_arguments.test.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts`
- `pnpm exec tsc --noEmit --project tsconfig.json`
- `pnpm exec vp fmt --check`
- `pnpm exec vp check --no-fmt`
- `pnpm exec vp run -w test_ts` still fails locally in `native_rules.test.ts` pending parity slice, matching the pre-existing local-only failure seen before this Rust rewrite.