### PR TITLE
fix: expose immediate superclass instances

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -569,6 +569,75 @@ describe("corsa oxlint type locations", () => {
     expect(seen.intersectionBases).toContain("Animal");
   });
 
+  integrationCase("returns immediate instance type for superclass constructor types", () => {
+    const seen: Record<string, { readonly name: string; readonly bases: readonly string[] }> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "superclass-constructor-base-types",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise superclass constructor type fallback lookups",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          ClassDeclaration(node: any) {
+            const className = node.id?.name;
+            if (!className || !node.superClass) {
+              return;
+            }
+            const superType = checker.getTypeAtLocation(node.superClass);
+            if (!superType) {
+              return;
+            }
+            seen[className] = {
+              name: checker.typeToString(superType),
+              bases: checker.getBaseTypes(superType).map((base) => checker.typeToString(base)),
+            };
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("superclass-constructor-base-types", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Animal {}",
+            "class Dog extends Animal {}",
+            "class GoldenRetriever extends Dog {}",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.Dog?.name).toBe("typeof Animal");
+    expect(seen.Dog?.bases).toContain("Animal");
+    expect(seen.GoldenRetriever?.name).toBe("typeof Dog");
+    expect(seen.GoldenRetriever?.bases[0]).toBe("Dog");
+  });
+
   integrationCase("resolves symbol and node handles exposed by signatures and types", () => {
     const seen: Record<string, unknown> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);

--- a/src/core/corsa_client/src/api/methods_relations.rs
+++ b/src/core/corsa_client/src/api/methods_relations.rs
@@ -134,6 +134,7 @@ impl ApiClient {
             else {
                 continue;
             };
+            append_unique_types(&mut construct_return_bases, vec![return_type.clone()]);
             let mut return_bases = self
                 .get_base_types_direct(snapshot.clone(), project.clone(), return_type.id.clone())
                 .await?;


### PR DESCRIPTION
## Summary

- Include constructor return instance types when deriving base types for constructor-shaped superclass expressions.
- Preserve existing base-chain fallback by appending return type bases after the immediate instance.
- Add a regression test for `getTypeAtLocation(node.superClass)` on `Animal`, `Dog`, and `GoldenRetriever`.

Closes #271

## Verification

- `cargo test -p corsa_client get_base_types`
- `pnpm exec napi build --platform` from `src/bindings/nodejs/corsa_node`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts -t "superclass constructor"`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts`
- `vp check --no-fmt`
- `cargo fmt --all --check`
- `vp fmt --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783000659&installation_id=136613492&pr_number=279&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F279&signature=f974c71b78a53c9237311ad2a2b8083a609e7f6033971655d84cbfcd2cff4327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->