### PR TITLE
refactor(corsa-oxlint): resolve parameter symbol types by id

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -81,8 +81,14 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
     getTypeOfSymbol(symbol) {
       return sessionForContext(context).session.getTypeOfSymbol(symbol);
     },
+    getTypeOfSymbolById(id) {
+      return sessionForContext(context).session.getTypeOfSymbolById(id);
+    },
     getDeclaredTypeOfSymbol(symbol) {
       return sessionForContext(context).session.getDeclaredTypeOfSymbol(symbol);
+    },
+    getDeclaredTypeOfSymbolById(id) {
+      return sessionForContext(context).session.getDeclaredTypeOfSymbolById(id);
     },
     getTypeOfSymbolAtLocation(symbol, node) {
       return (

--- a/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
@@ -144,8 +144,14 @@ function createEslintTypeChecker(
     getTypeOfSymbol(symbol) {
       return callChecker(source, "getTypeOfSymbol", symbol);
     },
+    getTypeOfSymbolById() {
+      return undefined;
+    },
     getDeclaredTypeOfSymbol(symbol) {
       return callChecker(source, "getDeclaredTypeOfSymbol", symbol);
+    },
+    getDeclaredTypeOfSymbolById() {
+      return undefined;
     },
     getTypeOfSymbolAtLocation(symbol, node) {
       return (

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
@@ -11,7 +11,14 @@ import type {
 
 import { createNativeRule } from "./rule_creator";
 import { checkerFor, propertyNamesOfNode, typeAtNode, typeTextsAtNode } from "./type_utils";
-import type { ContextWithParserOptions, CorsaNode, CorsaSignature, CorsaType } from "../types";
+import type {
+  ContextWithParserOptions,
+  CorsaNode,
+  CorsaSignature,
+  CorsaSymbol,
+  CorsaType,
+  CorsaTypeCheckerShape,
+} from "../types";
 
 type RangedNode = {
   readonly type: string;
@@ -494,17 +501,31 @@ function parameterTypeTexts(
   parameterId: string,
 ): readonly string[] {
   const checker = checkerFor(context);
-  const parameterSymbol = checker.getSymbol(parameterId) ?? ({ id: parameterId } as any);
-  const declaration =
-    checker.getNode(parameterSymbol.valueDeclaration) ??
-    checker.getNode(parameterSymbol.declarations?.[0]);
+  const parameterSymbol = checker.getSymbol(parameterId);
+  const declaration = parameterSymbol ? declarationForSymbol(checker, parameterSymbol) : undefined;
   const parameterType =
-    (declaration ? checker.getTypeOfSymbolAtLocation(parameterSymbol, declaration) : undefined) ??
-    checker.getTypeOfSymbol(parameterSymbol) ??
-    checker.getDeclaredTypeOfSymbol(parameterSymbol);
+    (parameterSymbol && declaration
+      ? checker.getTypeOfSymbolAtLocation(parameterSymbol, declaration)
+      : undefined) ??
+    (parameterSymbol ? checker.getTypeOfSymbol(parameterSymbol) : undefined) ??
+    (parameterSymbol ? checker.getDeclaredTypeOfSymbol(parameterSymbol) : undefined) ??
+    checker.getTypeOfSymbolById(parameterId) ??
+    checker.getDeclaredTypeOfSymbolById(parameterId);
   const typeTexts = parameterType ? renderTypeTexts(context, parameterType) : [];
   const fallbackTexts = parameterAnnotationTexts(context, declaration);
   return typeTexts.length > 0 ? typeTexts : fallbackTexts;
+}
+
+function declarationForSymbol(
+  checker: CorsaTypeCheckerShape,
+  symbol: CorsaSymbol,
+): CorsaNode | undefined {
+  const valueDeclaration = symbol.valueDeclaration;
+  const firstDeclaration = symbol.declarations?.[0];
+  return (
+    (valueDeclaration ? checker.getNode(valueDeclaration) : undefined) ??
+    (firstDeclaration ? checker.getNode(firstDeclaration) : undefined)
+  );
 }
 
 function parameterAnnotationTexts(

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -230,10 +230,18 @@ export class CorsaProjectSession {
     return type;
   }
 
+  getTypeOfSymbolById(id: string): CorsaType | undefined {
+    return this.rememberType(this.tryGetSymbolTypeId(id, "getTypeOfSymbol"));
+  }
+
   getDeclaredTypeOfSymbol(symbol: CorsaSymbol): CorsaType | undefined {
     const type = this.rememberType(this.tryGetSymbolType(symbol, "getDeclaredTypeOfSymbol"));
     this.rememberTypeSource(type, symbol.valueDeclaration);
     return type;
+  }
+
+  getDeclaredTypeOfSymbolById(id: string): CorsaType | undefined {
+    return this.rememberType(this.tryGetSymbolTypeId(id, "getDeclaredTypeOfSymbol"));
   }
 
   typeToString(type: CorsaType, flags?: number): string {
@@ -481,10 +489,15 @@ export class CorsaProjectSession {
     symbol: CorsaSymbol,
     method: "getTypeOfSymbol" | "getDeclaredTypeOfSymbol",
   ): CorsaType | undefined {
+    return this.tryGetSymbolTypeId(symbol.id, method);
+  }
+
+  private tryGetSymbolTypeId(
+    id: string,
+    method: "getTypeOfSymbol" | "getDeclaredTypeOfSymbol",
+  ): CorsaType | undefined {
     try {
-      return this.client()[method](this.#snapshot!, this.projectId(), symbol.id) as
-        | CorsaType
-        | undefined;
+      return this.client()[method](this.#snapshot!, this.projectId(), id) as CorsaType | undefined;
     } catch {
       return undefined;
     }

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -918,6 +918,12 @@ describe("corsa oxlint type locations", () => {
       "id",
       "props",
     ]);
+    expect(
+      signature?.parameters.map((id) => {
+        const type = checker.getTypeOfSymbolById(id) ?? checker.getDeclaredTypeOfSymbolById(id);
+        return type ? checker.typeToString(type) : undefined;
+      }),
+    ).toEqual(["Construct | undefined", "string | undefined", "StackProps | undefined"]);
   });
 
   integrationCase("resolves the symbol type at a location instead of the node type", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/types.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/types.ts
@@ -110,7 +110,9 @@ export interface CorsaTypeCheckerShape {
   getNode(node: string | CorsaNode): CorsaNode | undefined;
   getNodeById(id: string): CorsaNode | undefined;
   getTypeOfSymbol(symbol: CorsaSymbol): CorsaType | undefined;
+  getTypeOfSymbolById(id: string): CorsaType | undefined;
   getDeclaredTypeOfSymbol(symbol: CorsaSymbol): CorsaType | undefined;
+  getDeclaredTypeOfSymbolById(id: string): CorsaType | undefined;
   getTypeOfSymbolAtLocation(symbol: CorsaSymbol, node: Node | CorsaNode): CorsaType | undefined;
   typeToString(type: CorsaType, enclosingDeclaration?: Node | CorsaNode, flags?: number): string;
   getBaseTypeOfLiteralType(type: CorsaType): CorsaType | undefined;


### PR DESCRIPTION
## Summary
- add Corsa-backed checker/session methods to resolve symbol types directly from symbol handles
- remove the native bridge `{ id }` parameter symbol shell fallback
- cover signature parameter type resolution from dependency declarations

## Validation
- `vp check`
- `vp test src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts`
- `vp test src/bindings/nodejs/corsa_oxlint/ts/native_diagnostics_snapshot.test.ts`

Closes #293

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783007196&installation_id=136613492&pr_number=294&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F294&signature=732785bbf0d997a10a7d6b08742ad88b884250247914ddeaee8fd46a46a76063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->