### PR TITLE
fix: preserve mapped utility argument structure

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -153,6 +153,9 @@ export class CorsaProjectSession {
     const type = this.rememberType(state.typeBySourceRange.get(key));
     if (type) {
       this.#typeLookupById.set(type.id, { fileName, position: start, sourceText });
+      if (kind !== "Identifier") {
+        this.rememberTypeSourceRange(type, fileName, start, end, sourceText);
+      }
     }
     return type;
   }
@@ -520,6 +523,34 @@ export class CorsaProjectSession {
     if (source) {
       this.#typeSourceById.set(type.id, source);
     }
+  }
+
+  private rememberTypeSourceRange(
+    type: CorsaType,
+    fileName: string,
+    start: number,
+    end: number,
+    sourceText: string | undefined,
+  ): void {
+    if (
+      this.#typeSourceById.has(type.id) ||
+      !sourceText ||
+      start < 0 ||
+      end > sourceText.length ||
+      start >= end
+    ) {
+      return;
+    }
+    const node = {
+      fileName,
+      pos: start,
+      end,
+      range: [start, end] as const,
+    };
+    this.#typeSourceById.set(type.id, {
+      node,
+      text: sourceText.slice(start, end),
+    });
   }
 
   private cacheTypeText(type: CorsaType | undefined): void {

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_arguments.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_arguments.test.ts
@@ -248,4 +248,103 @@ describe("corsa oxlint type arguments", () => {
     expect(seen.partialDog).toEqual(expected);
     expect(seen.requiredDog).toEqual(expected);
   });
+
+  integrationCase("returns structural mapped utility arguments on class properties", () => {
+    const seen: Record<
+      string,
+      | {
+          readonly argument: string;
+          readonly bases: readonly string[];
+          readonly implemented: readonly string[];
+        }
+      | undefined
+    > = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "mapped-utility-class-property-argument-structure",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise mapped utility type arguments from class properties",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          PropertyDefinition(node: any) {
+            const keyName = node.key?.name;
+            if (!keyName) {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node);
+            const argument = type ? checker.getTypeArguments(type)[0] : undefined;
+            seen[keyName] = argument
+              ? {
+                  argument: checker.typeToString(argument),
+                  bases: checker.getBaseTypes(argument).map((base) => checker.typeToString(base)),
+                  implemented: checker
+                    .getImplementedTypesOfType(argument)
+                    .map((implemented) => checker.typeToString(implemented)),
+                }
+              : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("mapped-utility-class-property-argument-structure", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Animal {}",
+            "interface IDog {",
+            "  name: string;",
+            "}",
+            "class Dog extends Animal implements IDog {",
+            '  readonly name = "Rex";',
+            "}",
+            "interface Box<T> {",
+            "  value: T;",
+            "}",
+            "class Holder {",
+            "  readonly readonlyDog: Readonly<Dog> = {} as Readonly<Dog>;",
+            "  readonly partialDog: Partial<Dog> = {} as Partial<Dog>;",
+            "  readonly requiredDog: Required<Dog> = {} as Required<Dog>;",
+            "  readonly boxedDog: Box<Dog> = { value: {} as Dog };",
+            "  readonly dogList: Dog[] = [];",
+            "}",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    const expected = {
+      argument: "Dog",
+      bases: ["Animal"],
+      implemented: ["IDog"],
+    };
+    expect(seen.readonlyDog).toEqual(expected);
+    expect(seen.partialDog).toEqual(expected);
+    expect(seen.requiredDog).toEqual(expected);
+    expect(seen.boxedDog).toEqual(expected);
+    expect(seen.dogList).toEqual(expected);
+  });
 });


### PR DESCRIPTION
## Summary

- Remember source ranges for non-identifier type lookups so wrapper types from class properties can use source-aware type argument resolution.
- Keep identifier-only lookups on the existing declaration recovery path.
- Add a regression test for `Readonly<Dog>`, `Partial<Dog>`, and `Required<Dog>` on class `PropertyDefinition` nodes.

Closes #268

## Verification

- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/type_arguments.test.ts -t "class properties"`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/type_arguments.test.ts`
- `vp fmt --check`
- `vp check --no-fmt`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783000521&installation_id=136613492&pr_number=278&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F278&signature=71a2ee4c406c1727075bd354a26b596b9142979d5307297cae40272fe2a3d058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->