### PR TITLE
feat: add Elixir bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "corsa_elixir"
+version = "0.35.0"
+dependencies = [
+ "corsa_client",
+ "corsa_core",
+ "corsa_lsp",
+ "corsa_runtime",
+ "lsp-types",
+ "rustler",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "corsa_ffi"
 version = "0.35.0"
 dependencies = [
@@ -386,6 +400,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +663,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +685,31 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rustler"
+version = "0.37.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875c8fe88089b9bbc0977385e107d35bfae740c6b0734e60a1e9cc82d0017f49"
+dependencies = [
+ "inventory",
+ "libloading",
+ "regex-lite",
+ "rustler_codegen",
+]
+
+[[package]]
+name = "rustler_codegen"
+version = "0.37.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb5848e9c4cf3796f190d9b4516523af27f3444a3af1771f20465f6586d40b2"
+dependencies = [
+ "heck",
+ "inventory",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "src/core/corsa_runtime",
   "src/core/corsa_ref",
   "src/bindings/c/corsa_ffi",
+  "src/bindings/elixir/corsa_utils/native/corsa_elixir",
   "src/bindings/rust/corsa",
   "src/bindings/nodejs/corsa_node",
 ]

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@
 
 `corsa-bind` is a multi-crate workspace for talking to [Corsa](https://devblogs.microsoft.com/typescript/typescript-native-port/)
 (the native TypeScript 7 implementation line) from Rust and JavaScript runtimes.
-Hot paths live in Rust and stay zero-cost; `napi-rs` and a shared C ABI surface
-that performance to JS/TS, C, C++, Go, Zig, C#, Swift, and MoonBit — so you can
-author custom checker tooling and lint rules without reimplementing the checker.
+Hot paths live in Rust and stay zero-cost; `napi-rs`, Rustler, and a shared C
+ABI carry that performance to JS/TS, Elixir, C, C++, Go, Zig, C#, Swift, and
+MoonBit — so you can author custom checker tooling and lint rules without
+reimplementing the checker.
 
 > [!WARNING]
 > This repository is still evolving. The local Rust and Node API/LSP surfaces
@@ -73,20 +74,20 @@ binary.
 
 Full guides live under [`docs/`](./docs/index.md):
 
-| Guide                                                  | What it covers                                                |
-| ------------------------------------------------------ | ------------------------------------------------------------- |
-| [Getting started](./docs/getting_started.md)           | First program in Rust, Node.js, and Oxlint                    |
-| [Architecture](./docs/project_guide.md)                | Workspace shape, upstream policy, extension points, naming    |
-| [Node.js binding](./docs/nodejs_binding.md)            | `@corsa-bind/napi` for Node, Deno, and Bun                    |
-| [Language bindings](./docs/language_bindings.md)       | The `corsa_ffi` C ABI for C, C++, Go, Zig, C#, Swift, MoonBit |
-| [Type-aware Oxlint](./docs/oxlint_guide.md)            | `corsa-oxlint` rule authoring, native and stylistic rules     |
-| [Native rules](./docs/native_rules.md)                 | The type-aware Rust lint rules and their options              |
-| [Stylistic rules](./docs/stylistic_rules.md)           | The Rust-backed `@stylistic`-compatible formatting rules      |
-| [Stylistic benchmark](./docs/stylistic_benchmark.md)   | Native stylistic throughput vs the upstream `@stylistic`      |
-| [Performance](./docs/performance.md)                   | Benchmark entry points and measured numbers                   |
-| [CI and local checks](./docs/ci_guide.md)              | Reproduce the GitHub checks locally                           |
-| [Production readiness](./docs/production_readiness.md) | Runtime controls and release gates                            |
-| [Support policy](./docs/support_policy.md)             | Supported platforms, bindings, and experimental scope         |
+| Guide                                                  | What it covers                                                  |
+| ------------------------------------------------------ | --------------------------------------------------------------- |
+| [Getting started](./docs/getting_started.md)           | First program in Rust, Node.js, and Oxlint                      |
+| [Architecture](./docs/project_guide.md)                | Workspace shape, upstream policy, extension points, naming      |
+| [Node.js binding](./docs/nodejs_binding.md)            | `@corsa-bind/napi` for Node, Deno, and Bun                      |
+| [Language bindings](./docs/language_bindings.md)       | Native bindings for Elixir, C, C++, Go, Zig, C#, Swift, MoonBit |
+| [Type-aware Oxlint](./docs/oxlint_guide.md)            | `corsa-oxlint` rule authoring, native and stylistic rules       |
+| [Native rules](./docs/native_rules.md)                 | The type-aware Rust lint rules and their options                |
+| [Stylistic rules](./docs/stylistic_rules.md)           | The Rust-backed `@stylistic`-compatible formatting rules        |
+| [Stylistic benchmark](./docs/stylistic_benchmark.md)   | Native stylistic throughput vs the upstream `@stylistic`        |
+| [Performance](./docs/performance.md)                   | Benchmark entry points and measured numbers                     |
+| [CI and local checks](./docs/ci_guide.md)              | Reproduce the GitHub checks locally                             |
+| [Production readiness](./docs/production_readiness.md) | Runtime controls and release gates                              |
+| [Support policy](./docs/support_policy.md)             | Supported platforms, bindings, and experimental scope           |
 
 The generated documentation site starts at [`docs/index.md`](./docs/index.md)
 and is built with `vp run -w docs_build`.

--- a/docs/ci_guide.md
+++ b/docs/ci_guide.md
@@ -115,8 +115,8 @@ outside Node:
 - runs the Go wrapper tests in `src/bindings/go/corsa_utils`
 - compiles the C++ header surface against the generated C ABI header
 
-C#, Swift, Zig, and MoonBit remain tracked as experimental wrappers until their
-toolchains are promoted into the required matrix.
+C#, Swift, Zig, MoonBit, and Elixir remain tracked as experimental wrappers
+until their toolchains are promoted into the required matrix.
 
 ## Local Reproduction
 
@@ -127,7 +127,7 @@ The easiest local reproduction path is a shell that provides:
 - `vp` for Vite+, Node `24`, and package-manager access
 - `rust 1.85+`
 - `go 1.26`
-- the native-language toolchains under `src/bindings` (`clang`, `zig`, `dotnet`, `swift`, `moon`)
+- the native-language toolchains under `src/bindings` (`clang`, `zig`, `dotnet`, `swift`, `moon`, `elixir`)
 
 This repository now ships a `flake.nix` for that environment.
 The generated flake comes from a thin `tnix` entrypoint in

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -275,7 +275,7 @@ verified is documented in
 
 - [Architecture](./project_guide.md) — workspace shape, upstream policy, and extension points
 - [Node binding guide](./nodejs_binding.md) — the full `@corsa-bind/napi` surface
-- [Language bindings](./language_bindings.md) — C, C++, Go, Zig, C#, Swift, and MoonBit
+- [Language bindings](./language_bindings.md) — Elixir, C, C++, Go, Zig, C#, Swift, and MoonBit
 - [Oxlint guide](./oxlint_guide.md) — type-aware and native rule authoring
 - [CI and local checks](./ci_guide.md) — reproduce the GitHub checks locally
 - [Production readiness](./production_readiness.md) — runtime controls and release gates

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,10 +14,10 @@ line, commonly known as **`tsgo`**. It is the same engine that powers `tsgo`'s
 `--noEmit` type checking, exposed over stdio.
 
 `corsa-bind` is a multi-crate workspace for talking to that checker. Hot paths
-live in Rust and stay zero-cost; `napi-rs` and a shared C ABI surface that
-performance to JavaScript, C, C++, Go, Zig, C#, Swift, and MoonBit — so you can
-build custom checker tooling and type-aware lint rules on top of the real
-upstream checker, with no forks and no patches.
+live in Rust and stay zero-cost; `napi-rs`, Rustler, and a shared C ABI carry
+that performance to JavaScript, Elixir, C, C++, Go, Zig, C#, Swift, and MoonBit
+— so you can build custom checker tooling and type-aware lint rules on top of
+the real upstream checker, with no forks and no patches.
 
 ## Quick start
 
@@ -73,7 +73,8 @@ points.
   backed by [native rule implementations](./native_rules.md) ported from
   `tsgolint`.
 - **Bindings everywhere.** One C ABI (`corsa_ffi`) powers C, C++, Go, Zig, C#,
-  Swift, and MoonBit; `@corsa-bind/napi` covers Node.js, Deno, and Bun.
+  Swift, and MoonBit; Rustler powers Elixir; `@corsa-bind/napi` covers Node.js,
+  Deno, and Bun.
 - **Reproducible upstream.** `ref/corsa-upstream` is pinned by exact commit with
   a strict **no forks, no patches** policy, so behavior stays auditable.
 
@@ -85,7 +86,7 @@ points.
 ## Use the bindings
 
 - [Node.js binding](./nodejs_binding.md) — the full `@corsa-bind/napi` surface for Node, Deno, and Bun.
-- [Language bindings](./language_bindings.md) — the `corsa_ffi` C ABI for C, C++, Go, Zig, C#, Swift, MoonBit.
+- [Language bindings](./language_bindings.md) — native bindings for Elixir, C, C++, Go, Zig, C#, Swift, MoonBit.
 - [Type-aware Oxlint](./oxlint_guide.md) — `corsa-oxlint` rule authoring, native rules, and stylistic rules.
 - [Native rules](./native_rules.md) — the full set of type-aware rules implemented natively in Rust.
 - [Stylistic rules](./stylistic_rules.md) — the Rust-backed `@stylistic`-compatible formatting rules.

--- a/docs/language_bindings.md
+++ b/docs/language_bindings.md
@@ -1,15 +1,19 @@
 ---
 title: Language bindings
-description: Use the corsa_ffi C ABI from C, C++, Go, Zig, C#, Swift, and MoonBit — build the shared library, link it, and call the utils, API client, and virtual document surfaces.
+description: Use the native Corsa bindings from Elixir, C, C++, Go, Zig, C#, Swift, and MoonBit — build the shared library or Rustler NIF and call the utils, API client, and virtual document surfaces.
 ---
 
-# Language Bindings (C ABI)
+# Language Bindings
 
-Every non-Node binding is layered on a single shared C ABI crate,
+Most non-Node bindings are layered on a single shared C ABI crate,
 [`corsa_ffi`](https://github.com/ubugeeei/corsa-bind/tree/main/src/bindings/c/corsa_ffi).
 It exposes the Rust `corsa_client::ApiClient`, `corsa_core::utils`, and
 `corsa_lsp::VirtualDocument` surfaces over a stable C interface, and the thin
 per-language wrappers add idiomatic ergonomics on top.
+
+Elixir uses a Rustler NIF instead of the C ABI because BEAM runtimes need a NIF
+or port boundary. It exposes the same utils, virtual-document, and API-client
+surfaces through `Corsa`, `Corsa.VirtualDocument`, and `Corsa.ApiClient`.
 
 ```
 corsa_client / corsa_core::utils / corsa_lsp        (Rust)
@@ -18,6 +22,12 @@ corsa_client / corsa_core::utils / corsa_lsp        (Rust)
                   │
    ┌────────┬─────┴──────┬──────┬──────┬──────────┐
    C       C++          Go     Zig    C#   Swift / MoonBit
+
+corsa_client / corsa_core::utils / corsa_lsp        (Rust)
+                  │
+            Rustler NIF
+                  │
+                Elixir
 ```
 
 The Node.js binding is documented separately in the
@@ -26,7 +36,7 @@ C ABI.
 
 ## What each binding exposes
 
-All seven language wrappers cover the same three surfaces:
+All language wrappers cover the same three surfaces:
 
 - **Utils** — Rust-backed type-text predicates and splitters
   (`classify_type_text`, `is_string_like_type_texts`, `split_type_text`, …),
@@ -45,6 +55,7 @@ All seven language wrappers cover the same three surfaces:
 | C#       | `src/bindings/csharp/CorsaUtils`   | `CorsaUtils.csproj`                                               |
 | Swift    | `src/bindings/swift/CorsaUtils`    | `Package.swift`                                                   |
 | MoonBit  | `src/bindings/moonbit/corsa_utils` | `moon.pkg.json`                                                   |
+| Elixir   | `src/bindings/elixir/corsa_utils`  | `Corsa`, `Corsa.VirtualDocument`, `Corsa.ApiClient`               |
 
 > [!IMPORTANT]
 > Like the Node binding, these wrappers do **not** bundle a Corsa executable.
@@ -53,8 +64,9 @@ All seven language wrappers cover the same three surfaces:
 
 ## Build the shared library
 
-All bindings link against `corsa_ffi`. Build it first; the C ABI crate is
-configured as both a `cdylib` and a `staticlib`:
+C ABI bindings link against `corsa_ffi`. Build it first; the C ABI crate is
+configured as both a `cdylib` and a `staticlib`. Elixir builds its Rustler NIF
+from the `src/bindings/elixir/corsa_utils` package instead.
 
 ```bash
 cargo build -p corsa_ffi
@@ -215,13 +227,39 @@ moon test
 See `README.mbt.md` in that directory for the MoonBit-specific build details.
 The package mirrors the same utils, API client, and virtual document surfaces.
 
+## Elixir
+
+The Elixir package is backed by a Rustler NIF rather than the C ABI:
+
+```bash
+cd src/bindings/elixir/corsa_utils
+mix deps.get
+mix test
+```
+
+Use it as:
+
+```elixir
+Corsa.classify_type_text("string[]")
+
+{:ok, doc} = Corsa.VirtualDocument.untitled("/demo.ts", "typescript", "const value = 1;")
+:ok = Corsa.VirtualDocument.replace(doc, "const value = 2;")
+```
+
+`Corsa.ApiClient` accepts a caller-provided executable path and mirrors the C
+ABI API-client surface. Map-based helpers decode JSON through Jason; `_json`
+variants expose the raw JSON strings.
+
 ## How they are verified
 
 CI builds `corsa_ffi`, runs the Go binding tests, and compiles a C++ smoke
 translation unit against the headers in the `non-node-bindings` job. The
-binding benchmark harness (`scripts/bench_bindings.ts`, `vp run -w
-bench_bindings`) builds and links the C, C++, and Go bindings against the same
-shared library. See the [CI guide](./ci_guide.md) for the full job layout.
+Elixir NIF crate is part of the Rust workspace and is covered by Rust format,
+build, and clippy checks; Mix-level tests remain experimental until Elixir is
+added to the required CI matrix. The binding benchmark harness
+(`scripts/bench_bindings.ts`, `vp run -w bench_bindings`) builds and links the
+C, C++, and Go bindings against the same shared library. See the
+[CI guide](./ci_guide.md) for the full job layout.
 
 ## See also
 

--- a/docs/support_policy.md
+++ b/docs/support_policy.md
@@ -19,8 +19,8 @@ commitment:
 - the `experimental-distributed` cargo feature
 - the in-process Raft replication layer
 - upstream endpoints explicitly called out as unstable
-- C#, Swift, Zig, and MoonBit wrappers until their toolchains are added to the
-  required CI matrix
+- C#, Swift, Zig, MoonBit, and Elixir wrappers until their toolchains are added
+  to the required CI matrix
 
 ## Release Channels
 

--- a/src/bindings/elixir/corsa_utils/.formatter.exs
+++ b/src/bindings/elixir/corsa_utils/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/src/bindings/elixir/corsa_utils/LICENSE
+++ b/src/bindings/elixir/corsa_utils/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ubugeeei and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/bindings/elixir/corsa_utils/README.md
+++ b/src/bindings/elixir/corsa_utils/README.md
@@ -1,0 +1,47 @@
+# CorsaUtils for Elixir
+
+Elixir bindings for `corsa-bind`, backed by a Rustler NIF.
+
+The package exposes the same three surfaces as the other native bindings:
+
+- `Corsa` for pure type-text utility predicates.
+- `Corsa.VirtualDocument` for in-memory LSP document edits.
+- `Corsa.ApiClient` for checker API calls against a caller-provided Corsa executable.
+
+## Build
+
+```bash
+cd src/bindings/elixir/corsa_utils
+mix deps.get
+mix test
+```
+
+The Rust NIF is built by the Rustler Mix compiler from
+`native/corsa_elixir`. The API client does not bundle a Corsa executable; pass
+one with `Corsa.ApiClient.spawn/1`.
+
+## Example
+
+```elixir
+iex> Corsa.classify_type_text("string[]")
+"array"
+
+iex> {:ok, doc} = Corsa.VirtualDocument.untitled("/demo.ts", "typescript", "const value = 1;")
+iex> :ok = Corsa.VirtualDocument.replace(doc, "const value = 2;")
+iex> Corsa.VirtualDocument.text(doc)
+"const value = 2;"
+```
+
+API client calls return `{:ok, value}` or `{:error, reason}`:
+
+```elixir
+{:ok, client} =
+  Corsa.ApiClient.spawn(%{
+    executable: "/path/to/corsa",
+    cwd: File.cwd!(),
+    mode: "msgpack"
+  })
+
+{:ok, init} = Corsa.ApiClient.initialize(client)
+:ok = Corsa.ApiClient.close(client)
+```

--- a/src/bindings/elixir/corsa_utils/lib/corsa.ex
+++ b/src/bindings/elixir/corsa_utils/lib/corsa.ex
@@ -1,0 +1,36 @@
+defmodule Corsa do
+  @moduledoc """
+  Elixir binding for `corsa-bind`.
+
+  Pure utility functions are available directly from this module. Stateful
+  surfaces live under `Corsa.VirtualDocument` and `Corsa.ApiClient`.
+  """
+
+  alias Corsa.Native
+
+  defdelegate classify_type_text(text), to: Native
+  defdelegate split_type_text(text), to: Native
+
+  def split_top_level_type_text(text, delimiter) when is_integer(delimiter) do
+    Native.split_top_level_type_text(text, delimiter)
+  end
+
+  def split_top_level_type_text(text, delimiter) when is_binary(delimiter) do
+    case String.to_charlist(delimiter) do
+      [codepoint] -> Native.split_top_level_type_text(text, codepoint)
+      _ -> raise ArgumentError, "delimiter must contain exactly one codepoint"
+    end
+  end
+
+  defdelegate is_string_like_type_texts(type_texts), to: Native
+  defdelegate is_number_like_type_texts(type_texts), to: Native
+  defdelegate is_bigint_like_type_texts(type_texts), to: Native
+  defdelegate is_any_like_type_texts(type_texts), to: Native
+  defdelegate is_unknown_like_type_texts(type_texts), to: Native
+  defdelegate is_array_like_type_texts(type_texts), to: Native
+  defdelegate is_promise_like_type_texts(type_texts, property_names), to: Native
+  defdelegate is_error_like_type_texts(type_texts, property_names), to: Native
+  defdelegate has_unsafe_any_flow(source_texts, target_texts), to: Native
+  defdelegate is_unsafe_assignment(source_texts, target_texts), to: Native
+  defdelegate is_unsafe_return(source_texts, target_texts), to: Native
+end

--- a/src/bindings/elixir/corsa_utils/lib/corsa/api_client.ex
+++ b/src/bindings/elixir/corsa_utils/lib/corsa/api_client.ex
@@ -1,0 +1,202 @@
+defmodule Corsa.ApiClient do
+  @moduledoc """
+  Corsa checker API client.
+
+  The client talks to a caller-provided Corsa executable. Functions return
+  `{:ok, value}` or `{:error, reason}` unless explicitly documented otherwise.
+  """
+
+  alias Corsa.Native
+
+  defstruct [:ref]
+
+  @type t :: %__MODULE__{ref: reference()}
+
+  @spawn_option_keys %{
+    executable: "executable",
+    cwd: "cwd",
+    mode: "mode",
+    request_timeout_ms: "requestTimeoutMs",
+    shutdown_timeout_ms: "shutdownTimeoutMs",
+    outbound_capacity: "outboundCapacity",
+    allow_unstable_upstream_calls: "allowUnstableUpstreamCalls"
+  }
+
+  @spec spawn(map() | String.t()) :: {:ok, t()} | {:error, term()}
+  def spawn(options) when is_map(options) do
+    with {:ok, json} <- encode_spawn_options(options) do
+      spawn_json(json)
+    end
+  end
+
+  def spawn(options_json) when is_binary(options_json), do: spawn_json(options_json)
+
+  @spec spawn_json(String.t()) :: {:ok, t()} | {:error, term()}
+  def spawn_json(options_json) do
+    case Native.api_client_spawn(options_json) do
+      {:error, _reason} = error -> error
+      ref -> {:ok, %__MODULE__{ref: ref}}
+    end
+  end
+
+  @spec initialize(t()) :: {:ok, map()} | {:error, term()}
+  def initialize(client), do: decode_json_result(initialize_json(client))
+
+  @spec initialize_json(t()) :: {:ok, String.t()} | {:error, term()}
+  def initialize_json(%__MODULE__{ref: ref}), do: wrap_result(Native.api_client_initialize_json(ref))
+
+  @spec parse_config_file(t(), String.t()) :: {:ok, map()} | {:error, term()}
+  def parse_config_file(client, file), do: decode_json_result(parse_config_file_json(client, file))
+
+  @spec parse_config_file_json(t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def parse_config_file_json(%__MODULE__{ref: ref}, file) do
+    wrap_result(Native.api_client_parse_config_file_json(ref, file))
+  end
+
+  @spec update_snapshot(t(), map() | nil) :: {:ok, map()} | {:error, term()}
+  def update_snapshot(client, params \\ nil), do: decode_json_result(update_snapshot_json(client, params))
+
+  @spec update_snapshot_json(t(), map() | String.t() | nil) :: {:ok, String.t()} | {:error, term()}
+  def update_snapshot_json(%__MODULE__{ref: ref}, params \\ nil) do
+    with {:ok, params_json} <- encode_optional_json(params) do
+      wrap_result(Native.api_client_update_snapshot_json(ref, params_json))
+    end
+  end
+
+  @spec get_source_file(t(), String.t(), String.t(), String.t()) ::
+          {:ok, binary() | nil} | {:error, term()}
+  def get_source_file(%__MODULE__{ref: ref}, snapshot, project, file) do
+    wrap_result(Native.api_client_get_source_file(ref, snapshot, project, file))
+  end
+
+  @spec get_string_type(t(), String.t(), String.t()) :: {:ok, map()} | {:error, term()}
+  def get_string_type(client, snapshot, project) do
+    decode_json_result(get_string_type_json(client, snapshot, project))
+  end
+
+  @spec get_string_type_json(t(), String.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def get_string_type_json(%__MODULE__{ref: ref}, snapshot, project) do
+    wrap_result(Native.api_client_get_string_type_json(ref, snapshot, project))
+  end
+
+  @spec get_type_at_position(t(), String.t(), String.t(), String.t(), non_neg_integer()) ::
+          {:ok, map()} | {:error, term()}
+  def get_type_at_position(client, snapshot, project, file, position) do
+    decode_json_result(get_type_at_position_json(client, snapshot, project, file, position))
+  end
+
+  @spec get_type_at_position_json(t(), String.t(), String.t(), String.t(), non_neg_integer()) ::
+          {:ok, String.t()} | {:error, term()}
+  def get_type_at_position_json(%__MODULE__{ref: ref}, snapshot, project, file, position) do
+    wrap_result(Native.api_client_get_type_at_position_json(ref, snapshot, project, file, position))
+  end
+
+  @spec get_symbol_at_position(t(), String.t(), String.t(), String.t(), non_neg_integer()) ::
+          {:ok, map()} | {:error, term()}
+  def get_symbol_at_position(client, snapshot, project, file, position) do
+    decode_json_result(get_symbol_at_position_json(client, snapshot, project, file, position))
+  end
+
+  @spec get_symbol_at_position_json(t(), String.t(), String.t(), String.t(), non_neg_integer()) ::
+          {:ok, String.t()} | {:error, term()}
+  def get_symbol_at_position_json(%__MODULE__{ref: ref}, snapshot, project, file, position) do
+    wrap_result(Native.api_client_get_symbol_at_position_json(ref, snapshot, project, file, position))
+  end
+
+  @spec get_type_arguments(t(), String.t(), String.t(), String.t(), non_neg_integer()) ::
+          {:ok, list()} | {:error, term()}
+  def get_type_arguments(client, snapshot, project, type_handle, object_flags) do
+    decode_json_result(get_type_arguments_json(client, snapshot, project, type_handle, object_flags))
+  end
+
+  @spec get_type_arguments_json(t(), String.t(), String.t(), String.t(), non_neg_integer()) ::
+          {:ok, String.t()} | {:error, term()}
+  def get_type_arguments_json(%__MODULE__{ref: ref}, snapshot, project, type_handle, object_flags) do
+    wrap_result(
+      Native.api_client_get_type_arguments_json(ref, snapshot, project, type_handle, object_flags)
+    )
+  end
+
+  @spec get_type_of_symbol(t(), String.t(), String.t(), String.t()) ::
+          {:ok, map()} | {:error, term()}
+  def get_type_of_symbol(client, snapshot, project, symbol) do
+    decode_json_result(get_type_of_symbol_json(client, snapshot, project, symbol))
+  end
+
+  @spec get_type_of_symbol_json(t(), String.t(), String.t(), String.t()) ::
+          {:ok, String.t()} | {:error, term()}
+  def get_type_of_symbol_json(%__MODULE__{ref: ref}, snapshot, project, symbol) do
+    wrap_result(Native.api_client_get_type_of_symbol_json(ref, snapshot, project, symbol))
+  end
+
+  @spec get_declared_type_of_symbol(t(), String.t(), String.t(), String.t()) ::
+          {:ok, map()} | {:error, term()}
+  def get_declared_type_of_symbol(client, snapshot, project, symbol) do
+    decode_json_result(get_declared_type_of_symbol_json(client, snapshot, project, symbol))
+  end
+
+  @spec get_declared_type_of_symbol_json(t(), String.t(), String.t(), String.t()) ::
+          {:ok, String.t()} | {:error, term()}
+  def get_declared_type_of_symbol_json(%__MODULE__{ref: ref}, snapshot, project, symbol) do
+    wrap_result(Native.api_client_get_declared_type_of_symbol_json(ref, snapshot, project, symbol))
+  end
+
+  @spec type_to_string(t(), String.t(), String.t(), String.t(), String.t() | nil, integer() | nil) ::
+          {:ok, String.t()} | {:error, term()}
+  def type_to_string(%__MODULE__{ref: ref}, snapshot, project, type_handle, location \\ nil, flags \\ nil) do
+    wrap_result(
+      Native.api_client_type_to_string(
+        ref,
+        snapshot,
+        project,
+        type_handle,
+        location || "",
+        flags || -1
+      )
+    )
+  end
+
+  @spec call(t(), String.t(), map() | list() | nil) :: {:ok, term()} | {:error, term()}
+  def call(client, method, params \\ nil), do: decode_json_result(call_json(client, method, params))
+
+  @spec call_json(t(), String.t(), map() | list() | String.t() | nil) ::
+          {:ok, String.t()} | {:error, term()}
+  def call_json(%__MODULE__{ref: ref}, method, params \\ nil) do
+    with {:ok, params_json} <- encode_optional_json(params) do
+      wrap_result(Native.api_client_call_json(ref, method, params_json))
+    end
+  end
+
+  @spec call_binary(t(), String.t(), map() | list() | String.t() | nil) ::
+          {:ok, binary() | nil} | {:error, term()}
+  def call_binary(%__MODULE__{ref: ref}, method, params \\ nil) do
+    with {:ok, params_json} <- encode_optional_json(params) do
+      wrap_result(Native.api_client_call_binary(ref, method, params_json))
+    end
+  end
+
+  @spec release_handle(t(), String.t()) :: :ok | {:error, term()}
+  def release_handle(%__MODULE__{ref: ref}, handle), do: Native.api_client_release_handle(ref, handle)
+
+  @spec close(t()) :: :ok | {:error, term()}
+  def close(%__MODULE__{ref: ref}), do: Native.api_client_close(ref)
+
+  defp encode_spawn_options(options) do
+    options
+    |> Enum.into(%{}, fn
+      {key, value} when is_atom(key) -> {Map.get(@spawn_option_keys, key, Atom.to_string(key)), value}
+      {key, value} -> {key, value}
+    end)
+    |> Jason.encode()
+  end
+
+  defp encode_optional_json(nil), do: {:ok, ""}
+  defp encode_optional_json(value) when is_binary(value), do: {:ok, value}
+  defp encode_optional_json(value), do: Jason.encode(value)
+
+  defp decode_json_result({:ok, json}), do: Jason.decode(json)
+  defp decode_json_result({:error, _reason} = error), do: error
+
+  defp wrap_result({:error, _reason} = error), do: error
+  defp wrap_result(value), do: {:ok, value}
+end

--- a/src/bindings/elixir/corsa_utils/lib/corsa/native.ex
+++ b/src/bindings/elixir/corsa_utils/lib/corsa/native.ex
@@ -1,0 +1,74 @@
+defmodule Corsa.Native do
+  @moduledoc false
+
+  use Rustler, otp_app: :corsa_utils, crate: "corsa_elixir"
+
+  def classify_type_text(_text), do: :erlang.nif_error(:nif_not_loaded)
+  def split_top_level_type_text(_text, _delimiter), do: :erlang.nif_error(:nif_not_loaded)
+  def split_type_text(_text), do: :erlang.nif_error(:nif_not_loaded)
+
+  def is_string_like_type_texts(_type_texts), do: :erlang.nif_error(:nif_not_loaded)
+  def is_number_like_type_texts(_type_texts), do: :erlang.nif_error(:nif_not_loaded)
+  def is_bigint_like_type_texts(_type_texts), do: :erlang.nif_error(:nif_not_loaded)
+  def is_any_like_type_texts(_type_texts), do: :erlang.nif_error(:nif_not_loaded)
+  def is_unknown_like_type_texts(_type_texts), do: :erlang.nif_error(:nif_not_loaded)
+  def is_array_like_type_texts(_type_texts), do: :erlang.nif_error(:nif_not_loaded)
+  def is_promise_like_type_texts(_type_texts, _property_names), do: :erlang.nif_error(:nif_not_loaded)
+  def is_error_like_type_texts(_type_texts, _property_names), do: :erlang.nif_error(:nif_not_loaded)
+  def has_unsafe_any_flow(_source_texts, _target_texts), do: :erlang.nif_error(:nif_not_loaded)
+  def is_unsafe_assignment(_source_texts, _target_texts), do: :erlang.nif_error(:nif_not_loaded)
+  def is_unsafe_return(_source_texts, _target_texts), do: :erlang.nif_error(:nif_not_loaded)
+
+  def virtual_document_new(_uri, _language_id, _text), do: :erlang.nif_error(:nif_not_loaded)
+  def virtual_document_untitled(_path, _language_id, _text), do: :erlang.nif_error(:nif_not_loaded)
+
+  def virtual_document_in_memory(_authority, _path, _language_id, _text),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def virtual_document_uri(_document), do: :erlang.nif_error(:nif_not_loaded)
+  def virtual_document_language_id(_document), do: :erlang.nif_error(:nif_not_loaded)
+  def virtual_document_text(_document), do: :erlang.nif_error(:nif_not_loaded)
+  def virtual_document_key(_document), do: :erlang.nif_error(:nif_not_loaded)
+  def virtual_document_version(_document), do: :erlang.nif_error(:nif_not_loaded)
+  def virtual_document_replace(_document, _text), do: :erlang.nif_error(:nif_not_loaded)
+
+  def virtual_document_splice(
+        _document,
+        _start_line,
+        _start_character,
+        _end_line,
+        _end_character,
+        _text
+      ),
+      do: :erlang.nif_error(:nif_not_loaded)
+
+  def api_client_spawn(_options_json), do: :erlang.nif_error(:nif_not_loaded)
+  def api_client_initialize_json(_client), do: :erlang.nif_error(:nif_not_loaded)
+  def api_client_parse_config_file_json(_client, _file), do: :erlang.nif_error(:nif_not_loaded)
+  def api_client_update_snapshot_json(_client, _params_json), do: :erlang.nif_error(:nif_not_loaded)
+  def api_client_get_source_file(_client, _snapshot, _project, _file), do: :erlang.nif_error(:nif_not_loaded)
+  def api_client_get_string_type_json(_client, _snapshot, _project), do: :erlang.nif_error(:nif_not_loaded)
+
+  def api_client_get_type_at_position_json(_client, _snapshot, _project, _file, _position),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def api_client_get_symbol_at_position_json(_client, _snapshot, _project, _file, _position),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def api_client_get_type_arguments_json(_client, _snapshot, _project, _type_handle, _object_flags),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def api_client_get_type_of_symbol_json(_client, _snapshot, _project, _symbol),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def api_client_get_declared_type_of_symbol_json(_client, _snapshot, _project, _symbol),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def api_client_type_to_string(_client, _snapshot, _project, _type_handle, _location, _flags),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def api_client_call_json(_client, _method, _params_json), do: :erlang.nif_error(:nif_not_loaded)
+  def api_client_call_binary(_client, _method, _params_json), do: :erlang.nif_error(:nif_not_loaded)
+  def api_client_release_handle(_client, _handle), do: :erlang.nif_error(:nif_not_loaded)
+  def api_client_close(_client), do: :erlang.nif_error(:nif_not_loaded)
+end

--- a/src/bindings/elixir/corsa_utils/lib/corsa/virtual_document.ex
+++ b/src/bindings/elixir/corsa_utils/lib/corsa/virtual_document.ex
@@ -1,0 +1,56 @@
+defmodule Corsa.VirtualDocument do
+  @moduledoc """
+  In-memory virtual document used by the Corsa LSP surface.
+  """
+
+  alias Corsa.Native
+
+  defstruct [:ref]
+
+  @type t :: %__MODULE__{ref: reference()}
+
+  @spec new(String.t(), String.t(), String.t()) :: {:ok, t()} | {:error, term()}
+  def new(uri, language_id, text) do
+    Native.virtual_document_new(uri, language_id, text)
+    |> wrap_document()
+  end
+
+  @spec untitled(String.t(), String.t(), String.t()) :: {:ok, t()} | {:error, term()}
+  def untitled(path, language_id, text) do
+    Native.virtual_document_untitled(path, language_id, text)
+    |> wrap_document()
+  end
+
+  @spec in_memory(String.t(), String.t(), String.t(), String.t()) :: {:ok, t()} | {:error, term()}
+  def in_memory(authority, path, language_id, text) do
+    Native.virtual_document_in_memory(authority, path, language_id, text)
+    |> wrap_document()
+  end
+
+  @spec uri(t()) :: String.t()
+  def uri(%__MODULE__{ref: ref}), do: Native.virtual_document_uri(ref)
+
+  @spec language_id(t()) :: String.t()
+  def language_id(%__MODULE__{ref: ref}), do: Native.virtual_document_language_id(ref)
+
+  @spec text(t()) :: String.t()
+  def text(%__MODULE__{ref: ref}), do: Native.virtual_document_text(ref)
+
+  @spec key(t()) :: String.t()
+  def key(%__MODULE__{ref: ref}), do: Native.virtual_document_key(ref)
+
+  @spec version(t()) :: integer()
+  def version(%__MODULE__{ref: ref}), do: Native.virtual_document_version(ref)
+
+  @spec replace(t(), String.t()) :: :ok | {:error, term()}
+  def replace(%__MODULE__{ref: ref}, text), do: Native.virtual_document_replace(ref, text)
+
+  @spec splice(t(), non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer(), String.t()) ::
+          :ok | {:error, term()}
+  def splice(%__MODULE__{ref: ref}, start_line, start_character, end_line, end_character, text) do
+    Native.virtual_document_splice(ref, start_line, start_character, end_line, end_character, text)
+  end
+
+  defp wrap_document({:error, _reason} = error), do: error
+  defp wrap_document(ref), do: {:ok, %__MODULE__{ref: ref}}
+end

--- a/src/bindings/elixir/corsa_utils/mix.exs
+++ b/src/bindings/elixir/corsa_utils/mix.exs
@@ -1,0 +1,50 @@
+defmodule CorsaUtils.MixProject do
+  use Mix.Project
+
+  @version "0.35.0"
+  @source_url "https://github.com/ubugeeei-prod/corsa-bind"
+
+  def project do
+    [
+      app: :corsa_utils,
+      version: @version,
+      elixir: "~> 1.16",
+      description: "Elixir bindings for corsa-bind",
+      package: package(),
+      source_url: @source_url,
+      start_permanent: Mix.env() == :prod,
+      compilers: [:rustler] ++ Mix.compilers(),
+      rustler_crates: [
+        corsa_elixir: [
+          path: "native/corsa_elixir",
+          mode: rustler_mode(Mix.env())
+        ]
+      ],
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:jason, "~> 1.4"},
+      {:rustler, "~> 0.37.3", runtime: false}
+    ]
+  end
+
+  defp package do
+    [
+      licenses: ["MIT"],
+      links: %{"GitHub" => @source_url},
+      files: ["lib", "native/corsa_elixir", "mix.exs", "README.md", "LICENSE"]
+    ]
+  end
+
+  defp rustler_mode(:prod), do: :release
+  defp rustler_mode(_), do: :debug
+end

--- a/src/bindings/elixir/corsa_utils/native/corsa_elixir/Cargo.toml
+++ b/src/bindings/elixir/corsa_utils/native/corsa_elixir/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "corsa_elixir"
+version = "0.35.0"
+edition = "2024"
+description = "Rustler NIF for the corsa-bind Elixir binding"
+publish = false
+documentation.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+corsa_client = { version = "0.35.0", path = "../../../../../core/corsa_client" }
+corsa_core = { version = "0.35.0", path = "../../../../../core/corsa_core" }
+corsa_lsp = { version = "0.35.0", path = "../../../../../core/corsa_lsp" }
+corsa_runtime = { version = "0.35.0", path = "../../../../../core/corsa_runtime" }
+lsp-types = "0.97"
+rustler = { version = "0.37.3", features = ["nif_version_2_16"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/src/bindings/elixir/corsa_utils/native/corsa_elixir/src/lib.rs
+++ b/src/bindings/elixir/corsa_utils/native/corsa_elixir/src/lib.rs
@@ -1,0 +1,635 @@
+use std::{collections::HashMap, str::FromStr, sync::Mutex, time::Duration};
+
+use corsa_client::{
+    ApiClient, ApiMode, ApiSpawnConfig, ManagedSnapshot, NodeHandle, ProjectHandle, SnapshotHandle,
+    SymbolHandle, TypeHandle, UpdateSnapshotParams,
+};
+use corsa_core::utils;
+use corsa_lsp::{VirtualChange, VirtualDocument};
+use corsa_runtime::block_on;
+use lsp_types::{Position, Range, Uri};
+use rustler::{Atom, Binary, Env, Error, NifResult, OwnedBinary, ResourceArc, Term};
+use serde::{Serialize, de::DeserializeOwned};
+use serde_json::{Value, json};
+
+mod atoms {
+    rustler::atoms! {
+        ok
+    }
+}
+
+struct DocumentResource {
+    inner: Mutex<VirtualDocument>,
+}
+
+impl rustler::Resource for DocumentResource {}
+
+struct ApiClientState {
+    inner: ApiClient,
+    snapshots: HashMap<String, ManagedSnapshot>,
+}
+
+struct ApiClientResource {
+    inner: Mutex<Option<ApiClientState>>,
+}
+
+impl rustler::Resource for ApiClientResource {}
+
+impl Drop for ApiClientResource {
+    fn drop(&mut self) {
+        if let Ok(mut state) = self.inner.lock() {
+            if let Some(state) = state.take() {
+                let _ = close_state(state);
+            }
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SpawnOptions {
+    executable: String,
+    cwd: Option<String>,
+    mode: Option<String>,
+    request_timeout_ms: Option<u64>,
+    shutdown_timeout_ms: Option<u64>,
+    outbound_capacity: Option<usize>,
+    allow_unstable_upstream_calls: Option<bool>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SnapshotState<'a> {
+    snapshot: &'a SnapshotHandle,
+    projects: &'a [corsa_client::ProjectResponse],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    changes: &'a Option<corsa_client::SnapshotChanges>,
+}
+
+const OBJECT_FLAGS_REFERENCE: u32 = 1 << 2;
+
+fn load(env: Env, _term: Term) -> bool {
+    env.register::<DocumentResource>().is_ok() && env.register::<ApiClientResource>().is_ok()
+}
+
+fn nif_error<T>(message: impl ToString) -> NifResult<T> {
+    Err(Error::Term(Box::new(message.to_string())))
+}
+
+fn read_json<T>(input: &str, label: &str) -> NifResult<T>
+where
+    T: DeserializeOwned,
+{
+    serde_json::from_str(input)
+        .map_err(|error| Error::Term(Box::new(format!("invalid {label}: {error}"))))
+}
+
+fn read_optional_json<T>(input: &str, label: &str) -> NifResult<Option<T>>
+where
+    T: DeserializeOwned,
+{
+    if input.is_empty() {
+        return Ok(None);
+    }
+    read_json(input, label).map(Some)
+}
+
+fn serialize_json<T>(value: &T) -> NifResult<String>
+where
+    T: Serialize,
+{
+    serde_json::to_string(value).map_err(|error| Error::Term(Box::new(error.to_string())))
+}
+
+fn build_spawn_config(options: SpawnOptions) -> NifResult<ApiSpawnConfig> {
+    let mut config = ApiSpawnConfig::new(options.executable);
+    if let Some(cwd) = options.cwd {
+        config = config.with_cwd(cwd);
+    }
+    if let Some(mode) = options.mode {
+        config = config.with_mode(parse_mode(mode.as_str())?);
+    }
+    if let Some(timeout_ms) = options.request_timeout_ms {
+        config = config.with_request_timeout(Some(Duration::from_millis(timeout_ms)));
+    }
+    if let Some(timeout_ms) = options.shutdown_timeout_ms {
+        config = config.with_shutdown_timeout(Duration::from_millis(timeout_ms));
+    }
+    if let Some(capacity) = options.outbound_capacity {
+        config = config.with_outbound_capacity(capacity);
+    }
+    if let Some(allow) = options.allow_unstable_upstream_calls {
+        config = config.with_allow_unstable_upstream_calls(allow);
+    }
+    Ok(config)
+}
+
+fn parse_mode(mode: &str) -> NifResult<ApiMode> {
+    match mode {
+        "jsonrpc" => Ok(ApiMode::AsyncJsonRpcStdio),
+        "msgpack" => Ok(ApiMode::SyncMsgpackStdio),
+        _ => nif_error("unknown corsa api mode"),
+    }
+}
+
+fn close_state(state: ApiClientState) -> Result<(), String> {
+    for snapshot in state.snapshots.into_values() {
+        block_on(snapshot.release()).map_err(|error| error.to_string())?;
+    }
+    block_on(state.inner.close()).map_err(|error| error.to_string())
+}
+
+fn with_client<T>(
+    client: ResourceArc<ApiClientResource>,
+    operation: impl FnOnce(&mut ApiClientState) -> NifResult<T>,
+) -> NifResult<T> {
+    let mut state = client
+        .inner
+        .lock()
+        .map_err(|_| Error::Term(Box::new("corsa api client state poisoned")))?;
+    let Some(state) = state.as_mut() else {
+        return nif_error("corsa api client is closed");
+    };
+    operation(state)
+}
+
+fn into_binary<'a>(env: Env<'a>, bytes: Vec<u8>) -> NifResult<Binary<'a>> {
+    let mut binary = OwnedBinary::new(bytes.len())
+        .ok_or_else(|| Error::Term(Box::new("failed to allocate binary")))?;
+    binary.as_mut_slice().copy_from_slice(bytes.as_slice());
+    Ok(binary.release(env))
+}
+
+#[rustler::nif]
+fn classify_type_text(text: String) -> String {
+    utils::classify_type_text(Some(text.as_str())).to_string()
+}
+
+#[rustler::nif]
+fn split_top_level_type_text(text: String, delimiter: u32) -> NifResult<Vec<String>> {
+    let Some(delimiter) = char::from_u32(delimiter) else {
+        return nif_error("delimiter must be a valid Unicode scalar value");
+    };
+    Ok(utils::split_top_level_type_text(text.as_str(), delimiter))
+}
+
+#[rustler::nif]
+fn split_type_text(text: String) -> Vec<String> {
+    utils::split_type_text(text.as_str())
+}
+
+macro_rules! single_slice_predicate {
+    ($name:ident, $predicate:ident) => {
+        #[rustler::nif]
+        fn $name(type_texts: Vec<String>) -> bool {
+            let refs = type_texts.iter().map(String::as_str).collect::<Vec<_>>();
+            utils::$predicate(&refs)
+        }
+    };
+}
+
+macro_rules! dual_slice_predicate {
+    ($name:ident, $predicate:ident) => {
+        #[rustler::nif]
+        fn $name(type_texts: Vec<String>, property_names: Vec<String>) -> bool {
+            let type_refs = type_texts.iter().map(String::as_str).collect::<Vec<_>>();
+            let property_refs = property_names
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>();
+            utils::$predicate(&type_refs, &property_refs)
+        }
+    };
+}
+
+macro_rules! flow_predicate {
+    ($name:ident, $predicate:ident) => {
+        #[rustler::nif]
+        fn $name(source_texts: Vec<String>, target_texts: Vec<String>) -> bool {
+            let source_refs = source_texts.iter().map(String::as_str).collect::<Vec<_>>();
+            let target_refs = target_texts.iter().map(String::as_str).collect::<Vec<_>>();
+            utils::$predicate(&source_refs, &target_refs)
+        }
+    };
+}
+
+single_slice_predicate!(is_string_like_type_texts, is_string_like_type_texts);
+single_slice_predicate!(is_number_like_type_texts, is_number_like_type_texts);
+single_slice_predicate!(is_bigint_like_type_texts, is_bigint_like_type_texts);
+single_slice_predicate!(is_any_like_type_texts, is_any_like_type_texts);
+single_slice_predicate!(is_unknown_like_type_texts, is_unknown_like_type_texts);
+single_slice_predicate!(is_array_like_type_texts, is_array_like_type_texts);
+dual_slice_predicate!(is_promise_like_type_texts, is_promise_like_type_texts);
+dual_slice_predicate!(is_error_like_type_texts, is_error_like_type_texts);
+flow_predicate!(has_unsafe_any_flow, has_unsafe_any_flow);
+flow_predicate!(is_unsafe_assignment, is_unsafe_assignment);
+flow_predicate!(is_unsafe_return, is_unsafe_return);
+
+#[rustler::nif]
+fn virtual_document_new(
+    uri: String,
+    language_id: String,
+    text: String,
+) -> NifResult<ResourceArc<DocumentResource>> {
+    let uri = Uri::from_str(uri.as_str())
+        .map_err(|error| Error::Term(Box::new(format!("invalid uri: {error}"))))?;
+    Ok(ResourceArc::new(DocumentResource {
+        inner: Mutex::new(VirtualDocument::new(uri, language_id, text)),
+    }))
+}
+
+#[rustler::nif]
+fn virtual_document_untitled(
+    path: String,
+    language_id: String,
+    text: String,
+) -> NifResult<ResourceArc<DocumentResource>> {
+    let document = VirtualDocument::untitled(path, language_id, text)
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+    Ok(ResourceArc::new(DocumentResource {
+        inner: Mutex::new(document),
+    }))
+}
+
+#[rustler::nif]
+fn virtual_document_in_memory(
+    authority: String,
+    path: String,
+    language_id: String,
+    text: String,
+) -> NifResult<ResourceArc<DocumentResource>> {
+    let document = VirtualDocument::in_memory(authority, path, language_id, text)
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+    Ok(ResourceArc::new(DocumentResource {
+        inner: Mutex::new(document),
+    }))
+}
+
+#[rustler::nif]
+fn virtual_document_uri(document: ResourceArc<DocumentResource>) -> NifResult<String> {
+    let document = document
+        .inner
+        .lock()
+        .map_err(|_| Error::Term(Box::new("virtual document state poisoned")))?;
+    Ok(document.uri.to_string())
+}
+
+#[rustler::nif]
+fn virtual_document_language_id(document: ResourceArc<DocumentResource>) -> NifResult<String> {
+    let document = document
+        .inner
+        .lock()
+        .map_err(|_| Error::Term(Box::new("virtual document state poisoned")))?;
+    Ok(document.language_id.to_string())
+}
+
+#[rustler::nif]
+fn virtual_document_text(document: ResourceArc<DocumentResource>) -> NifResult<String> {
+    let document = document
+        .inner
+        .lock()
+        .map_err(|_| Error::Term(Box::new("virtual document state poisoned")))?;
+    Ok(document.text.to_string())
+}
+
+#[rustler::nif]
+fn virtual_document_key(document: ResourceArc<DocumentResource>) -> NifResult<String> {
+    let document = document
+        .inner
+        .lock()
+        .map_err(|_| Error::Term(Box::new("virtual document state poisoned")))?;
+    Ok(document.key().to_string())
+}
+
+#[rustler::nif]
+fn virtual_document_version(document: ResourceArc<DocumentResource>) -> NifResult<i32> {
+    let document = document
+        .inner
+        .lock()
+        .map_err(|_| Error::Term(Box::new("virtual document state poisoned")))?;
+    Ok(document.version)
+}
+
+#[rustler::nif]
+fn virtual_document_replace(
+    document: ResourceArc<DocumentResource>,
+    text: String,
+) -> NifResult<Atom> {
+    let mut document = document
+        .inner
+        .lock()
+        .map_err(|_| Error::Term(Box::new("virtual document state poisoned")))?;
+    document
+        .apply_changes(&[VirtualChange::replace(text)])
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+    Ok(atoms::ok())
+}
+
+#[rustler::nif]
+fn virtual_document_splice(
+    document: ResourceArc<DocumentResource>,
+    start_line: u32,
+    start_character: u32,
+    end_line: u32,
+    end_character: u32,
+    text: String,
+) -> NifResult<Atom> {
+    let mut document = document
+        .inner
+        .lock()
+        .map_err(|_| Error::Term(Box::new("virtual document state poisoned")))?;
+    let range = Range::new(
+        Position::new(start_line, start_character),
+        Position::new(end_line, end_character),
+    );
+    document
+        .apply_changes(&[VirtualChange::splice(range, text)])
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+    Ok(atoms::ok())
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_spawn(options_json: String) -> NifResult<ResourceArc<ApiClientResource>> {
+    let options = read_json::<SpawnOptions>(options_json.as_str(), "options_json")?;
+    let config = build_spawn_config(options)?;
+    let inner = block_on(ApiClient::spawn(config))
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+    Ok(ResourceArc::new(ApiClientResource {
+        inner: Mutex::new(Some(ApiClientState {
+            inner,
+            snapshots: HashMap::new(),
+        })),
+    }))
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_initialize_json(client: ResourceArc<ApiClientResource>) -> NifResult<String> {
+    with_client(client, |state| {
+        let response = block_on(state.inner.initialize())
+            .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+        serialize_json(response.as_ref())
+    })
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_parse_config_file_json(
+    client: ResourceArc<ApiClientResource>,
+    file: String,
+) -> NifResult<String> {
+    with_client(client, |state| {
+        let response = block_on(state.inner.parse_config_file(file))
+            .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+        serialize_json(&response)
+    })
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_update_snapshot_json(
+    client: ResourceArc<ApiClientResource>,
+    params_json: String,
+) -> NifResult<String> {
+    with_client(client, |state| {
+        let params =
+            read_optional_json::<UpdateSnapshotParams>(params_json.as_str(), "params_json")?
+                .unwrap_or_default();
+        let snapshot = block_on(state.inner.update_snapshot(params))
+            .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+        let payload = serialize_json(&SnapshotState {
+            snapshot: &snapshot.handle,
+            projects: snapshot.projects.as_slice(),
+            changes: &snapshot.changes,
+        })?;
+        state
+            .snapshots
+            .insert(snapshot.handle.as_str().to_owned(), snapshot);
+        Ok(payload)
+    })
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_get_source_file<'a>(
+    env: Env<'a>,
+    client: ResourceArc<ApiClientResource>,
+    snapshot: String,
+    project: String,
+    file: String,
+) -> NifResult<Option<Binary<'a>>> {
+    with_client(client, |state| {
+        let payload = block_on(state.inner.get_source_file(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            file,
+        ))
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+        payload
+            .map(|payload| into_binary(env, payload.into_bytes()))
+            .transpose()
+    })
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_get_string_type_json(
+    client: ResourceArc<ApiClientResource>,
+    snapshot: String,
+    project: String,
+) -> NifResult<String> {
+    with_client(client, |state| {
+        let response = block_on(state.inner.get_string_type(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+        ))
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+        serialize_json(&response)
+    })
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_get_type_at_position_json(
+    client: ResourceArc<ApiClientResource>,
+    snapshot: String,
+    project: String,
+    file: String,
+    position: u32,
+) -> NifResult<String> {
+    with_client(client, |state| {
+        let response = block_on(state.inner.get_type_at_position(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            file,
+            position,
+        ))
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+        serialize_json(&response)
+    })
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_get_symbol_at_position_json(
+    client: ResourceArc<ApiClientResource>,
+    snapshot: String,
+    project: String,
+    file: String,
+    position: u32,
+) -> NifResult<String> {
+    with_client(client, |state| {
+        let response = block_on(state.inner.get_symbol_at_position(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            file,
+            position,
+        ))
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+        serialize_json(&response)
+    })
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_get_type_arguments_json(
+    client: ResourceArc<ApiClientResource>,
+    snapshot: String,
+    project: String,
+    type_handle: String,
+    object_flags: u32,
+) -> NifResult<String> {
+    with_client(client, |state| {
+        if object_flags & OBJECT_FLAGS_REFERENCE == 0 {
+            return serialize_json(&Vec::<corsa_client::TypeResponse>::new());
+        }
+        let response = block_on(state.inner.get_type_arguments(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            TypeHandle::from(type_handle.as_str()),
+        ))
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+        serialize_json(&response)
+    })
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_get_type_of_symbol_json(
+    client: ResourceArc<ApiClientResource>,
+    snapshot: String,
+    project: String,
+    symbol: String,
+) -> NifResult<String> {
+    with_client(client, |state| {
+        let response = block_on(state.inner.get_type_of_symbol(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            SymbolHandle::from(symbol.as_str()),
+        ))
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+        serialize_json(&response)
+    })
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_get_declared_type_of_symbol_json(
+    client: ResourceArc<ApiClientResource>,
+    snapshot: String,
+    project: String,
+    symbol: String,
+) -> NifResult<String> {
+    with_client(client, |state| {
+        let response = block_on(state.inner.get_declared_type_of_symbol(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            SymbolHandle::from(symbol.as_str()),
+        ))
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+        serialize_json(&response)
+    })
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_type_to_string(
+    client: ResourceArc<ApiClientResource>,
+    snapshot: String,
+    project: String,
+    type_handle: String,
+    location: String,
+    flags: i32,
+) -> NifResult<String> {
+    with_client(client, |state| {
+        block_on(state.inner.type_to_string(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            TypeHandle::from(type_handle.as_str()),
+            (!location.is_empty()).then(|| NodeHandle::from(location.as_str())),
+            (flags >= 0).then_some(flags),
+        ))
+        .map_err(|error| Error::Term(Box::new(error.to_string())))
+    })
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_call_json(
+    client: ResourceArc<ApiClientResource>,
+    method: String,
+    params_json: String,
+) -> NifResult<String> {
+    with_client(client, |state| {
+        let params = read_optional_json::<Value>(params_json.as_str(), "params_json")?
+            .unwrap_or(Value::Null);
+        let response = block_on(state.inner.raw_json_request(method.as_str(), params))
+            .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+        serialize_json(&response)
+    })
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_call_binary<'a>(
+    env: Env<'a>,
+    client: ResourceArc<ApiClientResource>,
+    method: String,
+    params_json: String,
+) -> NifResult<Option<Binary<'a>>> {
+    with_client(client, |state| {
+        let params = read_optional_json::<Value>(params_json.as_str(), "params_json")?
+            .unwrap_or(Value::Null);
+        let response = block_on(state.inner.raw_binary_request(method.as_str(), params))
+            .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+        response
+            .map(|payload| into_binary(env, payload.into_bytes()))
+            .transpose()
+    })
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_release_handle(
+    client: ResourceArc<ApiClientResource>,
+    handle: String,
+) -> NifResult<Atom> {
+    with_client(client, |state| {
+        let snapshot = state.snapshots.remove(handle.as_str());
+        if let Some(snapshot) = snapshot {
+            block_on(snapshot.release())
+                .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+            return Ok(atoms::ok());
+        }
+        block_on(
+            state
+                .inner
+                .raw_json_request("release", json!({ "handle": handle })),
+        )
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+        Ok(atoms::ok())
+    })
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn api_client_close(client: ResourceArc<ApiClientResource>) -> NifResult<Atom> {
+    let state = {
+        let mut state = client
+            .inner
+            .lock()
+            .map_err(|_| Error::Term(Box::new("corsa api client state poisoned")))?;
+        state.take()
+    };
+    if let Some(state) = state {
+        close_state(state).map_err(|error| Error::Term(Box::new(error)))?;
+    }
+    Ok(atoms::ok())
+}
+
+rustler::init!("Elixir.Corsa.Native", load = load);

--- a/src/bindings/elixir/corsa_utils/test/corsa_utils_test.exs
+++ b/src/bindings/elixir/corsa_utils/test/corsa_utils_test.exs
@@ -1,0 +1,31 @@
+defmodule CorsaUtilsTest do
+  use ExUnit.Case, async: true
+
+  test "classifies and splits type text" do
+    assert Corsa.classify_type_text("string[]") == "array"
+    assert Corsa.split_type_text("string | number") == ["string", "number"]
+    assert Corsa.split_top_level_type_text("Map<string, number>, Set<string>", ",") == [
+             "Map<string, number>",
+             "Set<string>"
+           ]
+  end
+
+  test "checks type predicates" do
+    assert Corsa.is_string_like_type_texts(["string"])
+    refute Corsa.is_number_like_type_texts(["string"])
+    assert Corsa.is_unsafe_assignment(["any"], ["string"])
+  end
+
+  test "edits a virtual document" do
+    assert {:ok, document} =
+             Corsa.VirtualDocument.untitled("/virtual/demo.ts", "typescript", "const value = 1;")
+
+    assert Corsa.VirtualDocument.text(document) == "const value = 1;"
+    assert Corsa.VirtualDocument.version(document) == 0
+
+    assert :ok = Corsa.VirtualDocument.replace(document, "const value = 2;")
+
+    assert Corsa.VirtualDocument.text(document) == "const value = 2;"
+    assert Corsa.VirtualDocument.version(document) == 1
+  end
+end

--- a/src/bindings/elixir/corsa_utils/test/test_helper.exs
+++ b/src/bindings/elixir/corsa_utils/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Summary
- add an Elixir `corsa_utils` Mix package backed by a Rustler NIF
- expose utils, virtual document, and API client surfaces for Elixir
- document the Elixir binding and update support/CI guidance

## Verification
- cargo fmt --all --check
- cargo check -p corsa_elixir
- cargo test -p corsa_elixir
- cargo clippy -p corsa_elixir --all-targets -- -D warnings
- cargo clippy --workspace --all-targets -- -D warnings
- vp fmt --check
- vp run -w docs_build

## Notes
- `mix test` was not run locally because `elixir` and `mix` are not installed in this environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782968605&installation_id=136613492&pr_number=267&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F267&signature=55d3a192778a37adfbce70b52b9109dafb605154d97f063370f92ef980fc0b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->