### PR TITLE
refactor(corsa-oxlint): remove parameter source fallback

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
@@ -511,9 +511,7 @@ function parameterTypeTexts(
     (parameterSymbol ? checker.getDeclaredTypeOfSymbol(parameterSymbol) : undefined) ??
     checker.getTypeOfSymbolById(parameterId) ??
     checker.getDeclaredTypeOfSymbolById(parameterId);
-  const typeTexts = parameterType ? renderTypeTexts(context, parameterType) : [];
-  const fallbackTexts = parameterAnnotationTexts(context, declaration);
-  return typeTexts.length > 0 ? typeTexts : fallbackTexts;
+  return parameterType ? renderTypeTexts(context, parameterType) : [];
 }
 
 function declarationForSymbol(
@@ -526,35 +524,6 @@ function declarationForSymbol(
     (valueDeclaration ? checker.getNode(valueDeclaration) : undefined) ??
     (firstDeclaration ? checker.getNode(firstDeclaration) : undefined)
   );
-}
-
-function parameterAnnotationTexts(
-  context: ContextWithParserOptions,
-  declaration: CorsaNode | undefined,
-): readonly string[] {
-  if (!declaration) {
-    return [];
-  }
-  const sourceText = sourceTextForPath(context, declaration.fileName);
-  if (
-    !sourceText ||
-    declaration.pos < 0 ||
-    declaration.end > sourceText.length ||
-    declaration.pos >= declaration.end
-  ) {
-    return [];
-  }
-  const parameterText = sourceText.slice(declaration.pos, declaration.end);
-  const annotationStart = topLevelIndexOf(parameterText, ":");
-  if (annotationStart < 0) {
-    return [];
-  }
-  const annotationText = parameterText.slice(annotationStart + 1);
-  const defaultStart = topLevelIndexOf(annotationText, "=");
-  const typeText = (defaultStart >= 0 ? annotationText.slice(0, defaultStart) : annotationText)
-    .trim()
-    .replace(/\s+$/, "");
-  return typeText ? [typeText] : [];
 }
 
 function typeTextsOverlap(actual: readonly string[], expected: readonly string[]): boolean {


### PR DESCRIPTION
## Summary
- remove the TypeScript bridge fallback that parses parameter annotation text from source slices
- rely on Corsa-backed symbol-handle type resolution for expected argument type text
- keep the remaining signature declaration parsing for default type arguments unchanged

## Validation
- `vp check`
- `vp test src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts`
- `vp test src/bindings/nodejs/corsa_oxlint/ts/native_diagnostics_snapshot.test.ts`

Closes #295

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783007891&installation_id=136613492&pr_number=296&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F296&signature=dc79a5095f7c2a1823e045fb4ac1e803edb50ae9d1e01be2d223cdaa05362126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->