### PR TITLE
refactor(corsa-oxlint): limit eslint fallback checker semantics

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -261,6 +261,15 @@ describe("corsa oxlint", () => {
       getSymbolOfType() {
         return unionSymbol;
       },
+      getBaseTypes() {
+        return [];
+      },
+      getImplementedTypes(node: unknown) {
+        return node === classDeclaration ? [implementedType] : [];
+      },
+      getImplementedTypesOfType(type: unknown) {
+        return type === classType ? [implementedType] : [];
+      },
       getTypeArguments() {
         return [typeArgument];
       },
@@ -326,56 +335,21 @@ describe("corsa oxlint", () => {
     expect(corsaChecker.getNodeById("missing")).toBeUndefined();
   });
 
-  // Regression for GH#207: the @typescript-eslint fallback used to walk only
-  // the type's own `implements` clause, so a class that implemented an
-  // interface only through a base class came back empty here while the tsgo
-  // backend reported the interface. The fallback now walks the base chain
-  // too, matching tsgo.
-  it("includes inherited implemented interfaces in the eslint fallback checker", () => {
+  it("does not synthesize inherited implemented interfaces in the eslint fallback checker", () => {
     const interfaceType = { name: "IA" };
-    const interfaceExpression = { kind: "ia-expression" };
-    const baseImplementsClause = {
-      getText() {
-        return "implements IA";
-      },
-      types: [{ expression: interfaceExpression }],
-    };
-    const baseDeclaration = {
-      heritageClauses: [baseImplementsClause],
-    };
-    const baseType: { symbol: { declarations: unknown[] } } = {
-      symbol: { declarations: [baseDeclaration] },
-    };
-    const baseExpression = { kind: "base-expression" };
-    const derivedExtendsClause = {
-      getText() {
-        return "extends Base";
-      },
-      types: [{ expression: baseExpression }],
-    };
-    const derivedDeclaration = {
-      heritageClauses: [derivedExtendsClause],
-    };
-    const derivedType = {
-      symbol: { declarations: [derivedDeclaration] },
-    };
+    const baseType = { name: "Base" };
+    const derivedType = { name: "Derived" };
 
     const checker = {
-      getTypeAtLocation(node: unknown) {
-        if (node === interfaceExpression) {
-          return interfaceType;
-        }
-        if (node === baseExpression) {
-          return baseType;
-        }
-        return undefined;
-      },
       getSymbolAtLocation() {
         return { kind: "symbol" };
       },
       getBaseTypes(type: unknown) {
         return type === derivedType ? [baseType] : [];
       },
+      getImplementedTypesOfType(type: unknown) {
+        return type === baseType ? [interfaceType] : [];
+      },
     };
     const program = {
       getTypeChecker() {
@@ -417,101 +391,9 @@ describe("corsa oxlint", () => {
     } as never);
     const corsaChecker = services.program.getTypeChecker();
 
+    expect(corsaChecker.getBaseTypes(derivedType as never)).toEqual([baseType]);
     expect(corsaChecker.getImplementedTypesOfType(baseType as never)).toEqual([interfaceType]);
-    expect(corsaChecker.getImplementedTypesOfType(derivedType as never)).toEqual([interfaceType]);
-  });
-
-  // Companion to the GH#207 regression above: when the checker can't tell us
-  // the base types directly (the upstream `getBaseTypes` returns nothing), the
-  // fallback walks the `extends` clause from source and still reports
-  // inherited interfaces.
-  it("walks extends-clause base types when the eslint checker omits them", () => {
-    const interfaceType = { name: "IA" };
-    const interfaceExpression = { kind: "ia-expression" };
-    const baseImplementsClause = {
-      getText() {
-        return "implements IA";
-      },
-      types: [{ expression: interfaceExpression }],
-    };
-    const baseDeclaration = {
-      heritageClauses: [baseImplementsClause],
-    };
-    const baseType = {
-      symbol: { declarations: [baseDeclaration] },
-    };
-    const baseExpression = { kind: "base-expression" };
-    const derivedExtendsClause = {
-      getText() {
-        return "extends Base";
-      },
-      types: [{ expression: baseExpression }],
-    };
-    const derivedDeclaration = {
-      heritageClauses: [derivedExtendsClause],
-    };
-    const derivedType = {
-      symbol: { declarations: [derivedDeclaration] },
-    };
-
-    const checker = {
-      getTypeAtLocation(node: unknown) {
-        if (node === interfaceExpression) {
-          return interfaceType;
-        }
-        if (node === baseExpression) {
-          return baseType;
-        }
-        return undefined;
-      },
-      getSymbolAtLocation() {
-        return { kind: "symbol" };
-      },
-      getBaseTypes() {
-        return [];
-      },
-    };
-    const program = {
-      getTypeChecker() {
-        return checker;
-      },
-    };
-    const parserServices = {
-      program,
-      esTreeNodeToTSNodeMap: {
-        get() {
-          return undefined;
-        },
-        has() {
-          return false;
-        },
-      },
-      tsNodeToESTreeNodeMap: {
-        get() {
-          return { type: "Identifier" };
-        },
-        has() {
-          return true;
-        },
-      },
-    };
-
-    const services = getParserServices({
-      cwd: workspaceRoot,
-      filename: resolve(workspaceRoot, "fixture.ts"),
-      languageOptions: {
-        parserOptions: {},
-      },
-      report() {},
-      settings: {},
-      sourceCode: {
-        text: "",
-        parserServices: parserServices as never,
-      },
-    } as never);
-    const corsaChecker = services.program.getTypeChecker();
-
-    expect(corsaChecker.getImplementedTypesOfType(derivedType as never)).toEqual([interfaceType]);
+    expect(corsaChecker.getImplementedTypesOfType(derivedType as never)).toEqual([]);
   });
 
   it("propagates corsaOxlint settings through RuleTester", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
@@ -167,7 +167,7 @@ function createEslintTypeChecker(
           type,
           enclosingDeclaration ? tsNodeFor(enclosingDeclaration, esTreeNodeToTSNodeMap) : undefined,
           flags,
-        ) ?? fallbackTypeText(type)
+        ) ?? ""
       );
     },
     getBaseTypeOfLiteralType(type) {
@@ -186,18 +186,15 @@ function createEslintTypeChecker(
       return callChecker(source, "getTypePredicateOfSignature", signature);
     },
     getBaseTypes(type) {
-      const baseTypes = asReadonlyArray(callChecker(source, "getBaseTypes", type));
-      return baseTypes.length > 0 ? baseTypes : heritageTypes(type, source, "extends");
+      return asReadonlyArray(callChecker(source, "getBaseTypes", type));
     },
     getImplementedTypes(node) {
-      return heritageTypesFromDeclaration(
-        tsNodeFor(node, esTreeNodeToTSNodeMap),
-        source,
-        "implements",
+      return asReadonlyArray(
+        callChecker(source, "getImplementedTypes", tsNodeFor(node, esTreeNodeToTSNodeMap)),
       );
     },
     getImplementedTypesOfType(type) {
-      return implementedTypesIncludingBases(type, source);
+      return asReadonlyArray(callChecker(source, "getImplementedTypesOfType", type));
     },
     getTypeArguments(type) {
       return asReadonlyArray(callChecker(source, "getTypeArguments", type));
@@ -275,100 +272,6 @@ function hasNode(
   node: unknown,
 ): boolean {
   return typeof node === "object" && node !== null && esTreeNodeToTSNodeMap.has(node as never);
-}
-
-function fallbackTypeText(type: unknown): string {
-  const name = (type as { readonly name?: unknown }).name;
-  return typeof name === "string" || typeof name === "number" || typeof name === "boolean"
-    ? String(name)
-    : "";
-}
-
-function heritageTypes(
-  type: unknown,
-  checker: Record<string, unknown>,
-  keyword: "extends" | "implements",
-): readonly never[] {
-  const declarations = asReadonlyArray(
-    (type as { readonly symbol?: { readonly declarations?: unknown } }).symbol?.declarations,
-  );
-  return declarations.flatMap((declaration) =>
-    heritageTypesFromDeclaration(declaration, checker, keyword),
-  );
-}
-
-/**
- * Mirrors the tsgo-backed `getImplementedTypesOfType` behaviour by walking the
- * base-type chain so a class that implements an interface only through a base
- * class still reports that interface. Without this, a rule shared between
- * oxlint (tsgo) and ESLint (this `@typescript-eslint` fallback checker) would
- * see different implemented types for the same source (GH#207).
- *
- * The traversal is a DFS so we can use `pop()` (O(1)) instead of a queue with
- * `shift()` (O(n)) — visit order doesn't matter because we dedupe implemented
- * types by identity. We also `continue` on already-visited bases before
- * touching `Set.add`, so a deep diamond hierarchy never quadruples work.
- */
-function implementedTypesIncludingBases(
-  type: unknown,
-  checker: Record<string, unknown>,
-): readonly never[] {
-  if (type === undefined || type === null) {
-    return [];
-  }
-  const visited = new Set<unknown>();
-  const seenImplemented = new Set<unknown>();
-  const implemented: never[] = [];
-  const stack: unknown[] = [type];
-  while (stack.length > 0) {
-    const current = stack.pop();
-    if (current === undefined || current === null || visited.has(current)) {
-      continue;
-    }
-    visited.add(current);
-    const ownImplemented = heritageTypes(current, checker, "implements");
-    for (let index = 0; index < ownImplemented.length; index += 1) {
-      const ownType = ownImplemented[index];
-      if (seenImplemented.has(ownType)) {
-        continue;
-      }
-      seenImplemented.add(ownType);
-      implemented.push(ownType);
-    }
-    const directBases = asReadonlyArray(callChecker(checker, "getBaseTypes", current));
-    const bases = directBases.length > 0 ? directBases : heritageTypes(current, checker, "extends");
-    for (let index = bases.length - 1; index >= 0; index -= 1) {
-      const baseType = bases[index];
-      if (baseType === undefined || baseType === null || visited.has(baseType)) {
-        continue;
-      }
-      stack.push(baseType);
-    }
-  }
-  return implemented;
-}
-
-function heritageTypesFromDeclaration(
-  declaration: unknown,
-  checker: Record<string, unknown>,
-  keyword: "extends" | "implements",
-): readonly never[] {
-  const clauses = asReadonlyArray(
-    (declaration as { readonly heritageClauses?: unknown }).heritageClauses,
-  );
-  return clauses
-    .filter((clause) => heritageClauseText(clause).trimStart().startsWith(keyword))
-    .flatMap((clause) => asReadonlyArray((clause as { readonly types?: unknown }).types))
-    .map((node) => {
-      const expression = (node as { readonly expression?: unknown }).expression ?? node;
-      return callChecker(checker, "getTypeAtLocation", expression);
-    })
-    .filter((type): type is never => type !== undefined);
-}
-
-function heritageClauseText(clause: unknown): string {
-  const getText = (clause as { readonly getText?: unknown }).getText;
-  return typeof getText === "function" ? String(getText.call(clause)) : "";
 }
 
 function resolveEslintParserServices(


### PR DESCRIPTION
Closes #280

## Changes
- Stop synthesizing base and implemented type semantics in the ESLint fallback checker.
- Delegate fallback base/implemented type lookups to the upstream checker methods when present.
- Remove loose type-text rendering from fallback checker objects.

## Verification
- vp check
- vp test src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
- vp test src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783004913&installation_id=136613492&pr_number=287&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F287&signature=0ab0f5e077b5eee1c3c789560174dd29f1427b88396122bfbe5824b636cb3e3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->