### PR TITLE
feat: export signature kind

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
@@ -36,6 +36,11 @@ describe("api surface", () => {
     expect(tsestreeEntry.AST_NODE_TYPES.Identifier).toBe("Identifier");
   });
 
+  it("re-exports SignatureKind from the root entry", () => {
+    expect(main.SignatureKind.Call).toBe(0);
+    expect(main.SignatureKind.Construct).toBe(1);
+  });
+
   it("re-exports ESTree types from the root entry", () => {
     expectTypeOf<RootESTree["NewExpression"]>().toMatchTypeOf<{ type: "NewExpression" }>();
     expectTypeOf<RootESTree["BindingIdentifier"]["typeAnnotation"]>().toEqualTypeOf<

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -2,6 +2,7 @@ import type { Node } from "@oxlint/plugins";
 
 import { createNodeMaps, toPosition } from "./node_map";
 import { sessionForContext } from "./registry";
+import { SignatureKind } from "./types";
 import type {
   ContextWithParserOptions,
   CorsaNode,
@@ -213,7 +214,7 @@ function typeOfNewExpression(node: Node, checker: CorsaTypeCheckerShape): CorsaT
   if (!calleeType) {
     return undefined;
   }
-  const constructSignature = checker.getSignaturesOfType(calleeType, 1)[0];
+  const constructSignature = checker.getSignaturesOfType(calleeType, SignatureKind.Construct)[0];
   return constructSignature
     ? (checker.getReturnTypeOfSignature(constructSignature) ?? calleeType)
     : calleeType;

--- a/src/bindings/nodejs/corsa_oxlint/ts/index.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/index.ts
@@ -12,6 +12,7 @@ export { compatPlugin, definePlugin, defineRule } from "./plugin";
 export type { Plugin, Rule } from "./plugin";
 export { getParserServices } from "./parser_services";
 export { RuleTester } from "./rule_tester";
+export { SignatureKind } from "./types";
 export type { RuleTesterConfig } from "./rule_tester";
 export { TSESLint } from "./ts_eslint";
 export * as rules from "./rules/index";

--- a/src/bindings/nodejs/corsa_oxlint/ts/types.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/types.ts
@@ -73,6 +73,11 @@ export interface CorsaSignature {
   readonly target?: string;
 }
 
+export enum SignatureKind {
+  Call = 0,
+  Construct = 1,
+}
+
 export interface CorsaTypePredicate {
   readonly kind: number;
   readonly parameterIndex: number;
@@ -109,7 +114,7 @@ export interface CorsaTypeCheckerShape {
   typeToString(type: CorsaType, enclosingDeclaration?: Node | CorsaNode, flags?: number): string;
   getBaseTypeOfLiteralType(type: CorsaType): CorsaType | undefined;
   getPropertiesOfType(type: CorsaType): readonly CorsaSymbol[];
-  getSignaturesOfType(type: CorsaType, kind: number): readonly CorsaSignature[];
+  getSignaturesOfType(type: CorsaType, kind: SignatureKind): readonly CorsaSignature[];
   getReturnTypeOfSignature(signature: CorsaSignature): CorsaType | undefined;
   getTypePredicateOfSignature(signature: CorsaSignature): CorsaTypePredicate | undefined;
   getBaseTypes(type: CorsaType): readonly CorsaType[];


### PR DESCRIPTION
## Summary

- Export `SignatureKind` from the `corsa-oxlint` root entrypoint.
- Type `getSignaturesOfType` with the named signature kind enum.
- Use `SignatureKind.Construct` internally for construct signatures.

Closes #273

## Verification

- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts`
- `vp check --no-fmt`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782999686&installation_id=136613492&pr_number=274&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F274&signature=7a74efcd25004d071eacc9aa09166ca43207fc87b33eab0cd3a47ef82ac6dd8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->