### PR TITLE
fix: preserve active snapshot handles

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
@@ -66,6 +66,39 @@ describe("CorsaProjectSession", () => {
     expect(clients[0]?.updateSnapshot).toHaveBeenCalledTimes(1);
   });
 
+  it("does not rotate an unchanged snapshot only because the cache lifetime expired", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    try {
+      clients.length = 0;
+      const runtime = {
+        executable: "/tmp/corsa",
+        cwd: "/tmp",
+        mode: "msgpack",
+        cacheLifetimeMs: 1,
+      } as const;
+      const session = new CorsaProjectSession(
+        {
+          filename: "/tmp/one.ts",
+          rootDir: "/tmp",
+          configPath: "/tmp/tsconfig.json",
+          runtime,
+        },
+        runtime,
+      );
+
+      const type = session.getTypeAtPosition("/tmp/one.ts", 0);
+      vi.advanceTimersByTime(2);
+      session.typeToString(type as never);
+      session.getTypeAtPosition("/tmp/one.ts", 1);
+
+      expect(clients[0]?.updateSnapshot).toHaveBeenCalledTimes(1);
+      expect(clients[0]?.releaseHandle).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // Regression for GH#206: upstream Corsa occasionally drops a type handle
   // from its snapshot registry after a base-types query on a class with no
   // explicit `extends` clause, which then makes a follow-up

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -75,6 +75,7 @@ export class CorsaProjectSession {
   #typeSourceById = new Map<string, SourceSlice>();
   #typeTextById = new Map<string, string>();
   #lastRefreshMs = 0;
+  #snapshotHasIssuedHandles = false;
   #supportsOverlayChanges?: boolean;
 
   constructor(
@@ -496,6 +497,9 @@ export class CorsaProjectSession {
   }
 
   private rememberType<T extends CorsaType | undefined>(type: T): T {
+    if (type) {
+      this.#snapshotHasIssuedHandles = true;
+    }
     if (type?.symbol) {
       this.#symbolTypeById.set(type.symbol, type.id);
     }
@@ -548,6 +552,7 @@ export class CorsaProjectSession {
     if (!symbol) {
       return symbol;
     }
+    this.#snapshotHasIssuedHandles = true;
     const synthetic = this.#syntheticSymbolsById.get(symbol.id);
     if (synthetic) {
       return synthetic as T;
@@ -635,6 +640,7 @@ export class CorsaProjectSession {
     this.#nodesById.clear();
     this.#typeLookupById.clear();
     this.#typeSourceById.clear();
+    this.#snapshotHasIssuedHandles = false;
   }
 
   private parameterInfosForDeclaration(
@@ -752,7 +758,11 @@ export class CorsaProjectSession {
       lintSourceText: sourceText,
       sourceText: overlayText,
     };
-    const stale = !this.#snapshot || mtimeChanged || textChanged || expired;
+    const stale =
+      !this.#snapshot ||
+      mtimeChanged ||
+      textChanged ||
+      (expired && !this.#snapshotHasIssuedHandles);
     if (!stale) {
       return prepared;
     }


### PR DESCRIPTION
## Summary

- Track whether the active snapshot has issued type or symbol handles.
- Avoid rotating and releasing an unchanged snapshot solely due to `cacheLifetimeMs` once handles exist.
- Add a regression test for the `cacheLifetimeMs: 1` handle-preservation path.

Closes #270

## Verification

- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/session.test.ts`
- `vp check --no-fmt`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783000185&installation_id=136613492&pr_number=276&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F276&signature=62858ce50bf01d749f132405d006f148b8b08a9359e02d0e85910b34d8619e8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->