### PR TITLE
refactor(corsa-oxlint): derive tagged-template facts in Rust

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
@@ -326,9 +326,6 @@ function addHostFacts(
   if (current.type === "ExpressionStatement") {
     fields.__nearestFunctionAsync = nearestFunctionAncestor(context, current)?.async === true;
   }
-  if (current.type === "TemplateLiteral") {
-    fields.__taggedTemplate = current.parent?.type === "TaggedTemplateExpression";
-  }
   if (current.type === "CallExpression" && isPromiseExecutorRejectCall(context, current)) {
     fields.__promiseExecutorRejectCall = true;
   }

--- a/src/core/corsa_core/src/lint/rules/no_unnecessary_template_expression.rs
+++ b/src/core/corsa_core/src/lint/rules/no_unnecessary_template_expression.rs
@@ -52,7 +52,7 @@ impl RustLintRule for NoUnnecessaryTemplateExpressionRule {
 /// enables the type-only enum-member guard for the trivial special case.
 fn check_template(ctx: &mut RuleContext<'_>, node: &LintNode, is_type: bool) {
     // `tag` ${...}` `` is excluded from the rule entirely.
-    if !is_type && node.field_bool("__taggedTemplate").unwrap_or(false) {
+    if !is_type && is_tagged_template(node) {
         return;
     }
 
@@ -93,6 +93,10 @@ fn check_template(ctx: &mut RuleContext<'_>, node: &LintNode, is_type: bool) {
         }
         report_span(ctx, expr);
     }
+}
+
+fn is_tagged_template(node: &LintNode) -> bool {
+    node.field_str("__parentKind") == Some("TaggedTemplateExpression")
 }
 
 /// Reports the `${ ... }` span around `expr`. The `${` opens two bytes before
@@ -393,7 +397,7 @@ mod tests {
         let node = from(json!({
             "kind": "TemplateLiteral",
             "range": { "start": 0, "end": 6 },
-            "fields": { "__taggedTemplate": true },
+            "fields": { "__parentKind": "TaggedTemplateExpression" },
             "childLists": {
                 "quasis": [quasi(1, 1, ""), quasi(5, 5, "")],
                 "expressions": [{

--- a/src/core/corsa_core/src/lint/rules/restrict_template_expressions.rs
+++ b/src/core/corsa_core/src/lint/rules/restrict_template_expressions.rs
@@ -32,7 +32,7 @@ impl RustLintRule for RestrictTemplateExpressionsRule {
     }
 
     fn check(&self, ctx: &mut RuleContext<'_>, node: &LintNode) {
-        if node.kind != "TemplateLiteral" || node.field_bool("__taggedTemplate").unwrap_or(false) {
+        if node.kind != "TemplateLiteral" || is_tagged_template(node) {
             return;
         }
 
@@ -43,6 +43,10 @@ impl RustLintRule for RestrictTemplateExpressionsRule {
             }
         }
     }
+}
+
+fn is_tagged_template(node: &LintNode) -> bool {
+    node.field_str("__parentKind") == Some("TaggedTemplateExpression")
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/core/corsa_core/src/lint/tests.rs
+++ b/src/core/corsa_core/src/lint/tests.rs
@@ -1108,7 +1108,7 @@ fn ignores_tagged_template_expressions() {
         "{ value: number }",
     )]);
     node.fields
-        .insert("__taggedTemplate".to_owned(), json!(true));
+        .insert("__parentKind".to_owned(), json!("TaggedTemplateExpression"));
 
     let diagnostics = registry()
         .run_rule("restrict-template-expressions", &node)


### PR DESCRIPTION
## Summary

- remove the TS-side `__taggedTemplate` host fact from the native bridge
- derive tagged-template context in Rust template rules from the generic `__parentKind` fact
- update tagged-template regression coverage to use the generic parent-kind metadata

## Validation

- `cargo fmt --all --check`
- `cargo test -p corsa_core tagged_template`
- `cargo test -p corsa_core lint`
- `vp check`
- `vp test src/bindings/nodejs/corsa_oxlint/ts/native_diagnostics_snapshot.test.ts`
- `vp test src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts -t "runs restrict-template-expressions through RuleTester"`

Closes #288

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783005490&installation_id=136613492&pr_number=289&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F289&signature=4f7ab038ca671da05125f6337ad782fb55a7ab9ba772a1940c78ac0ba2e38d93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->