### PR TITLE
refactor(corsa-oxlint): move bridge metadata into Rust

### DIFF
--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -111,7 +111,8 @@ describe("CorsaApiClient", () => {
       },
     });
 
-    expect(nativeLintRuleMetas().map((meta) => meta.name)).toEqual([
+    const lintMetas = nativeLintRuleMetas();
+    expect(lintMetas.map((meta) => meta.name)).toEqual([
       "consistent-return",
       "consistent-type-exports",
       "dot-notation",
@@ -172,6 +173,21 @@ describe("CorsaApiClient", () => {
       "unbound-method",
       "use-unknown-in-catch-callback-variable",
     ]);
+    const bridgeMetas = new Map(lintMetas.map((meta) => [meta.name, meta.bridge]));
+    expect(bridgeMetas.get("consistent-return")).toEqual({ maxDepth: 5 });
+    expect(bridgeMetas.get("no-misused-promises")).toEqual({
+      maxDepth: 5,
+      typeTexts: { minDepth: 0, maxDepth: 2 },
+    });
+    expect(bridgeMetas.get("no-array-delete")).toEqual({
+      maxDepth: 2,
+      typeTexts: { minDepth: 2, maxDepth: 2 },
+    });
+    expect(bridgeMetas.get("await-thenable")).toEqual({
+      maxDepth: 3,
+      typeTexts: { minDepth: 1, maxDepth: 2 },
+      propertyNames: { minDepth: 1, maxDepth: 2 },
+    });
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].messageId).toBe("unexpected");
     expect(diagnostics[0].suggestions?.[0]?.fixes.map((fix) => fix.replacementText)).toEqual([

--- a/src/bindings/nodejs/corsa_node/ts/types.ts
+++ b/src/bindings/nodejs/corsa_node/ts/types.ts
@@ -172,6 +172,18 @@ export interface NativeLintDiagnostic {
   suggestions?: readonly NativeLintSuggestion[];
 }
 
+export interface NativeNodeMetadataDepth {
+  minDepth: number;
+  maxDepth: number;
+}
+
+export interface NativeRuleBridgeRequirements {
+  maxDepth: number;
+  typeTexts?: NativeNodeMetadataDepth;
+  propertyNames?: NativeNodeMetadataDepth;
+  text?: NativeNodeMetadataDepth;
+}
+
 export interface NativeLintRuleMeta {
   name: string;
   docsDescription: string;
@@ -179,6 +191,7 @@ export interface NativeLintRuleMeta {
   hasSuggestions: boolean;
   listeners: readonly string[];
   requiresTypeTexts: boolean;
+  bridge: NativeRuleBridgeRequirements;
 }
 
 export interface NativeStylisticRuleConfig {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/await_thenable.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/await_thenable.ts
@@ -1,15 +1,3 @@
 import { createRustNativeRule } from "./native_bridge";
 
-export const awaitThenableRule = createRustNativeRule(
-  "await-thenable",
-  {},
-  {
-    includePropertyNames: includeAwaitTypeMetadata,
-    includeTypeTexts: includeAwaitTypeMetadata,
-    maxDepth: 3,
-  },
-);
-
-function includeAwaitTypeMetadata(_node: any, depth: number): boolean {
-  return depth === 1 || depth === 2;
-}
+export const awaitThenableRule = createRustNativeRule("await-thenable");

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
@@ -6,6 +6,7 @@ import type {
   NativeLintNode,
   NativeLintRange,
   NativeLintRuleMeta,
+  NativeNodeMetadataDepth,
 } from "@corsa-bind/napi";
 
 import { createNativeRule } from "./rule_creator";
@@ -55,6 +56,7 @@ export function createRustNativeRule(
               return;
             }
             const includeTypeTexts = includeTypeTextsOption(bridgeOptions, meta);
+            const includeText = includeTextOption(bridgeOptions, meta);
             reportNativeDiagnostics(
               context,
               node,
@@ -64,10 +66,10 @@ export function createRustNativeRule(
                   context,
                   node,
                   includeTypeTexts,
-                  bridgeOptions.maxDepth ?? MAX_NATIVE_NODE_DEPTH,
+                  maxDepthOption(bridgeOptions, meta),
                   true,
-                  includePropertyNamesOption(bridgeOptions, includeTypeTexts),
-                  bridgeOptions.includeText ?? false,
+                  includePropertyNamesOption(bridgeOptions, meta),
+                  includeText,
                 ),
               ),
             );
@@ -252,14 +254,35 @@ function includeTypeTextsOption(
   options: NativeRuleBridgeOptions,
   meta: NativeLintRuleMeta,
 ): NodeMetadataOption {
-  return options.includeTypeTexts ?? meta.requiresTypeTexts;
+  return options.includeTypeTexts ?? nodeMetadataDepthOption(meta.bridge.typeTexts, false);
 }
 
 function includePropertyNamesOption(
   options: NativeRuleBridgeOptions,
-  includeTypeTexts: NodeMetadataOption,
+  meta: NativeLintRuleMeta,
 ): NodeMetadataOption {
-  return options.includePropertyNames ?? includeTypeTexts;
+  return options.includePropertyNames ?? nodeMetadataDepthOption(meta.bridge.propertyNames, false);
+}
+
+function includeTextOption(
+  options: NativeRuleBridgeOptions,
+  meta: NativeLintRuleMeta,
+): NodeMetadataOption {
+  return options.includeText ?? nodeMetadataDepthOption(meta.bridge.text, false);
+}
+
+function maxDepthOption(options: NativeRuleBridgeOptions, meta: NativeLintRuleMeta): number {
+  return options.maxDepth ?? meta.bridge.maxDepth ?? MAX_NATIVE_NODE_DEPTH;
+}
+
+function nodeMetadataDepthOption(
+  metadata: NativeNodeMetadataDepth | undefined,
+  fallback: NodeMetadataOption,
+): NodeMetadataOption {
+  if (!metadata) {
+    return fallback;
+  }
+  return (_node, depth) => depth >= metadata.minDepth && depth <= metadata.maxDepth;
 }
 
 function includeMetadataForNode(

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/no_array_delete.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/no_array_delete.ts
@@ -3,12 +3,7 @@ import { createRustNativeRule } from "./native_bridge";
 export const noArrayDeleteRule = createRustNativeRule(
   "no-array-delete",
   {},
-  {
-    includePropertyNames: false,
-    includeTypeTexts: (_node, depth) => depth === 2,
-    maxDepth: 2,
-    shouldRun: shouldRunNoArrayDelete,
-  },
+  { shouldRun: shouldRunNoArrayDelete },
 );
 
 function shouldRunNoArrayDelete(node: any): boolean {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/no_base_to_string.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/no_base_to_string.ts
@@ -4,12 +4,7 @@ import { createRustNativeRule } from "./native_bridge";
 export const noBaseToStringRule = createRustNativeRule(
   "no-base-to-string",
   {},
-  {
-    includePropertyNames: false,
-    includeTypeTexts: (_node, depth) => depth === 1 || depth === 2,
-    maxDepth: 2,
-    shouldRun: shouldRunNoBaseToString,
-  },
+  { shouldRun: shouldRunNoBaseToString },
 );
 
 function shouldRunNoBaseToString(node: any): boolean {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/no_floating_promises.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/no_floating_promises.ts
@@ -4,16 +4,8 @@ import { createRustNativeRule } from "./native_bridge";
 export const noFloatingPromisesRule = createRustNativeRule(
   "no-floating-promises",
   {},
-  {
-    includePropertyNames: includeFloatingPromiseTypeMetadata,
-    includeTypeTexts: includeFloatingPromiseTypeMetadata,
-    shouldRun: shouldRunNoFloatingPromises,
-  },
+  { shouldRun: shouldRunNoFloatingPromises },
 );
-
-function includeFloatingPromiseTypeMetadata(_node: any, depth: number): boolean {
-  return depth === 1 || depth === 2;
-}
 
 function shouldRunNoFloatingPromises(node: any): boolean {
   const expression = stripChainExpression(node.expression);

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/no_for_in_array.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/no_for_in_array.ts
@@ -1,11 +1,3 @@
 import { createRustNativeRule } from "./native_bridge";
 
-export const noForInArrayRule = createRustNativeRule(
-  "no-for-in-array",
-  {},
-  {
-    includePropertyNames: false,
-    includeTypeTexts: (_node, depth) => depth === 1,
-    maxDepth: 1,
-  },
-);
+export const noForInArrayRule = createRustNativeRule("no-for-in-array");

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/no_implied_eval.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/no_implied_eval.ts
@@ -9,12 +9,7 @@ import { createRustNativeRule } from "./native_bridge";
 export const noImpliedEvalRule = createRustNativeRule(
   "no-implied-eval",
   {},
-  {
-    includePropertyNames: false,
-    includeTypeTexts: (_node, depth) => depth === 1,
-    maxDepth: 2,
-    shouldRun: shouldRunNoImpliedEval,
-  },
+  { shouldRun: shouldRunNoImpliedEval },
 );
 
 function shouldRunNoImpliedEval(node: any): boolean {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/no_meaningless_void_operator.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/no_meaningless_void_operator.ts
@@ -6,12 +6,7 @@ export const noMeaninglessVoidOperatorRule = createRustNativeRule(
     hasSuggestions: true,
     schema: { type: "array" },
   },
-  {
-    includePropertyNames: false,
-    includeTypeTexts: (_node, depth) => depth === 1,
-    maxDepth: 1,
-    shouldRun: shouldRunNoMeaninglessVoidOperator,
-  },
+  { shouldRun: shouldRunNoMeaninglessVoidOperator },
 );
 
 function shouldRunNoMeaninglessVoidOperator(node: any): boolean {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/no_unsafe_assignment.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/no_unsafe_assignment.ts
@@ -3,12 +3,7 @@ import { createRustNativeRule } from "./native_bridge";
 export const noUnsafeAssignmentRule = createRustNativeRule(
   "no-unsafe-assignment",
   {},
-  {
-    includePropertyNames: false,
-    includeTypeTexts: (_node, depth) => depth === 1,
-    maxDepth: 2,
-    shouldRun: shouldRunNoUnsafeAssignment,
-  },
+  { shouldRun: shouldRunNoUnsafeAssignment },
 );
 
 function shouldRunNoUnsafeAssignment(node: any): boolean {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/no_unsafe_call.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/no_unsafe_call.ts
@@ -3,12 +3,7 @@ import { createRustNativeRule } from "./native_bridge";
 export const noUnsafeCallRule = createRustNativeRule(
   "no-unsafe-call",
   {},
-  {
-    includePropertyNames: false,
-    includeTypeTexts: (_node, depth) => depth === 1,
-    maxDepth: 1,
-    shouldRun: shouldRunNoUnsafeCall,
-  },
+  { shouldRun: shouldRunNoUnsafeCall },
 );
 
 function shouldRunNoUnsafeCall(node: any): boolean {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/no_unsafe_member_access.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/no_unsafe_member_access.ts
@@ -5,12 +5,7 @@ export const noUnsafeMemberAccessRule = createRustNativeRule(
   {
     schema: { type: "array" },
   },
-  {
-    includePropertyNames: false,
-    includeTypeTexts: (_node, depth) => depth === 1,
-    maxDepth: 1,
-    shouldRun: shouldRunNoUnsafeMemberAccess,
-  },
+  { shouldRun: shouldRunNoUnsafeMemberAccess },
 );
 
 function shouldRunNoUnsafeMemberAccess(node: any): boolean {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/no_unsafe_return.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/no_unsafe_return.ts
@@ -3,12 +3,7 @@ import { createRustNativeRule } from "./native_bridge";
 export const noUnsafeReturnRule = createRustNativeRule(
   "no-unsafe-return",
   {},
-  {
-    includePropertyNames: false,
-    includeTypeTexts: (_node, depth) => depth === 1,
-    maxDepth: 1,
-    shouldRun: shouldRunNoUnsafeReturn,
-  },
+  { shouldRun: shouldRunNoUnsafeReturn },
 );
 
 function shouldRunNoUnsafeReturn(node: any): boolean {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/no_unsafe_type_assertion.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/no_unsafe_type_assertion.ts
@@ -5,12 +5,7 @@ export const noUnsafeTypeAssertionRule = createRustNativeRule(
   {
     schema: { type: "array" },
   },
-  {
-    includePropertyNames: false,
-    includeTypeTexts: (_node, depth) => depth === 1,
-    maxDepth: 1,
-    shouldRun: shouldRunNoUnsafeTypeAssertion,
-  },
+  { shouldRun: shouldRunNoUnsafeTypeAssertion },
 );
 
 function shouldRunNoUnsafeTypeAssertion(node: any): boolean {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/no_unsafe_unary_minus.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/no_unsafe_unary_minus.ts
@@ -3,12 +3,7 @@ import { createRustNativeRule } from "./native_bridge";
 export const noUnsafeUnaryMinusRule = createRustNativeRule(
   "no-unsafe-unary-minus",
   {},
-  {
-    includePropertyNames: false,
-    includeTypeTexts: (_node, depth) => depth === 1,
-    maxDepth: 1,
-    shouldRun: shouldRunNoUnsafeUnaryMinus,
-  },
+  { shouldRun: shouldRunNoUnsafeUnaryMinus },
 );
 
 function shouldRunNoUnsafeUnaryMinus(node: any): boolean {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/only_throw_error.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/only_throw_error.ts
@@ -3,17 +3,8 @@ import { createRustNativeRule } from "./native_bridge";
 export const onlyThrowErrorRule = createRustNativeRule(
   "only-throw-error",
   {},
-  {
-    includePropertyNames: includeThrowTypeMetadata,
-    includeTypeTexts: includeThrowTypeMetadata,
-    maxDepth: 2,
-    shouldRun: shouldRunOnlyThrowError,
-  },
+  { shouldRun: shouldRunOnlyThrowError },
 );
-
-function includeThrowTypeMetadata(_node: any, depth: number): boolean {
-  return depth === 1 || depth === 2;
-}
 
 function shouldRunOnlyThrowError(node: any): boolean {
   return node.type !== "ThrowStatement" || Boolean(node.argument);

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/pending_parity.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/pending_parity.ts
@@ -1,158 +1,52 @@
 import { createRustNativeRule } from "./native_bridge";
 
-const syntaxOnlyBridge = {
-  includePropertyNames: false,
-  includeTypeTexts: false,
-  maxDepth: 5,
-};
-
-const typedBridge = {
-  includePropertyNames: false,
-  includeTypeTexts: (_node: any, depth: number) => depth <= 2,
-  maxDepth: 5,
-};
-
-const shallowTypedBridge = {
-  includePropertyNames: false,
-  includeTypeTexts: (_node: any, depth: number) => depth <= 1,
-  maxDepth: 3,
-};
-
-const functionBodyTypedBridge = {
-  includePropertyNames: false,
-  includeTypeTexts: (_node: any, depth: number) => depth <= 3,
-  maxDepth: 5,
-};
-
-export const consistentReturnRule = createRustNativeRule("consistent-return", {}, syntaxOnlyBridge);
-export const consistentTypeExportsRule = createRustNativeRule(
-  "consistent-type-exports",
-  {},
-  syntaxOnlyBridge,
-);
-export const dotNotationRule = createRustNativeRule("dot-notation", {}, syntaxOnlyBridge);
-export const noConfusingVoidExpressionRule = createRustNativeRule(
-  "no-confusing-void-expression",
-  {},
-  shallowTypedBridge,
-);
-export const noDeprecatedRule = createRustNativeRule("no-deprecated", {}, syntaxOnlyBridge);
+export const consistentReturnRule = createRustNativeRule("consistent-return");
+export const consistentTypeExportsRule = createRustNativeRule("consistent-type-exports");
+export const dotNotationRule = createRustNativeRule("dot-notation");
+export const noConfusingVoidExpressionRule = createRustNativeRule("no-confusing-void-expression");
+export const noDeprecatedRule = createRustNativeRule("no-deprecated");
 export const noDuplicateTypeConstituentsRule = createRustNativeRule(
   "no-duplicate-type-constituents",
-  {},
-  {
-    ...syntaxOnlyBridge,
-    includeText: (_node: any, depth: number) => depth <= 1,
-  },
 );
-export const noMisusedPromisesRule = createRustNativeRule("no-misused-promises", {}, typedBridge);
-export const noMisusedSpreadRule = createRustNativeRule("no-misused-spread", {}, typedBridge);
+export const noMisusedPromisesRule = createRustNativeRule("no-misused-promises");
+export const noMisusedSpreadRule = createRustNativeRule("no-misused-spread");
 export const noRedundantTypeConstituentsRule = createRustNativeRule(
   "no-redundant-type-constituents",
-  {},
-  {
-    ...syntaxOnlyBridge,
-    includeText: (_node: any, depth: number) => depth <= 1,
-  },
 );
 export const noUnnecessaryBooleanLiteralCompareRule = createRustNativeRule(
   "no-unnecessary-boolean-literal-compare",
-  {},
-  typedBridge,
 );
-export const noUnnecessaryConditionRule = createRustNativeRule(
-  "no-unnecessary-condition",
-  {},
-  shallowTypedBridge,
-);
-export const noUnnecessaryQualifierRule = createRustNativeRule(
-  "no-unnecessary-qualifier",
-  {},
-  syntaxOnlyBridge,
-);
+export const noUnnecessaryConditionRule = createRustNativeRule("no-unnecessary-condition");
+export const noUnnecessaryQualifierRule = createRustNativeRule("no-unnecessary-qualifier");
 export const noUnnecessaryTemplateExpressionRule = createRustNativeRule(
   "no-unnecessary-template-expression",
-  {},
-  syntaxOnlyBridge,
 );
-export const noUnnecessaryTypeArgumentsRule = createRustNativeRule(
-  "no-unnecessary-type-arguments",
-  {},
-  typedBridge,
-);
-export const noUnnecessaryTypeAssertionRule = createRustNativeRule(
-  "no-unnecessary-type-assertion",
-  {},
-  typedBridge,
-);
+export const noUnnecessaryTypeArgumentsRule = createRustNativeRule("no-unnecessary-type-arguments");
+export const noUnnecessaryTypeAssertionRule = createRustNativeRule("no-unnecessary-type-assertion");
 export const noUnnecessaryTypeConversionRule = createRustNativeRule(
   "no-unnecessary-type-conversion",
-  {},
-  typedBridge,
 );
 export const noUnnecessaryTypeParametersRule = createRustNativeRule(
   "no-unnecessary-type-parameters",
-  {},
-  syntaxOnlyBridge,
 );
-export const noUnsafeArgumentRule = createRustNativeRule("no-unsafe-argument", {}, typedBridge);
-export const noUnsafeEnumComparisonRule = createRustNativeRule(
-  "no-unsafe-enum-comparison",
-  {},
-  shallowTypedBridge,
-);
-export const noUselessDefaultAssignmentRule = createRustNativeRule(
-  "no-useless-default-assignment",
-  {},
-  syntaxOnlyBridge,
-);
+export const noUnsafeArgumentRule = createRustNativeRule("no-unsafe-argument");
+export const noUnsafeEnumComparisonRule = createRustNativeRule("no-unsafe-enum-comparison");
+export const noUselessDefaultAssignmentRule = createRustNativeRule("no-useless-default-assignment");
 export const nonNullableTypeAssertionStyleRule = createRustNativeRule(
   "non-nullable-type-assertion-style",
-  {},
-  typedBridge,
 );
-export const preferNullishCoalescingRule = createRustNativeRule(
-  "prefer-nullish-coalescing",
-  {},
-  shallowTypedBridge,
-);
-export const preferOptionalChainRule = createRustNativeRule(
-  "prefer-optional-chain",
-  {},
-  syntaxOnlyBridge,
-);
-export const preferReadonlyRule = createRustNativeRule("prefer-readonly", {}, typedBridge);
+export const preferNullishCoalescingRule = createRustNativeRule("prefer-nullish-coalescing");
+export const preferOptionalChainRule = createRustNativeRule("prefer-optional-chain");
+export const preferReadonlyRule = createRustNativeRule("prefer-readonly");
 export const preferReadonlyParameterTypesRule = createRustNativeRule(
   "prefer-readonly-parameter-types",
-  {},
-  typedBridge,
 );
-export const preferReturnThisTypeRule = createRustNativeRule(
-  "prefer-return-this-type",
-  {},
-  typedBridge,
-);
-export const promiseFunctionAsyncRule = createRustNativeRule(
-  "promise-function-async",
-  {},
-  typedBridge,
-);
-export const relatedGetterSetterPairsRule = createRustNativeRule(
-  "related-getter-setter-pairs",
-  {},
-  typedBridge,
-);
-export const requireAwaitRule = createRustNativeRule("require-await", {}, functionBodyTypedBridge);
-export const returnAwaitRule = createRustNativeRule("return-await", {}, typedBridge);
-export const strictBooleanExpressionsRule = createRustNativeRule(
-  "strict-boolean-expressions",
-  {},
-  shallowTypedBridge,
-);
-export const strictVoidReturnRule = createRustNativeRule("strict-void-return", {}, typedBridge);
-export const switchExhaustivenessCheckRule = createRustNativeRule(
-  "switch-exhaustiveness-check",
-  {},
-  shallowTypedBridge,
-);
-export const unboundMethodRule = createRustNativeRule("unbound-method", {}, shallowTypedBridge);
+export const preferReturnThisTypeRule = createRustNativeRule("prefer-return-this-type");
+export const promiseFunctionAsyncRule = createRustNativeRule("promise-function-async");
+export const relatedGetterSetterPairsRule = createRustNativeRule("related-getter-setter-pairs");
+export const requireAwaitRule = createRustNativeRule("require-await");
+export const returnAwaitRule = createRustNativeRule("return-await");
+export const strictBooleanExpressionsRule = createRustNativeRule("strict-boolean-expressions");
+export const strictVoidReturnRule = createRustNativeRule("strict-void-return");
+export const switchExhaustivenessCheckRule = createRustNativeRule("switch-exhaustiveness-check");
+export const unboundMethodRule = createRustNativeRule("unbound-method");

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/prefer_promise_reject_errors.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/prefer_promise_reject_errors.ts
@@ -7,17 +7,8 @@ export const preferPromiseRejectErrorsRule = createRustNativeRule(
   {
     schema: { type: "array" },
   },
-  {
-    includePropertyNames: includeRejectTypeMetadata,
-    includeTypeTexts: includeRejectTypeMetadata,
-    maxDepth: 2,
-    shouldRun: shouldRunPreferPromiseRejectErrors,
-  },
+  { shouldRun: shouldRunPreferPromiseRejectErrors },
 );
-
-function includeRejectTypeMetadata(_node: any, depth: number): boolean {
-  return depth === 1 || depth === 2;
-}
 
 function shouldRunPreferPromiseRejectErrors(node: any, context: ContextWithParserOptions): boolean {
   const callee = stripChainExpression(node.callee) as any;

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/prefer_reduce_type_parameter.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/prefer_reduce_type_parameter.ts
@@ -7,12 +7,7 @@ export const preferReduceTypeParameterRule = createRustNativeRule(
     hasSuggestions: true,
     schema: { type: "array" },
   },
-  {
-    includePropertyNames: false,
-    includeTypeTexts: (_node, depth) => depth === 2,
-    maxDepth: 3,
-    shouldRun: shouldRunPreferReduceTypeParameter,
-  },
+  { shouldRun: shouldRunPreferReduceTypeParameter },
 );
 
 function shouldRunPreferReduceTypeParameter(node: any): boolean {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/require_array_sort_compare.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/require_array_sort_compare.ts
@@ -6,12 +6,7 @@ export const requireArraySortCompareRule = createRustNativeRule(
   {
     schema: { type: "array" },
   },
-  {
-    includePropertyNames: false,
-    includeTypeTexts: (_node, depth) => depth === 2,
-    maxDepth: 2,
-    shouldRun: shouldRunRequireArraySortCompare,
-  },
+  { shouldRun: shouldRunRequireArraySortCompare },
 );
 
 function shouldRunRequireArraySortCompare(node: any): boolean {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/restrict_plus_operands.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/restrict_plus_operands.ts
@@ -5,12 +5,7 @@ export const restrictPlusOperandsRule = createRustNativeRule(
   {
     schema: { type: "array" },
   },
-  {
-    includePropertyNames: false,
-    includeTypeTexts: (_node, depth) => depth === 1,
-    maxDepth: 1,
-    shouldRun: shouldRunRestrictPlusOperands,
-  },
+  { shouldRun: shouldRunRestrictPlusOperands },
 );
 
 function shouldRunRestrictPlusOperands(node: any): boolean {

--- a/src/core/corsa_core/src/lint/context.rs
+++ b/src/core/corsa_core/src/lint/context.rs
@@ -1,4 +1,7 @@
-use super::{LintDiagnostic, LintNode, LintSuggestion, RuleMessage, RuleMeta, TextRange};
+use super::{
+    LintDiagnostic, LintNode, LintSuggestion, NodeMetadataDepth, RuleBridgeRequirements,
+    RuleMessage, RuleMeta, TextRange,
+};
 
 /// A Rust-authored type-aware lint rule.
 ///
@@ -28,6 +31,11 @@ pub trait RustLintRule: Send + Sync {
         true
     }
 
+    /// Returns host metadata requirements for the JavaScript native bridge.
+    fn bridge_requirements(&self) -> RuleBridgeRequirements {
+        bridge_requirements_for_rule(self.name(), self.requires_type_texts())
+    }
+
     /// Checks one host-provided node and records diagnostics in `ctx`.
     fn check(&self, ctx: &mut RuleContext<'_>, node: &LintNode);
 
@@ -48,7 +56,84 @@ pub trait RustLintRule: Send + Sync {
                 .map(|listener| (*listener).to_owned())
                 .collect(),
             requires_type_texts: self.requires_type_texts(),
+            bridge: self.bridge_requirements(),
         }
+    }
+}
+
+fn bridge_requirements_for_rule(name: &str, requires_type_texts: bool) -> RuleBridgeRequirements {
+    match name {
+        "consistent-return"
+        | "consistent-type-exports"
+        | "dot-notation"
+        | "no-deprecated"
+        | "no-unnecessary-qualifier"
+        | "no-unnecessary-template-expression"
+        | "no-unnecessary-type-parameters"
+        | "no-useless-default-assignment"
+        | "prefer-optional-chain" => RuleBridgeRequirements::syntax_only(5),
+        "no-duplicate-type-constituents" | "no-redundant-type-constituents" => {
+            RuleBridgeRequirements::syntax_only(5).with_text(NodeMetadataDepth::through(1))
+        }
+        "no-confusing-void-expression"
+        | "no-unnecessary-condition"
+        | "no-unsafe-enum-comparison"
+        | "prefer-nullish-coalescing"
+        | "strict-boolean-expressions"
+        | "switch-exhaustiveness-check"
+        | "unbound-method" => RuleBridgeRequirements::type_texts(3, NodeMetadataDepth::through(1)),
+        "no-misused-promises"
+        | "no-misused-spread"
+        | "no-unnecessary-boolean-literal-compare"
+        | "no-unnecessary-type-arguments"
+        | "no-unnecessary-type-assertion"
+        | "no-unnecessary-type-conversion"
+        | "no-unsafe-argument"
+        | "non-nullable-type-assertion-style"
+        | "prefer-readonly"
+        | "prefer-readonly-parameter-types"
+        | "prefer-return-this-type"
+        | "promise-function-async"
+        | "related-getter-setter-pairs"
+        | "return-await"
+        | "strict-void-return" => {
+            RuleBridgeRequirements::type_texts(5, NodeMetadataDepth::through(2))
+        }
+        "require-await" => RuleBridgeRequirements::type_texts(5, NodeMetadataDepth::through(3)),
+        "await-thenable" => {
+            RuleBridgeRequirements::type_texts_and_properties(3, NodeMetadataDepth::range(1, 2))
+        }
+        "no-array-delete" => RuleBridgeRequirements::type_texts(2, NodeMetadataDepth::exact(2)),
+        "no-base-to-string" => {
+            RuleBridgeRequirements::type_texts(2, NodeMetadataDepth::range(1, 2))
+        }
+        "no-floating-promises" => {
+            RuleBridgeRequirements::type_texts_and_properties(4, NodeMetadataDepth::range(1, 2))
+        }
+        "no-for-in-array" => RuleBridgeRequirements::type_texts(1, NodeMetadataDepth::exact(1)),
+        "no-implied-eval" => RuleBridgeRequirements::type_texts(2, NodeMetadataDepth::exact(1)),
+        "no-meaningless-void-operator"
+        | "no-unsafe-call"
+        | "no-unsafe-member-access"
+        | "no-unsafe-return"
+        | "no-unsafe-type-assertion"
+        | "no-unsafe-unary-minus"
+        | "restrict-plus-operands" => {
+            RuleBridgeRequirements::type_texts(1, NodeMetadataDepth::exact(1))
+        }
+        "no-unsafe-assignment" => {
+            RuleBridgeRequirements::type_texts(2, NodeMetadataDepth::exact(1))
+        }
+        "only-throw-error" | "prefer-promise-reject-errors" => {
+            RuleBridgeRequirements::type_texts_and_properties(2, NodeMetadataDepth::range(1, 2))
+        }
+        "prefer-reduce-type-parameter" => {
+            RuleBridgeRequirements::type_texts(3, NodeMetadataDepth::exact(2))
+        }
+        "require-array-sort-compare" => {
+            RuleBridgeRequirements::type_texts(2, NodeMetadataDepth::exact(2))
+        }
+        _ => RuleBridgeRequirements::default_for_type_texts(requires_type_texts),
     }
 }
 

--- a/src/core/corsa_core/src/lint/mod.rs
+++ b/src/core/corsa_core/src/lint/mod.rs
@@ -40,5 +40,6 @@ pub use stylistic::{
     StylisticRuleConfig, StylisticRunConfig, run_stylistic_lint, stylistic_rule_metas,
 };
 pub use types::{
-    LintDiagnostic, LintFix, LintNode, LintSuggestion, RuleMessage, RuleMeta, TextRange,
+    LintDiagnostic, LintFix, LintNode, LintSuggestion, NodeMetadataDepth, RuleBridgeRequirements,
+    RuleMessage, RuleMeta, TextRange,
 };

--- a/src/core/corsa_core/src/lint/stylistic/mod.rs
+++ b/src/core/corsa_core/src/lint/stylistic/mod.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use serde::Deserialize;
 use serde_json::Value;
 
-use super::{LintDiagnostic, RuleMeta};
+use super::{LintDiagnostic, RuleBridgeRequirements, RuleMeta};
 
 mod context;
 mod context_rules;
@@ -678,6 +678,7 @@ pub fn stylistic_rule_metas() -> Vec<RuleMeta> {
                 .map(|listener| (*listener).to_owned())
                 .collect(),
             requires_type_texts: false,
+            bridge: RuleBridgeRequirements::default_for_type_texts(false),
         })
         .collect()
 }

--- a/src/core/corsa_core/src/lint/types.rs
+++ b/src/core/corsa_core/src/lint/types.rs
@@ -159,6 +159,113 @@ pub struct RuleMessage {
     pub description: &'static str,
 }
 
+/// Depth range for metadata the JavaScript host should attach to native nodes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeMetadataDepth {
+    /// Minimum recursive node depth, where the listener node is depth 0.
+    pub min_depth: u8,
+    /// Maximum recursive node depth, inclusive.
+    pub max_depth: u8,
+}
+
+impl NodeMetadataDepth {
+    /// Includes metadata at a single depth.
+    pub const fn exact(depth: u8) -> Self {
+        Self {
+            min_depth: depth,
+            max_depth: depth,
+        }
+    }
+
+    /// Includes metadata from the listener node through `max_depth`.
+    pub const fn through(max_depth: u8) -> Self {
+        Self {
+            min_depth: 0,
+            max_depth,
+        }
+    }
+
+    /// Includes metadata for the provided inclusive depth range.
+    pub const fn range(min_depth: u8, max_depth: u8) -> Self {
+        Self {
+            min_depth,
+            max_depth,
+        }
+    }
+}
+
+/// Host-side metadata requirements for a Rust-authored lint rule.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuleBridgeRequirements {
+    /// Maximum AST recursion depth the host should serialize.
+    pub max_depth: u8,
+    /// Depths where rendered type text should be attached.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub type_texts: Option<NodeMetadataDepth>,
+    /// Depths where property names should be attached.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub property_names: Option<NodeMetadataDepth>,
+    /// Depths where source text should be attached.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<NodeMetadataDepth>,
+}
+
+impl RuleBridgeRequirements {
+    /// Default recursion depth used by the JavaScript host bridge.
+    pub const DEFAULT_MAX_DEPTH: u8 = 4;
+
+    /// Creates requirements for syntax-only rules.
+    pub const fn syntax_only(max_depth: u8) -> Self {
+        Self {
+            max_depth,
+            type_texts: None,
+            property_names: None,
+            text: None,
+        }
+    }
+
+    /// Creates requirements that attach type text in an inclusive depth range.
+    pub const fn type_texts(max_depth: u8, type_texts: NodeMetadataDepth) -> Self {
+        Self {
+            max_depth,
+            type_texts: Some(type_texts),
+            property_names: None,
+            text: None,
+        }
+    }
+
+    /// Creates requirements that attach type text and property names together.
+    pub const fn type_texts_and_properties(max_depth: u8, metadata: NodeMetadataDepth) -> Self {
+        Self {
+            max_depth,
+            type_texts: Some(metadata),
+            property_names: Some(metadata),
+            text: None,
+        }
+    }
+
+    /// Adds source text metadata to existing requirements.
+    pub const fn with_text(mut self, text: NodeMetadataDepth) -> Self {
+        self.text = Some(text);
+        self
+    }
+
+    /// Creates the default requirements for rules that only declare whether
+    /// they need type text.
+    pub const fn default_for_type_texts(requires_type_texts: bool) -> Self {
+        if requires_type_texts {
+            Self::type_texts_and_properties(
+                Self::DEFAULT_MAX_DEPTH,
+                NodeMetadataDepth::through(Self::DEFAULT_MAX_DEPTH),
+            )
+        } else {
+            Self::syntax_only(Self::DEFAULT_MAX_DEPTH)
+        }
+    }
+}
+
 /// Serializable metadata that describes one Rust-authored lint rule.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -175,4 +282,6 @@ pub struct RuleMeta {
     pub listeners: Vec<String>,
     /// Whether the host should include rendered TypeScript type text.
     pub requires_type_texts: bool,
+    /// Native bridge metadata requirements owned by the Rust rule registry.
+    pub bridge: RuleBridgeRequirements,
 }


### PR DESCRIPTION
Closes #285

## Changes
- Add Rust-owned native bridge metadata requirements to lint rule metas.
- Make the oxlint native bridge consume Rust metadata for node depth, type text, property names, and source text.
- Remove TS-side bridge workaround presets and per-rule metadata overrides.

## Verification
- vp check
- cargo fmt --all --check
- cargo test -p corsa_core lint
- vp test src/bindings/nodejs/corsa_node/ts/index.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783004249&installation_id=136613492&pr_number=286&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F286&signature=9583527e1c12956b719b7105a57d54bb15087d705c13a888407ff4be2bb0ad83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->