### PR TITLE
feat: expose type symbol lookup

### DIFF
--- a/src/bindings/nodejs/corsa_node/index.d.ts
+++ b/src/bindings/nodejs/corsa_node/index.d.ts
@@ -34,6 +34,9 @@ export declare class CorsaApiClient {
   /** Resolves the checker symbol visible at a file position. */
   getSymbolAtPosition(snapshot: string, project: string, file: string, position: number): any
   getSymbolAtPositionAsync(snapshot: string, project: string, file: string, position: number): Promise<unknown>
+  /** Resolves the symbol attached to a checker type. */
+  getSymbolOfType(snapshot: string, typeHandle: string): any
+  getSymbolOfTypeAsync(snapshot: string, typeHandle: string): Promise<unknown>
   /** Resolves type arguments for type-reference and mapped objects, and returns [] otherwise. */
   getTypeArguments(snapshot: string, project: string, typeHandle: string, objectFlags?: number | undefined | null): any
   /** Resolves type arguments and prefers structural handles from source locations when available. */

--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -137,6 +137,10 @@ enum JsonTaskKind {
         file: String,
         position: u32,
     },
+    GetSymbolOfType {
+        snapshot: String,
+        type_handle: String,
+    },
     GetTypeArguments {
         snapshot: String,
         project: String,
@@ -275,6 +279,17 @@ impl<'task> ScopedTask<'task> for JsonApiTask {
                     ProjectHandle::from(project.as_str()),
                     file.clone(),
                     *position,
+                ))
+                .map_err(into_napi_error)?;
+                to_value(&response)
+            }
+            JsonTaskKind::GetSymbolOfType {
+                snapshot,
+                type_handle,
+            } => {
+                let response = block_on(self.client.get_symbol_of_type(
+                    SnapshotHandle::from(snapshot.as_str()),
+                    TypeHandle::from(type_handle.as_str()),
                 ))
                 .map_err(into_napi_error)?;
                 to_value(&response)
@@ -778,6 +793,32 @@ impl CorsaApiClient {
                 project,
                 file,
                 position,
+            },
+        })
+    }
+
+    /// Resolves the symbol attached to a checker type.
+    #[napi]
+    pub fn get_symbol_of_type(&self, snapshot: String, type_handle: String) -> Result<Value> {
+        let response = block_on(self.inner.get_symbol_of_type(
+            SnapshotHandle::from(snapshot.as_str()),
+            TypeHandle::from(type_handle.as_str()),
+        ))
+        .map_err(into_napi_error)?;
+        to_value(&response)
+    }
+
+    #[napi]
+    pub fn get_symbol_of_type_async(
+        &self,
+        snapshot: String,
+        type_handle: String,
+    ) -> AsyncTask<JsonApiTask> {
+        AsyncTask::new(JsonApiTask {
+            client: self.inner.clone(),
+            kind: JsonTaskKind::GetSymbolOfType {
+                snapshot,
+                type_handle,
             },
         })
     }

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -288,6 +288,7 @@ describe("CorsaApiClient", () => {
         client.getSymbolAtPosition(snapshot.snapshot, project.id, "/workspace/src/index.ts", 1)
           ?.name,
       ).toBe("value");
+      expect(client.getSymbolOfType(snapshot.snapshot, stringType.id)?.name).toBe("value");
       expect(
         client.getTypeArguments(
           snapshot.snapshot,
@@ -361,6 +362,9 @@ describe("CorsaApiClient", () => {
         1,
       );
       expect(nodeType?.id).toBe("t0000000000000001");
+      await expect(client.getSymbolOfTypeAsync(snapshot.snapshot, stringType.id)).resolves.toEqual(
+        expect.objectContaining({ name: "value" }),
+      );
       await expect(
         client.typeToStringAsync(snapshot.snapshot, project.id, stringType.id),
       ).resolves.toBe("type:string");

--- a/src/bindings/nodejs/corsa_node/ts/index.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.ts
@@ -80,6 +80,8 @@ export interface CorsaApiClient {
     file: string,
     position: number,
   ): Promise<SymbolResponse | null>;
+  getSymbolOfType(snapshot: string, typeHandle: string): SymbolResponse | null;
+  getSymbolOfTypeAsync(snapshot: string, typeHandle: string): Promise<SymbolResponse | null>;
   getTypeArguments(
     snapshot: string,
     project: string,

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -68,6 +68,9 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
     getSymbolById(id) {
       return sessionForContext(context).session.getSymbol(id);
     },
+    getSymbolOfType(type) {
+      return sessionForContext(context).session.getSymbolOfType(type);
+    },
     getNode(node) {
       return sessionForContext(context).session.getNode(node);
     },

--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -228,6 +228,7 @@ describe("corsa oxlint", () => {
       },
       types: [{ name: "string" }, { name: "number" }],
     };
+    const unionSymbol = { name: "UnionAlias" };
     const implementedType = { name: "Implemented" };
     const implementationExpression = { kind: "implementation-expression" };
     const implementedClause = {
@@ -256,6 +257,9 @@ describe("corsa oxlint", () => {
       },
       getSymbolAtLocation() {
         return { kind: "symbol" };
+      },
+      getSymbolOfType() {
+        return unionSymbol;
       },
       getTypeArguments() {
         return [typeArgument];
@@ -314,6 +318,7 @@ describe("corsa oxlint", () => {
     expect(corsaChecker.isUnionType(type as never)).toBe(true);
     expect(corsaChecker.getTypesOfType(type as never)).toEqual(unionType.types);
     expect(corsaChecker.getBaseTypes(type as never)).toEqual([]);
+    expect(corsaChecker.getSymbolOfType(type as never)).toBe(unionSymbol);
     expect(corsaChecker.getImplementedTypes(classNode as never)).toEqual([implementedType]);
     expect(corsaChecker.getImplementedTypesOfType(classType as never)).toEqual([implementedType]);
     expect(corsaChecker.getTypeArguments(type as never)).toEqual([typeArgument]);

--- a/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
@@ -129,6 +129,12 @@ function createEslintTypeChecker(
     getSymbolById(id) {
       return typeof id === "object" ? id : undefined;
     },
+    getSymbolOfType(type) {
+      return (
+        callChecker(source, "getSymbolOfType", type) ??
+        ((type as { readonly symbol?: unknown }).symbol as never)
+      );
+    },
     getNode(node) {
       return typeof node === "object" ? node : undefined;
     },

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -190,11 +190,23 @@ export class CorsaProjectSession {
     if (!typeId || !this.#snapshot) {
       return undefined;
     }
-    const resolved = this.client().callJson<CorsaSymbol | null>("getSymbolOfType", {
-      snapshot: this.#snapshot,
-      type: typeId,
-    });
+    const resolved = this.client().getSymbolOfType(this.#snapshot, typeId) as CorsaSymbol | null;
     return resolved?.id === symbol ? this.rememberSymbol(resolved) : undefined;
+  }
+
+  getSymbolOfType(type: CorsaType): CorsaSymbol | undefined {
+    if (type.symbol) {
+      const symbol = this.getSymbol(type.symbol);
+      if (symbol) {
+        return symbol;
+      }
+    }
+    if (!this.#snapshot) {
+      return undefined;
+    }
+    return this.rememberSymbol(
+      this.client().getSymbolOfType(this.#snapshot, type.id) as CorsaSymbol | undefined,
+    );
   }
 
   getNode(node: string | CorsaNode): CorsaNode | undefined {

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -1027,6 +1027,61 @@ describe("corsa oxlint type locations", () => {
     expect(seen.mapped.target).toBe("Readonly<T>");
   });
 
+  integrationCase("exposes symbols from type handles", () => {
+    const seen: Record<string, string | undefined> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "type-symbol-accessor",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise type to symbol lookup",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          TSPropertySignature(node: any) {
+            if (node.key?.name !== "animal") {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node);
+            seen.animal = type ? checker.getSymbolOfType(type)?.name : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("type-symbol-accessor", rule as any, {
+      valid: [
+        {
+          code: ["class Animal {}", "interface Bag {", "  animal: Animal;", "}"].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.animal).toBe("Animal");
+  });
+
   it("sends linted source text overlay changes when it differs from disk", () => {
     const workspace = mkdtempSync(resolve(tmpdir(), "corsa-oxlint-overlay-"));
     const srcDir = resolve(workspace, "src");

--- a/src/bindings/nodejs/corsa_oxlint/ts/types.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/types.ts
@@ -101,6 +101,7 @@ export interface CorsaTypeCheckerShape {
   getSymbolAtLocation(node: Node | CorsaNode): CorsaSymbol | undefined;
   getSymbol(symbol: string | CorsaSymbol): CorsaSymbol | undefined;
   getSymbolById(id: string): CorsaSymbol | undefined;
+  getSymbolOfType(type: CorsaType): CorsaSymbol | undefined;
   getNode(node: string | CorsaNode): CorsaNode | undefined;
   getNodeById(id: string): CorsaNode | undefined;
   getTypeOfSymbol(symbol: CorsaSymbol): CorsaType | undefined;


### PR DESCRIPTION
## Summary

- Add native `getSymbolOfType` sync and async methods on `@corsa-bind/napi`.
- Expose `CorsaTypeCheckerShape.getSymbolOfType(type)` in `corsa-oxlint`.
- Route existing type-symbol recovery through the typed Rust API method instead of raw JSON.

Closes #272

## Verification

- `cargo test -p corsa_client get_symbol_of_type`
- `pnpm exec napi build --platform` from `src/bindings/nodejs/corsa_node`
- `cargo build -p corsa --bin mock_corsa`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_node/ts/index.test.ts`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts -t "exposes symbols from type handles"`
- `vp check --no-fmt`
- `cargo fmt --all --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783000058&installation_id=136613492&pr_number=275&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F275&signature=3734c7e460602dfdb8fd4b5d44a3c4315e8d4e39f9c061bd6c5318e58d9b17a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->