### PR TITLE
fix: resolve qualified implemented types

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -414,10 +414,12 @@ function implementedTypesFromSourceText(
         end,
         range: [pos, end] as const,
       };
-      const symbol = checker.getSymbolAtLocation(lookupNode);
+      const nameNode = implementedClauseNameNode(lookupNode, raw);
+      const symbol =
+        checker.getSymbolAtLocation(nameNode) ?? checker.getSymbolAtLocation(lookupNode);
       const type = symbol
         ? (checker.getDeclaredTypeOfSymbol(symbol) ?? checker.getTypeOfSymbol(symbol))
-        : checker.getTypeAtLocation(lookupNode);
+        : (checker.getTypeAtLocation(nameNode) ?? checker.getTypeAtLocation(lookupNode));
       if (type) {
         // Implemented-interface handles come back with empty `texts`, so warm
         // the type-text cache with the `implements` identifier. If upstream
@@ -428,6 +430,49 @@ function implementedTypesFromSourceText(
       return type;
     })
     .filter((type): type is CorsaType => type !== undefined);
+}
+
+function implementedClauseNameNode(node: CorsaNode, raw: string): CorsaNode {
+  const range = lastTypeNameIdentifierRange(raw);
+  if (!range) {
+    return node;
+  }
+  const pos = node.pos + range.start;
+  const end = node.pos + range.end;
+  return {
+    fileName: node.fileName,
+    pos,
+    end,
+    range: [pos, end] as const,
+  };
+}
+
+function lastTypeNameIdentifierRange(
+  text: string,
+): { readonly start: number; readonly end: number } | undefined {
+  let last: { start: number; end: number } | undefined;
+  const scanner = createScanner();
+  for (let index = 0; index < text.length; index += 1) {
+    const nextIndex = scanner.skip(text, index);
+    if (nextIndex > index) {
+      index = nextIndex - 1;
+      continue;
+    }
+    const char = text[index];
+    if (char === "<") {
+      break;
+    }
+    if (!isIdentifierStart(char)) {
+      continue;
+    }
+    let end = index + 1;
+    while (isIdentifierPart(text[end])) {
+      end += 1;
+    }
+    last = { start: index, end };
+    index = end - 1;
+  }
+  return last;
 }
 
 function findClassBodyOpen(text: string, start: number): number {
@@ -487,7 +532,11 @@ function matchesKeyword(text: string, keyword: string, index: number): boolean {
 }
 
 function isIdentifierPart(char: string | undefined): boolean {
-  return char !== undefined && /[A-Za-z0-9_$]/.test(char);
+  return char !== undefined && (isIdentifierStart(char) || /[0-9]/.test(char));
+}
+
+function isIdentifierStart(char: string | undefined): boolean {
+  return char !== undefined && /[A-Za-z_$]/.test(char);
 }
 
 function splitTopLevelRanges(

--- a/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
@@ -149,6 +149,92 @@ describe("corsa oxlint implemented types", () => {
     expect(seen.byType).toEqual(["IChild"]);
   });
 
+  integrationCase("resolves namespace-qualified implemented interfaces from class types", () => {
+    const seen: Record<string, readonly string[] | undefined> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "qualified-implemented-types-of-type",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise qualified implemented types resolved from a class type",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          ClassDeclaration(node: any) {
+            const className = node.id?.name;
+            if (!className) {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node);
+            seen[className] = type
+              ? checker
+                  .getImplementedTypesOfType(type)
+                  .map((implemented) => checker.typeToString(implemented))
+              : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("qualified-implemented-types-of-type", rule as any, {
+      valid: [
+        {
+          code: [
+            "interface IFoo {",
+            "  foo: string;",
+            "}",
+            "class A implements IFoo {",
+            '  foo = "";',
+            "}",
+            "namespace ns {",
+            "  export interface IBar {",
+            "    bar: number;",
+            "  }",
+            "}",
+            "class B implements ns.IBar {",
+            "  bar = 1;",
+            "}",
+            "namespace outer {",
+            "  export namespace inner {",
+            "    export interface IBaz {",
+            "      baz: boolean;",
+            "    }",
+            "  }",
+            "}",
+            "class C implements outer.inner.IBaz {",
+            "  baz = true;",
+            "}",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.A).toEqual(["IFoo"]);
+    expect(seen.B).toEqual(["IBar"]);
+    expect(seen.C).toEqual(["IBaz"]);
+  });
+
   integrationCase(
     "resolves implemented interfaces after getBaseTypes has been called on the same type",
     () => {


### PR DESCRIPTION
## Summary

- Resolve implemented-clause lookups through the rightmost type-name identifier for qualified names.
- Keep using Corsa symbol/type APIs for the actual interface resolution.
- Add a regression test for `implements ns.IBar` and nested `implements outer.inner.IBaz`.

Closes #269

## Verification

- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts -t "namespace-qualified implemented"`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts`
- `vp fmt --check`
- `vp check --no-fmt`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783000326&installation_id=136613492&pr_number=277&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F277&signature=904ddc974cf0be9716f98fda8ede65333fe730f4c94fbbe10ffa18f0bfc37e38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->