### PR TITLE
refactor(corsa-oxlint): remove unused native host fact

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
@@ -341,9 +341,6 @@ function addHostFacts(
   if (current.parent?.type) {
     fields.__parentKind = current.parent.type;
   }
-  if (current.type === "ExportNamedDeclaration" && hasTypeOnlyValueExport(context, current)) {
-    fields.__nativeRuleViolation = true;
-  }
   if (
     (current.type === "Identifier" || current.type === "MemberExpression") &&
     isDeprecatedSymbolUse(context, current)
@@ -670,21 +667,6 @@ function topLevelIndexOf(text: string, needle: string): number {
     }
   }
   return -1;
-}
-
-function hasTypeOnlyValueExport(context: ContextWithParserOptions, node: any): boolean {
-  if (node.exportKind === "type" || !Array.isArray(node.specifiers)) {
-    return false;
-  }
-  const checker = checkerFor(context);
-  return node.specifiers.some((specifier: any) => {
-    if (specifier.exportKind === "type") {
-      return false;
-    }
-    const target = specifier.local ?? specifier.exported;
-    const symbol = target ? checker.getSymbolAtLocation(target) : undefined;
-    return symbol !== undefined && symbol.valueDeclaration === undefined;
-  });
 }
 
 function isDeprecatedSymbolUse(context: ContextWithParserOptions, node: any): boolean {


### PR DESCRIPTION
## Summary
- remove the unused `__nativeRuleViolation` field from the native oxlint bridge
- delete the TS-only `hasTypeOnlyValueExport` checker helper that only fed that field
- keep native rule behavior owned by Rust facts that are actually consumed

## Validation
- `vp check`
- `vp test src/bindings/nodejs/corsa_oxlint/ts/native_diagnostics_snapshot.test.ts`
- `cargo test -p corsa_core lint`

Closes #290

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783006071&installation_id=136613492&pr_number=291&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F291&signature=ddd34d2fcf6ad5c2349791681d084a1efb7df240a7abbccf3f278541c3821a0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->