### PR TITLE
refactor(corsa-oxlint): move host facts into Rust

### DIFF
--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -1,10 +1,13 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    fs,
+    sync::{Arc, Mutex},
+};
 
 use corsa::{
     CorsaError,
     api::{
-        ApiClient, ManagedSnapshot, ProjectHandle, SnapshotHandle, SymbolHandle, TypeHandle,
-        TypeResponse, UpdateSnapshotParams,
+        ApiClient, ManagedSnapshot, NodeHandle, ProjectHandle, SignatureResponse, SnapshotHandle,
+        SymbolHandle, SymbolResponse, TypeHandle, TypeResponse, UpdateSnapshotParams,
     },
     fast::{CompactString, FastMap},
     runtime::block_on,
@@ -51,6 +54,70 @@ struct TypeOnlyParams {
     snapshot: String,
     #[serde(rename = "type")]
     type_handle: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SignatureOfTypeParams {
+    snapshot: String,
+    project: String,
+    #[serde(rename = "type")]
+    type_handle: String,
+    kind: i32,
+    file: Option<String>,
+    source_text: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CallSignatureFactsParams {
+    snapshot: String,
+    project: String,
+    #[serde(rename = "type")]
+    type_handle: String,
+    kind: i32,
+    file: Option<String>,
+    source_text: Option<String>,
+    #[serde(default)]
+    argument_type_texts: Vec<Vec<String>>,
+    #[serde(default)]
+    explicit_type_argument_texts: Vec<String>,
+}
+
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CallSignatureFactsResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    signature: Option<SignatureResponse>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    expected_argument_type_texts: Vec<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    explicit_type_arguments_required: Option<bool>,
+}
+
+struct SignatureSourceOverride {
+    file: String,
+    source_text: String,
+}
+
+struct CallSignatureFactsLookup<'a> {
+    snapshot: SnapshotHandle,
+    project: ProjectHandle,
+    r#type: TypeHandle,
+    kind: i32,
+    source_override: Option<&'a SignatureSourceOverride>,
+    argument_type_texts: Vec<Vec<String>>,
+    explicit_type_argument_texts: Vec<String>,
+}
+
+fn signature_source_override(
+    file: Option<String>,
+    source_text: Option<String>,
+) -> Option<SignatureSourceOverride> {
+    Some(SignatureSourceOverride {
+        file: file?,
+        source_text: source_text?,
+    })
 }
 
 struct SourceRangeLookup {
@@ -1877,6 +1944,508 @@ fn is_stale_handle_message(message: &str) -> bool {
     message.contains("not found in snapshot registry")
 }
 
+async fn get_signatures_of_type_with_parameter_texts(
+    client: &ApiClient,
+    snapshot: SnapshotHandle,
+    project: ProjectHandle,
+    r#type: TypeHandle,
+    kind: i32,
+    source_override: Option<&SignatureSourceOverride>,
+) -> corsa::Result<Vec<SignatureResponse>> {
+    let mut signatures = client
+        .get_signatures_of_type(snapshot.clone(), project.clone(), r#type, kind)
+        .await?;
+    for signature in &mut signatures {
+        if signature.parameter_symbols.is_empty() && !signature.parameters.is_empty() {
+            signature.parameter_symbols = parameter_symbols_for_signature(
+                client,
+                snapshot.clone(),
+                project.clone(),
+                signature,
+                source_override,
+            )
+            .await?;
+        }
+        if signature.type_parameter_default_texts.is_empty()
+            && !signature.type_parameters.is_empty()
+        {
+            signature.type_parameter_default_texts = type_parameter_default_texts_for_signature(
+                client,
+                snapshot.clone(),
+                project.clone(),
+                signature,
+                source_override,
+            )
+            .await?;
+        }
+        if !signature.parameter_type_texts.is_empty() {
+            continue;
+        }
+        signature.parameter_type_texts = render_symbol_type_texts(
+            client,
+            snapshot.clone(),
+            project.clone(),
+            &signature.parameters,
+        )
+        .await?;
+        if let Some(this_parameter) = &signature.this_parameter {
+            signature.this_parameter_type_texts = render_symbol_type_texts(
+                client,
+                snapshot.clone(),
+                project.clone(),
+                std::slice::from_ref(this_parameter),
+            )
+            .await?
+            .into_iter()
+            .next()
+            .unwrap_or_default();
+        }
+    }
+    Ok(signatures)
+}
+
+async fn parameter_symbols_for_signature(
+    client: &ApiClient,
+    snapshot: SnapshotHandle,
+    project: ProjectHandle,
+    signature: &SignatureResponse,
+    source_override: Option<&SignatureSourceOverride>,
+) -> corsa::Result<Vec<SymbolResponse>> {
+    let Some(declaration) = &signature.declaration else {
+        return Ok(Vec::new());
+    };
+    let Ok(parsed) = declaration.parse() else {
+        return Ok(Vec::new());
+    };
+    let source_text = source_text_for_signature_declaration(
+        client,
+        snapshot,
+        project,
+        parsed.path.as_str(),
+        source_override,
+    )
+    .await?;
+    let Some((start, end)) = utf16_byte_range(&source_text, parsed.pos, parsed.end) else {
+        return Ok(Vec::new());
+    };
+    let Some(declaration_text) = source_text.get(start..end) else {
+        return Ok(Vec::new());
+    };
+    let parameters = parameter_ranges_in_signature_declaration(declaration_text, start)
+        .into_iter()
+        .filter_map(|parameter| {
+            let pos = utf16_index_from_byte(&source_text, parameter.start)?;
+            let end = utf16_index_from_byte(&source_text, parameter.end)?;
+            Some((parameter.name, pos, end))
+        })
+        .collect::<Vec<_>>();
+    if parameters.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    Ok(signature
+        .parameters
+        .iter()
+        .zip(parameters)
+        .map(|(symbol, (name, pos, end))| {
+            let declaration =
+                NodeHandle::from(format!("{}.{}.0.{}", pos, end, parsed.path.as_str()));
+            SymbolResponse {
+                id: symbol.clone(),
+                name,
+                flags: 1,
+                check_flags: 0,
+                declarations: vec![declaration.clone()],
+                value_declaration: Some(declaration),
+            }
+        })
+        .collect())
+}
+
+async fn type_parameter_default_texts_for_signature(
+    client: &ApiClient,
+    snapshot: SnapshotHandle,
+    project: ProjectHandle,
+    signature: &SignatureResponse,
+    source_override: Option<&SignatureSourceOverride>,
+) -> corsa::Result<Vec<String>> {
+    let Some(declaration) = &signature.declaration else {
+        return Ok(Vec::new());
+    };
+    let Ok(parsed) = declaration.parse() else {
+        return Ok(Vec::new());
+    };
+    let source_text = source_text_for_signature_declaration(
+        client,
+        snapshot,
+        project,
+        parsed.path.as_str(),
+        source_override,
+    )
+    .await?;
+    let Some((start, end)) = utf16_byte_range(&source_text, parsed.pos, parsed.end) else {
+        return Ok(Vec::new());
+    };
+    let Some(declaration_text) = source_text.get(start..end) else {
+        return Ok(Vec::new());
+    };
+    Ok(type_parameter_default_texts_in_signature_declaration(
+        declaration_text,
+    ))
+}
+
+fn type_parameter_default_texts_in_signature_declaration(declaration_text: &str) -> Vec<String> {
+    let Some(open) = first_top_level_opening_angle(declaration_text) else {
+        return Vec::new();
+    };
+    let Some(first_paren) = first_top_level_opening_paren(declaration_text) else {
+        return Vec::new();
+    };
+    if open > first_paren {
+        return Vec::new();
+    }
+    let Some(close) = matching_angle_close(declaration_text, open) else {
+        return Vec::new();
+    };
+    let parameters_text = &declaration_text[open + 1..close];
+    split_top_level_ranges(parameters_text, ',')
+        .into_iter()
+        .map(|range| {
+            let parameter_text = &parameters_text[range.start..range.end];
+            first_top_level_index_of_any(parameter_text, &['='])
+                .and_then(|index| char_len_at(parameter_text, index).map(|len| index + len))
+                .map(|start| parameter_text[start..].trim().to_owned())
+                .unwrap_or_default()
+        })
+        .collect()
+}
+
+async fn source_text_for_signature_declaration(
+    client: &ApiClient,
+    snapshot: SnapshotHandle,
+    project: ProjectHandle,
+    path: &str,
+    source_override: Option<&SignatureSourceOverride>,
+) -> corsa::Result<String> {
+    if let Some(source_override) = source_override
+        && (source_override.file == path || source_override.file.ends_with(path))
+    {
+        return Ok(source_override.source_text.clone());
+    }
+    if let Ok(source_text) = fs::read_to_string(path) {
+        return Ok(source_text);
+    }
+    let Some(source) = client
+        .get_source_file(snapshot, project, path.to_owned())
+        .await?
+    else {
+        return Ok(String::new());
+    };
+    Ok(String::from_utf8(source.into_bytes()).unwrap_or_default())
+}
+
+struct ParameterSourceRange {
+    name: String,
+    start: usize,
+    end: usize,
+}
+
+fn parameter_ranges_in_signature_declaration(
+    declaration_text: &str,
+    declaration_start: usize,
+) -> Vec<ParameterSourceRange> {
+    let Some(open) = first_top_level_opening_paren(declaration_text) else {
+        return Vec::new();
+    };
+    let Some(close) = matching_paren_close(declaration_text, open) else {
+        return Vec::new();
+    };
+    let parameters_text = &declaration_text[open + 1..close];
+    split_top_level_ranges(parameters_text, ',')
+        .into_iter()
+        .filter_map(|range| {
+            let raw = &parameters_text[range.start..range.end];
+            let leading = first_non_whitespace(raw)?;
+            let trailing = raw
+                .char_indices()
+                .rev()
+                .find(|(_, ch)| !ch.is_whitespace())
+                .map(|(index, ch)| index + ch.len_utf8())?;
+            let name = parameter_name(raw)?;
+            Some(ParameterSourceRange {
+                name,
+                start: declaration_start + open + 1 + range.start + leading,
+                end: declaration_start + open + 1 + range.start + trailing,
+            })
+        })
+        .collect()
+}
+
+fn parameter_name(text: &str) -> Option<String> {
+    let mut index = skip_whitespace(text, 0);
+    loop {
+        if text.get(index..)?.starts_with("...") {
+            index = skip_whitespace(text, index + 3);
+        }
+        let (start, end) = read_identifier(text, index)?;
+        let word = &text[start..end];
+        if is_modifier(word) {
+            index = skip_whitespace(text, end);
+            continue;
+        }
+        return Some(word.to_owned());
+    }
+}
+
+fn first_top_level_opening_paren(text: &str) -> Option<usize> {
+    let mut angle_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+    let mut index = 0usize;
+    let mut scanner = SourceScanner::default();
+    while index < text.len() {
+        let next = scanner.skip(text, index);
+        if next > index {
+            index = next;
+            continue;
+        }
+        let ch = char_at(text, index)?;
+        match ch {
+            '<' => angle_depth += 1,
+            '>' => angle_depth = angle_depth.saturating_sub(1),
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '{' => brace_depth += 1,
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            '(' if angle_depth == 0 && bracket_depth == 0 && brace_depth == 0 => {
+                return Some(index);
+            }
+            _ => {}
+        }
+        index += ch.len_utf8();
+    }
+    None
+}
+
+fn matching_paren_close(text: &str, open: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut index = open;
+    let mut scanner = SourceScanner::default();
+    while index < text.len() {
+        let next = scanner.skip(text, index);
+        if next > index {
+            index = next;
+            continue;
+        }
+        let ch = char_at(text, index)?;
+        if ch == '(' {
+            depth += 1;
+        } else if ch == ')' {
+            depth = depth.checked_sub(1)?;
+            if depth == 0 {
+                return Some(index);
+            }
+        }
+        index += ch.len_utf8();
+    }
+    None
+}
+
+async fn get_call_signature_facts(
+    client: &ApiClient,
+    lookup: CallSignatureFactsLookup<'_>,
+) -> corsa::Result<CallSignatureFactsResponse> {
+    let signatures = get_signatures_of_type_with_parameter_texts(
+        client,
+        lookup.snapshot,
+        lookup.project,
+        lookup.r#type,
+        lookup.kind,
+        lookup.source_override,
+    )
+    .await?;
+    let Some(signature) =
+        select_signature_for_argument_texts(&signatures, &lookup.argument_type_texts)
+    else {
+        return Ok(CallSignatureFactsResponse::default());
+    };
+
+    let expected_argument_type_texts =
+        expected_argument_type_texts(signature, lookup.argument_type_texts.len());
+    let explicit_type_arguments_required =
+        explicit_type_arguments_required(signature, &lookup.explicit_type_argument_texts);
+
+    Ok(CallSignatureFactsResponse {
+        signature: Some(signature.clone()),
+        expected_argument_type_texts,
+        explicit_type_arguments_required,
+    })
+}
+
+fn select_signature_for_argument_texts<'a>(
+    signatures: &'a [SignatureResponse],
+    argument_type_texts: &[Vec<String>],
+) -> Option<&'a SignatureResponse> {
+    if signatures.len() <= 1 {
+        return signatures.first();
+    }
+    signatures
+        .iter()
+        .max_by_key(|signature| score_signature_for_arguments(signature, argument_type_texts))
+}
+
+fn expected_argument_type_texts(
+    signature: &SignatureResponse,
+    argument_count: usize,
+) -> Vec<Vec<String>> {
+    if signature.parameter_type_texts.is_empty() {
+        return Vec::new();
+    }
+    (0..argument_count)
+        .map(|index| {
+            signature
+                .parameter_type_texts
+                .get(index.min(signature.parameter_type_texts.len().saturating_sub(1)))
+                .cloned()
+                .unwrap_or_default()
+        })
+        .collect()
+}
+
+fn explicit_type_arguments_required(
+    signature: &SignatureResponse,
+    explicit_type_argument_texts: &[String],
+) -> Option<bool> {
+    if explicit_type_argument_texts.is_empty() || signature.type_parameter_default_texts.is_empty()
+    {
+        return None;
+    }
+    explicit_type_argument_texts
+        .iter()
+        .enumerate()
+        .all(|(index, explicit)| {
+            signature
+                .type_parameter_default_texts
+                .get(index)
+                .filter(|default| !default.trim().is_empty())
+                .is_some_and(|default| {
+                    normalize_type_text(default) == normalize_type_text(explicit)
+                })
+        })
+        .then_some(false)
+}
+
+fn score_signature_for_arguments(
+    signature: &SignatureResponse,
+    argument_type_texts: &[Vec<String>],
+) -> i32 {
+    let parameter_types = &signature.parameter_type_texts;
+    let mut score = -(argument_type_texts.len().abs_diff(parameter_types.len()) as i32);
+    for (index, actual) in argument_type_texts.iter().enumerate() {
+        let expected = parameter_types
+            .get(index.min(parameter_types.len().saturating_sub(1)))
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        if expected.is_empty() {
+            score -= 2;
+        } else if is_permissive_type_texts(expected) {
+            score += 1;
+        } else if fuzzy_type_texts_overlap(actual, expected) {
+            score += 4;
+        } else {
+            score -= 1;
+        }
+    }
+    score
+}
+
+fn fuzzy_type_texts_overlap(actual: &[String], expected: &[String]) -> bool {
+    let expected = expected
+        .iter()
+        .map(|text| normalize_type_text(text))
+        .collect::<Vec<_>>();
+    actual.iter().any(|actual_text| {
+        let actual = normalize_type_text(actual_text);
+        expected.iter().any(|expected| {
+            expected == &actual || expected.contains(actual.as_str()) || actual.contains(expected)
+        })
+    })
+}
+
+fn is_permissive_type_texts(texts: &[String]) -> bool {
+    texts.iter().any(|text| {
+        matches!(
+            normalize_type_text(text).as_str(),
+            "any" | "unknown" | "never"
+        )
+    })
+}
+
+fn normalize_type_text(text: &str) -> String {
+    text.split_whitespace().collect()
+}
+
+async fn render_symbol_type_texts(
+    client: &ApiClient,
+    snapshot: SnapshotHandle,
+    project: ProjectHandle,
+    symbols: &[SymbolHandle],
+) -> corsa::Result<Vec<Vec<String>>> {
+    let mut rendered = Vec::with_capacity(symbols.len());
+    for symbol in symbols {
+        let type_response = match client
+            .get_type_of_symbol(snapshot.clone(), project.clone(), symbol.clone())
+            .await
+        {
+            Ok(Some(type_response)) => Some(type_response),
+            Ok(None) => {
+                client
+                    .get_declared_type_of_symbol(snapshot.clone(), project.clone(), symbol.clone())
+                    .await?
+            }
+            Err(error) if is_stale_handle_error(&error) => None,
+            Err(error) => return Err(error),
+        };
+        match type_response {
+            Some(type_response) => {
+                rendered.push(
+                    render_type_texts(client, snapshot.clone(), project.clone(), type_response)
+                        .await?,
+                );
+            }
+            None => rendered.push(Vec::new()),
+        }
+    }
+    Ok(rendered)
+}
+
+async fn render_type_texts(
+    client: &ApiClient,
+    snapshot: SnapshotHandle,
+    project: ProjectHandle,
+    type_response: TypeResponse,
+) -> corsa::Result<Vec<String>> {
+    let mut texts = Vec::with_capacity(type_response.texts.len() + 1);
+    for text in &type_response.texts {
+        push_unique_text(&mut texts, text);
+    }
+    if texts.is_empty() {
+        let rendered = client
+            .type_to_string(snapshot, project, type_response.id, None, None)
+            .await?;
+        push_unique_text(&mut texts, rendered.as_str());
+    }
+    Ok(texts)
+}
+
+fn push_unique_text(texts: &mut Vec<String>, text: &str) {
+    let trimmed = text.trim();
+    if trimmed.is_empty() || texts.iter().any(|existing| existing == trimmed) {
+        return;
+    }
+    texts.push(trimmed.to_owned());
+}
+
 #[derive(Default)]
 struct SourceScanner {
     quote: Option<char>,
@@ -1949,6 +2518,42 @@ fn call_json_blocking(client: &ApiClient, method: &str, params: Option<Value>) -
         let response = block_on(client.get_types_of_type(
             SnapshotHandle::from(params.snapshot.as_str()),
             TypeHandle::from(params.type_handle.as_str()),
+        ))
+        .map_err(into_napi_error)?;
+        return to_value(&response);
+    }
+    if method == "getSignaturesOfType" {
+        let params =
+            params.ok_or_else(|| into_napi_error("getSignaturesOfType requires params"))?;
+        let params = from_value::<SignatureOfTypeParams>(params)?;
+        let source_override = signature_source_override(params.file, params.source_text);
+        let response = block_on(get_signatures_of_type_with_parameter_texts(
+            client,
+            SnapshotHandle::from(params.snapshot.as_str()),
+            ProjectHandle::from(params.project.as_str()),
+            TypeHandle::from(params.type_handle.as_str()),
+            params.kind,
+            source_override.as_ref(),
+        ))
+        .map_err(into_napi_error)?;
+        return to_value(&response);
+    }
+    if method == "getCallSignatureFacts" {
+        let params =
+            params.ok_or_else(|| into_napi_error("getCallSignatureFacts requires params"))?;
+        let params = from_value::<CallSignatureFactsParams>(params)?;
+        let source_override = signature_source_override(params.file, params.source_text);
+        let response = block_on(get_call_signature_facts(
+            client,
+            CallSignatureFactsLookup {
+                snapshot: SnapshotHandle::from(params.snapshot.as_str()),
+                project: ProjectHandle::from(params.project.as_str()),
+                r#type: TypeHandle::from(params.type_handle.as_str()),
+                kind: params.kind,
+                source_override: source_override.as_ref(),
+                argument_type_texts: params.argument_type_texts,
+                explicit_type_argument_texts: params.explicit_type_argument_texts,
+            },
         ))
         .map_err(into_napi_error)?;
         return to_value(&response);

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -288,6 +288,23 @@ describe("CorsaApiClient", () => {
       );
       expect(Buffer.from(sourceFile ?? []).toString("utf8")).toBe("source-file");
       expect(client.callJson<string>("ping")).toBe("pong");
+      expect(
+        client.callJson<Array<{ parameterTypeTexts?: string[][] }>>("getSignaturesOfType", {
+          snapshot: snapshot.snapshot,
+          project: project.id,
+          type: "t0000000000000001",
+          kind: 0,
+        })[0]?.parameterTypeTexts,
+      ).toEqual([["type-text"]]);
+      expect(
+        client.callJson<{ expectedArgumentTypeTexts?: string[][] }>("getCallSignatureFacts", {
+          snapshot: snapshot.snapshot,
+          project: project.id,
+          type: "t0000000000000001",
+          kind: 0,
+          argumentTypeTexts: [["type-text"]],
+        }).expectedArgumentTypeTexts,
+      ).toEqual([["type-text"]]);
       const sourceViaGeneric = client.callBinary("getSourceFile", {
         snapshot: snapshot.snapshot,
         project: project.id,

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -110,6 +110,14 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
     getSignaturesOfType(type, kind) {
       return sessionForContext(context).session.getSignaturesOfType(type, kind);
     },
+    getCallSignatureFacts(type, kind, argumentTypeTexts, explicitTypeArgumentTexts) {
+      return sessionForContext(context).session.getCallSignatureFacts(
+        type,
+        kind,
+        argumentTypeTexts,
+        explicitTypeArgumentTexts,
+      );
+    },
     getReturnTypeOfSignature(signature) {
       return sessionForContext(context).session.getReturnTypeOfSignature(signature);
     },
@@ -405,7 +413,6 @@ function implementedTypesFromSourceText(
   if (implementsIndex < 0) {
     return [];
   }
-  const session = sessionForContext(context).session;
   const clauseText = headerText.slice(implementsIndex + "implements".length);
   const clauseStart = node.pos + headerStart + implementsIndex + "implements".length;
   return splitTopLevelRanges(clauseText, ",")
@@ -431,11 +438,12 @@ function implementedTypesFromSourceText(
         ? (checker.getDeclaredTypeOfSymbol(symbol) ?? checker.getTypeOfSymbol(symbol))
         : (checker.getTypeAtLocation(nameNode) ?? checker.getTypeAtLocation(lookupNode));
       if (type) {
-        // Implemented-interface handles come back with empty `texts`, so warm
-        // the type-text cache with the `implements` identifier. If upstream
-        // later evicts the handle, `typeToString` falls back to this name
-        // instead of throwing (GH#211).
-        session.rememberTypeText(type.id, raw.slice(leading, raw.length - trailing));
+        try {
+          checker.typeToString(type);
+        } catch {
+          // Corsa-side relation fallbacks handle stale type handles; avoid
+          // deriving replacement text from source names in the JS bridge.
+        }
       }
       return type;
     })

--- a/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -88,5 +88,25 @@ describe("context", () => {
   it("resolves the platform-specific default corsa executable", () => {
     expect(defaultCorsaExecutable("/repo", "linux")).toBe(resolve("/repo", ".cache/corsa"));
     expect(defaultCorsaExecutable("/repo", "win32")).toBe(resolve("/repo", ".cache/corsa.exe"));
+  });
+
+  it("prefers the installed native-preview tsgo binary when available", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
+    cleanupDirs.add(workspace);
+    const packageDir = resolve(workspace, "node_modules/@typescript/native-preview");
+    const binPath = resolve(packageDir, "bin/tsgo.js");
+    mkdirSync(dirname(binPath), { recursive: true });
+    writeFileSync(
+      resolve(packageDir, "package.json"),
+      JSON.stringify({
+        name: "@typescript/native-preview",
+        bin: {
+          tsgo: "bin/tsgo.js",
+        },
+      }),
+    );
+    writeFileSync(binPath, "#!/usr/bin/env node\n");
+
+    expect(defaultCorsaExecutable(workspace)).toBe(realpathSync(binPath));
   });
 });

--- a/src/bindings/nodejs/corsa_oxlint/ts/context.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 
 import type {
@@ -21,7 +22,10 @@ const DEFAULT_TS_CONFIG = {
 };
 
 export function defaultCorsaExecutable(rootDir: string, platform = process.platform): string {
-  return resolve(rootDir, platform === "win32" ? ".cache/corsa.exe" : ".cache/corsa");
+  return (
+    resolveNativePreviewExecutable(rootDir) ??
+    resolve(rootDir, platform === "win32" ? ".cache/corsa.exe" : ".cache/corsa")
+  );
 }
 
 export function resolveProjectConfig(context: ContextWithParserOptions): ResolvedProjectConfig {
@@ -55,11 +59,13 @@ export function resolveProjectConfig(context: ContextWithParserOptions): Resolve
  */
 export function resolveTypeAwareParserOptions(
   context: ContextWithParserOptions,
+  defaults: { readonly projectService?: boolean } = {},
 ): TypeAwareParserOptions {
-  return mergeTypeAwareParserOptions(
+  const parserOptions = mergeTypeAwareParserOptions(
     resolveSettingsParserOptions(context.settings?.corsaOxlint),
     mergeTypeAwareParserOptions(context.parserOptions, context.languageOptions?.parserOptions),
   );
+  return applyTypeAwareParserOptionDefaults(parserOptions, defaults);
 }
 
 function resolveRuntimeOptions(
@@ -157,6 +163,45 @@ function asArray(value: string | string[] | undefined): string[] {
   return value ? (Array.isArray(value) ? value : [value]) : [];
 }
 
+function resolveNativePreviewExecutable(rootDir: string): string | undefined {
+  const requireFromRoot = createRequire(resolve(rootDir, "package.json"));
+  const packageJsonPath = resolveOptional(
+    requireFromRoot,
+    "@typescript/native-preview/package.json",
+  );
+  if (packageJsonPath) {
+    const binPath = nativePreviewBinPath(packageJsonPath);
+    if (binPath && existsSync(binPath)) {
+      return binPath;
+    }
+  }
+  const packageEntry = resolveOptional(requireFromRoot, "@typescript/native-preview");
+  return packageEntry && existsSync(packageEntry) ? packageEntry : undefined;
+}
+
+function resolveOptional(requireFromRoot: NodeJS.Require, specifier: string): string | undefined {
+  try {
+    return requireFromRoot.resolve(specifier);
+  } catch {
+    return undefined;
+  }
+}
+
+function nativePreviewBinPath(packageJsonPath: string): string | undefined {
+  try {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      readonly bin?: string | Record<string, string>;
+    };
+    const bin =
+      typeof packageJson.bin === "string"
+        ? packageJson.bin
+        : (packageJson.bin?.tsgo ?? Object.values(packageJson.bin ?? {})[0]);
+    return bin ? resolve(dirname(packageJsonPath), bin) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function resolveSettingsParserOptions(
   settings: CorsaOxlintSettings | undefined,
 ): TypeAwareParserOptions {
@@ -165,6 +210,23 @@ function resolveSettingsParserOptions(
   }
   const { parserOptions, ...inline } = settings;
   return mergeTypeAwareParserOptions(inline, parserOptions);
+}
+
+function applyTypeAwareParserOptionDefaults(
+  parserOptions: TypeAwareParserOptions,
+  defaults: { readonly projectService?: boolean },
+): TypeAwareParserOptions {
+  if (
+    defaults.projectService !== true ||
+    parserOptions.projectService !== undefined ||
+    parserOptions.project !== undefined
+  ) {
+    return parserOptions;
+  }
+  return {
+    ...parserOptions,
+    projectService: true,
+  };
 }
 
 export function mergeTypeAwareParserOptions(

--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -103,6 +103,46 @@ describe("corsa oxlint", () => {
     });
   });
 
+  it("defaults projectService for type-aware rules", () => {
+    let seen: Record<string, unknown> | undefined;
+    const rule = decorateRule({
+      meta: {
+        docs: {
+          requiresTypeChecking: true,
+        },
+        messages: {
+          demo: "demo",
+        },
+        schema: [],
+      },
+      create(context: any) {
+        seen = {
+          parserProjectService: context.parserOptions.projectService,
+          languageProjectService: context.languageOptions?.parserOptions?.projectService,
+        };
+        return {};
+      },
+    } as any);
+
+    rule.create!({
+      cwd: workspaceRoot,
+      filename: resolve(workspaceRoot, "fixture.ts"),
+      languageOptions: {
+        parserOptions: {},
+      },
+      report() {},
+      settings: {},
+      sourceCode: {
+        text: "const fixture = 1;",
+      },
+    } as any);
+
+    expect(seen).toEqual({
+      parserProjectService: true,
+      languageProjectService: true,
+    });
+  });
+
   it("reuses existing parserServices when ESLint already provides type information", () => {
     const program = {
       getTypeChecker() {

--- a/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
@@ -185,6 +185,9 @@ function createEslintTypeChecker(
     getSignaturesOfType(type, kind) {
       return asReadonlyArray(callChecker(source, "getSignaturesOfType", type, kind));
     },
+    getCallSignatureFacts() {
+      return {};
+    },
     getReturnTypeOfSignature(signature) {
       return callChecker(source, "getReturnTypeOfSignature", signature);
     },

--- a/src/bindings/nodejs/corsa_oxlint/ts/plugin.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/plugin.ts
@@ -55,7 +55,7 @@ export function decorateRule(rule: Rule): Rule {
     return {
       ...rule,
       create(context) {
-        return rule.create!(decorateContext(context));
+        return rule.create!(decorateContext(context, rule));
       },
     } as Rule;
   }
@@ -63,7 +63,7 @@ export function decorateRule(rule: Rule): Rule {
     return {
       ...rule,
       createOnce(context) {
-        return (rule as any).createOnce(decorateContext(context));
+        return (rule as any).createOnce(decorateContext(context, rule));
       },
     } as Rule;
   }
@@ -76,8 +76,12 @@ function wrapRules(rules: Record<string, Rule>): Record<string, Rule> {
   );
 }
 
-function decorateContext(context: ContextWithParserOptions): ContextWithParserOptions {
-  const parserOptions = Object.freeze(resolveTypeAwareParserOptions(context));
+function decorateContext(context: ContextWithParserOptions, rule: Rule): ContextWithParserOptions {
+  const parserOptions = Object.freeze(
+    resolveTypeAwareParserOptions(context, {
+      projectService: requiresTypeChecking(rule),
+    }),
+  );
   const baseLanguageOptions = context.languageOptions;
   const languageOptions = Object.freeze({
     ...baseLanguageOptions,
@@ -106,4 +110,11 @@ function decorateContext(context: ContextWithParserOptions): ContextWithParserOp
       },
     },
   }) as ContextWithParserOptions;
+}
+
+function requiresTypeChecking(rule: Rule): boolean {
+  return (
+    (rule.meta as { readonly docs?: { readonly requiresTypeChecking?: unknown } } | undefined)?.docs
+      ?.requiresTypeChecking === true
+  );
 }

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from "node:fs";
-
 import { nativeLintRuleMetas, runNativeLintRule } from "@corsa-bind/napi";
 import type {
   NativeLintDiagnostic,
@@ -11,14 +9,7 @@ import type {
 
 import { createNativeRule } from "./rule_creator";
 import { checkerFor, propertyNamesOfNode, typeAtNode, typeTextsAtNode } from "./type_utils";
-import type {
-  ContextWithParserOptions,
-  CorsaNode,
-  CorsaSignature,
-  CorsaSymbol,
-  CorsaType,
-  CorsaTypeCheckerShape,
-} from "../types";
+import type { ContextWithParserOptions, CorsaCallSignatureFacts, CorsaType } from "../types";
 
 type RangedNode = {
   readonly type: string;
@@ -157,7 +148,7 @@ export function toNativeNode(
     fields.__ruleOptions = options;
   }
   if (includeRuleOptions) {
-    addHostFacts(context, node, fields);
+    addHostInputs(context, node, fields);
   }
 
   const nativeNode: NativeLintNode = {
@@ -324,119 +315,194 @@ function sameRange(range: readonly [number, number], expected: NativeLintRange):
   return range[0] === expected.start && range[1] === expected.end;
 }
 
-function addHostFacts(
+function addHostInputs(
   context: ContextWithParserOptions,
   node: RangedNode,
   fields: Record<string, unknown>,
 ): void {
   const current = node as any;
-  if (current.type === "ExpressionStatement") {
-    fields.__nearestFunctionAsync = nearestFunctionAncestor(context, current)?.async === true;
-  }
-  if (current.type === "CallExpression" && isPromiseExecutorRejectCall(context, current)) {
-    fields.__promiseExecutorRejectCall = true;
+  const ancestors = ancestorFacts(context, current);
+  if (ancestors.length > 0) {
+    fields.__ancestorFacts = ancestors;
   }
   if (current.type === "CallExpression" || current.type === "NewExpression") {
-    const expectedArgumentTypeTexts = expectedArgumentTypeTextsOfCall(context, current);
-    if (expectedArgumentTypeTexts.length > 0) {
-      fields.__expectedArgumentTypeTexts = expectedArgumentTypeTexts;
-    }
-    if (hasUnnecessaryExplicitTypeArguments(context, current)) {
-      fields.__explicitTypeArgumentsRequired = false;
+    const callFacts = callFactsOfNode(context, current);
+    if (Object.keys(callFacts).length > 0) {
+      fields.__callFacts = callFacts;
     }
   }
   if (current.parent?.type) {
     fields.__parentKind = current.parent.type;
   }
-  if (
-    (current.type === "Identifier" || current.type === "MemberExpression") &&
-    isDeprecatedSymbolUse(context, current)
-  ) {
-    fields.__deprecated = true;
+  const symbolFacts = symbolFactsOfNode(context, current);
+  if (Object.keys(symbolFacts).length > 0) {
+    fields.__symbolFacts = symbolFacts;
   }
-  if (
-    current.type === "TSTypeParameterDeclaration" &&
-    hasSingleUseTypeParameter(context, current)
-  ) {
-    fields.__hasSingleUseTypeParameter = true;
+  const typeParameterFacts = typeParameterFactsOfNode(context, current);
+  if (Object.keys(typeParameterFacts).length > 0) {
+    fields.__typeParameterFacts = typeParameterFacts;
   }
-  if (current.type === "ReturnStatement") {
-    const returnTypeTexts = returnTypeTextsOfNearestFunction(context, current);
-    if (returnTypeTexts.length > 0) {
-      fields.__returnTypeTexts = returnTypeTexts;
-    }
-    if (returnAwaitRequiresAwait(context, current)) {
-      fields.__returnAwaitRequiresAwait = true;
-    }
-  }
-  if (isFunctionLike(current)) {
-    const returnTypeTexts = returnTypeTextsOfFunction(context, current);
-    if (returnTypeTexts.length > 0) {
-      fields.__returnTypeTexts = returnTypeTexts;
-    }
-    const nearestClass = nearestClassAncestor(context, current);
-    const className = nearestClass?.id?.name;
-    if (typeof className === "string" && className.length > 0) {
-      fields.__nearestClassName = className;
-    }
-  }
-  if (current.type === "ArrowFunctionExpression" && current.body?.type !== "BlockStatement") {
-    const returnTypeTexts = returnTypeTextsOfFunction(context, current);
-    if (returnTypeTexts.length > 0) {
-      fields.__returnTypeTexts = returnTypeTexts;
-    }
+  const returnTypeFacts = returnTypeFactsOfNode(context, current);
+  if (Object.keys(returnTypeFacts).length > 0) {
+    fields.__returnTypeFacts = returnTypeFacts;
   }
 }
 
-function expectedArgumentTypeTextsOfCall(
+function callFactsOfNode(context: ContextWithParserOptions, node: any): Record<string, unknown> {
+  const facts: Record<string, unknown> = {};
+  const calleeName = identifierName(stripChainExpression(node.callee));
+  if (calleeName) {
+    facts.calleeName = calleeName;
+  }
+  const signatureFacts = callSignatureFactsOfNode(context, node);
+  if (signatureFacts.expectedArgumentTypeTexts?.length) {
+    facts.expectedArgumentTypeTexts = signatureFacts.expectedArgumentTypeTexts;
+  }
+  if (signatureFacts.explicitTypeArgumentsRequired !== undefined) {
+    facts.explicitTypeArgumentsRequired = signatureFacts.explicitTypeArgumentsRequired;
+  }
+  const typeArgumentFacts = typeArgumentFactsOfCall(node, signatureFacts);
+  for (const [key, value] of Object.entries(typeArgumentFacts)) {
+    facts[key] = value;
+  }
+  return facts;
+}
+
+function symbolFactsOfNode(context: ContextWithParserOptions, node: any): Record<string, unknown> {
+  if (node.type !== "Identifier" && node.type !== "MemberExpression") {
+    return {};
+  }
+  const target = node.type === "MemberExpression" ? node.property : node;
+  if (target?.type !== "Identifier") {
+    return {};
+  }
+  const symbol = checkerFor(context).getSymbolAtLocation(target);
+  const declarations = symbol?.declarations?.filter(
+    (declaration): declaration is string => typeof declaration === "string",
+  );
+  if (!declarations || declarations.length === 0) {
+    return {};
+  }
+  return {
+    declarations,
+    filename: context.filename,
+    cwd: context.cwd,
+    sourceText: context.sourceCode.text,
+  };
+}
+
+function typeParameterFactsOfNode(
   context: ContextWithParserOptions,
   node: any,
-): readonly (readonly string[])[] {
+): Record<string, unknown> {
+  if (node.type !== "TSTypeParameterDeclaration") {
+    return {};
+  }
+  const params = Array.isArray(node.params) ? node.params : [];
+  if (params.length !== 1) {
+    return {};
+  }
+  const name = typeParameterName(params[0]);
+  if (!name) {
+    return {};
+  }
+  return {
+    name,
+    ownerText: node.parent
+      ? context.sourceCode.getText(node.parent)
+      : context.sourceCode.getText(node),
+  };
+}
+
+function returnTypeFactsOfNode(
+  context: ContextWithParserOptions,
+  node: any,
+): Record<string, unknown> {
+  const returnTypeTexts =
+    node.type === "ReturnStatement"
+      ? returnTypeTextsOfNearestFunction(context, node)
+      : isFunctionLike(node) || node.type === "ArrowFunctionExpression"
+        ? returnTypeTextsOfFunction(context, node)
+        : [];
+  return returnTypeTexts.length > 0 ? { texts: returnTypeTexts } : {};
+}
+
+function ancestorFacts(
+  context: ContextWithParserOptions,
+  node: any,
+): readonly Record<string, unknown>[] {
+  const ancestors = (context.sourceCode as any)?.getAncestors?.(node) ?? [];
+  return ancestors
+    .filter((ancestor: any) => typeof ancestor?.type === "string")
+    .map((ancestor: any) => {
+      const fact: Record<string, unknown> = { kind: ancestor.type };
+      if (isRange(ancestor.range)) {
+        fact.start = ancestor.range[0];
+        fact.end = ancestor.range[1];
+      }
+      if (typeof ancestor.async === "boolean") {
+        fact.async = ancestor.async;
+      }
+      const className = ancestor.id?.name;
+      if (
+        (ancestor.type === "ClassDeclaration" || ancestor.type === "ClassExpression") &&
+        typeof className === "string" &&
+        className.length > 0
+      ) {
+        fact.className = className;
+      }
+      if (isFunctionLike(ancestor)) {
+        const paramNames = Array.isArray(ancestor.params)
+          ? ancestor.params
+              .map(identifierName)
+              .filter((name: string | undefined): name is string => name !== undefined)
+          : [];
+        if (paramNames.length > 0) {
+          fact.paramNames = paramNames;
+        }
+        if (ancestor.parent?.type) {
+          fact.parentKind = ancestor.parent.type;
+        }
+        const parentCalleeName = identifierName(stripChainExpression(ancestor.parent?.callee));
+        if (parentCalleeName) {
+          fact.parentCalleeName = parentCalleeName;
+        }
+        if (ancestor.parent?.parent?.type) {
+          fact.parentParentKind = ancestor.parent.parent.type;
+        }
+        const parentParentCalleeName = identifierName(
+          stripChainExpression(ancestor.parent?.parent?.callee),
+        );
+        if (parentParentCalleeName) {
+          fact.parentParentCalleeName = parentParentCalleeName;
+        }
+      }
+      return fact;
+    });
+}
+
+function callSignatureFactsOfNode(
+  context: ContextWithParserOptions,
+  node: any,
+): CorsaCallSignatureFacts {
   const callee = stripChainExpression(node.callee);
   if (!callee) {
-    return [];
+    return {};
   }
   const calleeType = typeAtNode(context, callee);
   if (!calleeType) {
-    return [];
-  }
-  const signature = signatureForCall(context, node, calleeType);
-  const parameters = signatureParameters(signature);
-  if (parameters.length === 0) {
-    return [];
+    return {};
   }
   const args = Array.isArray(node.arguments) ? node.arguments : [];
-  return args.map((_arg: unknown, index: number) => {
-    const parameterId = parameters[Math.min(index, parameters.length - 1)];
-    return parameterId ? parameterTypeTexts(context, parameterId) : [];
-  });
-}
-
-function hasUnnecessaryExplicitTypeArguments(
-  context: ContextWithParserOptions,
-  node: any,
-): boolean {
-  const explicitTypeArguments = typeArgumentNodes(node);
-  if (explicitTypeArguments.length === 0) {
-    return false;
-  }
-  const callee = stripChainExpression(node.callee);
-  const calleeType = callee ? typeAtNode(context, callee) : undefined;
-  const signature = calleeType ? signatureForCall(context, node, calleeType) : undefined;
-  const defaultTypeArguments = signature
-    ? defaultTypeArgumentTextsForSignature(context, signature)
-    : [];
-  if (defaultTypeArguments.length === 0) {
-    return false;
-  }
-  return explicitTypeArguments.every((typeArgument, index) => {
-    const defaultTypeArgument = defaultTypeArguments[index];
-    if (!defaultTypeArgument) {
-      return false;
-    }
-    const explicit = normalizeTypeText(context.sourceCode.getText(typeArgument));
-    return normalizeTypeText(defaultTypeArgument) === explicit;
-  });
+  const explicitTypeArguments = typeArgumentNodes(node)
+    .map((typeArgument) => context.sourceCode.getText(typeArgument))
+    .filter((text: string): text is string => text.length > 0);
+  return checkerFor(context).getCallSignatureFacts(
+    calleeType,
+    node.type === "NewExpression" ? 1 : 0,
+    args.map((arg: unknown) => typeTextsAtNode(context, arg as never)),
+    explicitTypeArguments,
+  );
 }
 
 function typeArgumentNodes(node: any): readonly any[] {
@@ -448,290 +514,65 @@ function typeArgumentNodes(node: any): readonly any[] {
   return candidates.find(Array.isArray) ?? [];
 }
 
-function signatureForCall(
-  context: ContextWithParserOptions,
+function typeArgumentFactsOfCall(
   node: any,
-  calleeType: CorsaType,
-): CorsaSignature | undefined {
-  const checker = checkerFor(context);
-  const signatures = checker.getSignaturesOfType(calleeType, node.type === "NewExpression" ? 1 : 0);
-  if (signatures.length <= 1) {
-    return signatures[0];
+  signatureFacts: CorsaCallSignatureFacts,
+): Record<string, unknown> {
+  const typeArguments = typeArgumentNodes(node);
+  if (typeArguments.length === 0) {
+    return {};
   }
-  const args = Array.isArray(node.arguments) ? node.arguments : [];
-  return signatures
-    .map((signature) => ({
-      signature,
-      score: scoreSignatureForArguments(context, signature, args),
-    }))
-    .sort((left, right) => right.score - left.score)[0]?.signature;
-}
-
-function scoreSignatureForArguments(
-  context: ContextWithParserOptions,
-  signature: CorsaSignature,
-  args: readonly any[],
-): number {
-  const parameterTypes = signatureParameters(signature).map((parameterId) =>
-    parameterTypeTexts(context, parameterId),
-  );
-  let score = -Math.abs(args.length - parameterTypes.length);
-  for (const [index, arg] of args.entries()) {
-    const expected = parameterTypes[Math.min(index, parameterTypes.length - 1)] ?? [];
-    const actual = typeTextsAtNode(context, arg);
-    if (expected.length === 0) {
-      score -= 2;
-    } else if (isPermissiveTypeTexts(expected)) {
-      score += 1;
-    } else if (typeTextsOverlap(actual, expected)) {
-      score += 4;
-    } else {
-      score -= 1;
+  const facts: Record<string, unknown> = {
+    typeArgumentRanges: typeArguments
+      .map((typeArgument) => rangeObject(typeArgument.range))
+      .filter((range): range is { start: number; end: number } => range !== undefined),
+  };
+  const listRange = typeArgumentListRange(node, typeArguments);
+  if (listRange) {
+    facts.typeArgumentListRange = listRange;
+  }
+  const parameterCount =
+    signatureFacts.signature?.typeParameters?.length ??
+    signatureFacts.signature?.typeParameterDefaultTexts?.length ??
+    0;
+  if (parameterCount > 0) {
+    facts.typeParameterCount = parameterCount;
+  }
+  const defaultTexts = signatureFacts.signature?.typeParameterDefaultTexts ?? [];
+  const lastIndex = typeArguments.length - 1;
+  const lastDefaultText = defaultTexts[lastIndex];
+  if (lastDefaultText !== undefined) {
+    const hasDefault = lastDefaultText.trim().length > 0;
+    facts.lastTypeParameterHasDefault = hasDefault;
+    if (hasDefault && signatureFacts.explicitTypeArgumentsRequired === false) {
+      facts.lastTypeArgumentEqualsDefault = true;
+      facts.lastTypeArgumentSameTypeFlagsAsDefault = true;
+      facts.lastTypeArgumentIdenticalToDefault = true;
     }
   }
-  return score;
+  return facts;
 }
 
-function signatureParameters(signature: CorsaSignature | undefined): readonly string[] {
-  return Array.isArray(signature?.parameters) ? signature.parameters : [];
-}
-
-function parameterTypeTexts(
-  context: ContextWithParserOptions,
-  parameterId: string,
-): readonly string[] {
-  const checker = checkerFor(context);
-  const parameterSymbol = checker.getSymbol(parameterId);
-  const declaration = parameterSymbol ? declarationForSymbol(checker, parameterSymbol) : undefined;
-  const parameterType =
-    (parameterSymbol && declaration
-      ? checker.getTypeOfSymbolAtLocation(parameterSymbol, declaration)
-      : undefined) ??
-    (parameterSymbol ? checker.getTypeOfSymbol(parameterSymbol) : undefined) ??
-    (parameterSymbol ? checker.getDeclaredTypeOfSymbol(parameterSymbol) : undefined) ??
-    checker.getTypeOfSymbolById(parameterId) ??
-    checker.getDeclaredTypeOfSymbolById(parameterId);
-  return parameterType ? renderTypeTexts(context, parameterType) : [];
-}
-
-function declarationForSymbol(
-  checker: CorsaTypeCheckerShape,
-  symbol: CorsaSymbol,
-): CorsaNode | undefined {
-  const valueDeclaration = symbol.valueDeclaration;
-  const firstDeclaration = symbol.declarations?.[0];
-  return (
-    (valueDeclaration ? checker.getNode(valueDeclaration) : undefined) ??
-    (firstDeclaration ? checker.getNode(firstDeclaration) : undefined)
-  );
-}
-
-function typeTextsOverlap(actual: readonly string[], expected: readonly string[]): boolean {
-  const normalizedExpected = expected.map(normalizeTypeText);
-  return actual.some((actualText) => {
-    const normalizedActual = normalizeTypeText(actualText);
-    return normalizedExpected.some(
-      (expectedText) =>
-        expectedText === normalizedActual ||
-        expectedText.includes(normalizedActual) ||
-        normalizedActual.includes(expectedText),
-    );
-  });
-}
-
-function defaultTypeArgumentTextsForSignature(
-  context: ContextWithParserOptions,
-  signature: CorsaSignature,
-): readonly string[] {
-  const declarationText = declarationTextForHandle(context, signature.declaration);
-  if (!declarationText) {
-    return [];
+function typeArgumentListRange(
+  node: any,
+  typeArguments: readonly any[],
+): { start: number; end: number } | undefined {
+  const candidates = [node.typeArguments, node.typeParameters, node.typeParameterInstantiation];
+  const list = candidates.find((candidate) => Array.isArray(candidate?.params));
+  const fromList = rangeObject(list?.range);
+  if (fromList) {
+    return fromList;
   }
-  return typeParameterDefaultTexts(declarationText);
-}
-
-function declarationTextForHandle(
-  context: ContextWithParserOptions,
-  handleText: string | undefined,
-): string | undefined {
-  if (!handleText) {
+  const first = rangeObject(typeArguments[0]?.range);
+  const last = rangeObject(typeArguments[typeArguments.length - 1]?.range);
+  if (!first || !last || first.start <= 0) {
     return undefined;
   }
-  const handle = parseNodeHandle(handleText);
-  if (!handle) {
-    return undefined;
-  }
-  const sourceText = sourceTextForPath(context, handle.path);
-  if (!sourceText || handle.pos < 0 || handle.end > sourceText.length || handle.pos >= handle.end) {
-    return undefined;
-  }
-  return sourceText.slice(handle.pos, handle.end);
+  return { start: first.start - 1, end: last.end + 1 };
 }
 
-function typeParameterDefaultTexts(declarationText: string): readonly string[] {
-  const parametersText = firstDelimitedText(declarationText, "<", ">");
-  if (!parametersText) {
-    return [];
-  }
-  return splitTopLevel(parametersText, ",").map((parameterText) => {
-    const defaultStart = topLevelIndexOf(parameterText, "=");
-    return defaultStart >= 0 ? parameterText.slice(defaultStart + 1).trim() : "";
-  });
-}
-
-function firstDelimitedText(text: string, open: string, close: string): string | undefined {
-  const start = text.indexOf(open);
-  if (start < 0) {
-    return undefined;
-  }
-  let depth = 0;
-  for (let index = start; index < text.length; index += 1) {
-    const char = text[index];
-    if (char === open) {
-      depth += 1;
-    } else if (char === close) {
-      depth -= 1;
-      if (depth === 0) {
-        return text.slice(start + 1, index);
-      }
-    }
-  }
-  return undefined;
-}
-
-function splitTopLevel(text: string, delimiter: string): readonly string[] {
-  const parts: string[] = [];
-  let start = 0;
-  let angleDepth = 0;
-  let parenDepth = 0;
-  let bracketDepth = 0;
-  let braceDepth = 0;
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
-    if (char === "<") angleDepth += 1;
-    else if (char === ">") angleDepth = Math.max(0, angleDepth - 1);
-    else if (char === "(") parenDepth += 1;
-    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
-    else if (char === "[") bracketDepth += 1;
-    else if (char === "]") bracketDepth = Math.max(0, bracketDepth - 1);
-    else if (char === "{") braceDepth += 1;
-    else if (char === "}") braceDepth = Math.max(0, braceDepth - 1);
-    else if (
-      char === delimiter &&
-      angleDepth === 0 &&
-      parenDepth === 0 &&
-      bracketDepth === 0 &&
-      braceDepth === 0
-    ) {
-      parts.push(text.slice(start, index).trim());
-      start = index + 1;
-    }
-  }
-  parts.push(text.slice(start).trim());
-  return parts;
-}
-
-function topLevelIndexOf(text: string, needle: string): number {
-  let angleDepth = 0;
-  let parenDepth = 0;
-  let bracketDepth = 0;
-  let braceDepth = 0;
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
-    if (char === "<") angleDepth += 1;
-    else if (char === ">") angleDepth = Math.max(0, angleDepth - 1);
-    else if (char === "(") parenDepth += 1;
-    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
-    else if (char === "[") bracketDepth += 1;
-    else if (char === "]") bracketDepth = Math.max(0, bracketDepth - 1);
-    else if (char === "{") braceDepth += 1;
-    else if (char === "}") braceDepth = Math.max(0, braceDepth - 1);
-    else if (
-      char === needle &&
-      angleDepth === 0 &&
-      parenDepth === 0 &&
-      bracketDepth === 0 &&
-      braceDepth === 0
-    ) {
-      return index;
-    }
-  }
-  return -1;
-}
-
-function isDeprecatedSymbolUse(context: ContextWithParserOptions, node: any): boolean {
-  const target = node.type === "MemberExpression" ? node.property : node;
-  if (target?.type !== "Identifier") {
-    return false;
-  }
-  const symbol = checkerFor(context).getSymbolAtLocation(target);
-  return (
-    symbol?.declarations?.some((declaration) =>
-      declarationHasDeprecatedJSDoc(context, declaration),
-    ) === true
-  );
-}
-
-function declarationHasDeprecatedJSDoc(
-  context: ContextWithParserOptions,
-  declaration: string,
-): boolean {
-  const handle = parseNodeHandle(declaration);
-  if (!handle) {
-    return false;
-  }
-  const sourceText = sourceTextForPath(context, handle.path);
-  if (!sourceText) {
-    return false;
-  }
-  const pos = handle.pos;
-  if (!Number.isFinite(pos)) {
-    return false;
-  }
-  return sourceText.slice(Math.max(0, pos - 500), pos).includes("@deprecated");
-}
-
-function parseNodeHandle(
-  value: string,
-): { readonly pos: number; readonly end: number; readonly path: string } | undefined {
-  const [posText, endText, _kindText, ...pathParts] = value.split(".");
-  const pos = Number(posText);
-  const end = Number(endText);
-  if (!Number.isFinite(pos) || !Number.isFinite(end)) {
-    return undefined;
-  }
-  return { pos, end, path: pathParts.join(".") };
-}
-
-function sourceTextForPath(context: ContextWithParserOptions, path: string): string | undefined {
-  if (!path || path === context.filename || context.filename.endsWith(path)) {
-    return context.sourceCode.text;
-  }
-  try {
-    return readFileSync(path, "utf8");
-  } catch {
-    try {
-      return readFileSync(`${context.cwd}/${path}`, "utf8");
-    } catch {
-      return undefined;
-    }
-  }
-}
-
-function hasSingleUseTypeParameter(context: ContextWithParserOptions, node: any): boolean {
-  const params = Array.isArray(node.params) ? node.params : [];
-  if (params.length !== 1) {
-    return false;
-  }
-  const name = typeParameterName(params[0]);
-  if (!name) {
-    return false;
-  }
-  const ownerText = node.parent
-    ? context.sourceCode.getText(node.parent)
-    : context.sourceCode.getText(node);
-  const matches = ownerText.match(new RegExp(`\\b${escapeRegExp(name)}\\b`, "g")) ?? [];
-  return matches.length <= 2;
+function rangeObject(range: unknown): { start: number; end: number } | undefined {
+  return isRange(range) ? { start: range[0], end: range[1] } : undefined;
 }
 
 function typeParameterName(node: any): string | undefined {
@@ -742,14 +583,6 @@ function typeParameterName(node: any): string | undefined {
     return node.name.name;
   }
   return undefined;
-}
-
-function normalizeTypeText(text: string): string {
-  return text.replace(/\s+/g, "");
-}
-
-function escapeRegExp(text: string): string {
-  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function renderTypeTexts(context: ContextWithParserOptions, type: CorsaType): readonly string[] {
@@ -763,58 +596,9 @@ function renderTypeTexts(context: ContextWithParserOptions, type: CorsaType): re
   return [...texts];
 }
 
-function isPromiseExecutorRejectCall(context: ContextWithParserOptions, node: any): boolean {
-  const callee = stripChainExpression(node.callee);
-  if (callee?.type !== "Identifier") {
-    return false;
-  }
-  const nearestFunction = nearestFunctionAncestor(context, node);
-  const rejectParam = nearestFunction?.params?.[1];
-  if (!rejectParam || rejectParam.type !== "Identifier" || rejectParam.name !== callee.name) {
-    return false;
-  }
-  const promiseConstructor = stripChainExpression(nearestFunction.parent?.parent);
-  return (
-    (nearestFunction.parent?.type === "NewExpression" &&
-      isIdentifierNamed(nearestFunction.parent.callee, "Promise")) ||
-    (promiseConstructor?.type === "NewExpression" &&
-      isIdentifierNamed(promiseConstructor.callee, "Promise"))
-  );
-}
-
-function returnAwaitRequiresAwait(context: ContextWithParserOptions, node: any): boolean {
-  const ancestors = (context.sourceCode as any)?.getAncestors?.(node) ?? [];
-  return ancestors.some(
-    (ancestor: any) =>
-      ancestor.type === "TryStatement" &&
-      (rangeContains(ancestor.block, node) ||
-        rangeContains(ancestor.handler?.body, node) ||
-        rangeContains(ancestor.finalizer, node)),
-  );
-}
-
-function rangeContains(container: any, node: any): boolean {
-  return (
-    isRange(container?.range) &&
-    isRange(node?.range) &&
-    container.range[0] <= node.range[0] &&
-    node.range[1] <= container.range[1]
-  );
-}
-
 function nearestFunctionAncestor(context: ContextWithParserOptions, node: any): any {
   const ancestors = (context.sourceCode as any)?.getAncestors?.(node) ?? [];
   return [...ancestors].reverse().find((ancestor: any) => ancestor.type?.includes("Function"));
-}
-
-function nearestClassAncestor(context: ContextWithParserOptions, node: any): any {
-  const ancestors = (context.sourceCode as any)?.getAncestors?.(node) ?? [];
-  return [...ancestors]
-    .reverse()
-    .find(
-      (ancestor: any) =>
-        ancestor.type === "ClassDeclaration" || ancestor.type === "ClassExpression",
-    );
 }
 
 function isFunctionLike(node: any): boolean {
@@ -868,10 +652,6 @@ function isPermissiveTypeText(text: string): boolean {
   return text === "any" || text === "unknown" || text === "never";
 }
 
-function isPermissiveTypeTexts(texts: readonly string[]): boolean {
-  return texts.some((text) => isPermissiveTypeText(normalizeTypeText(text)));
-}
-
 function stripChainExpression(node: any): any {
   let current = node;
   while (current?.type === "ChainExpression") {
@@ -880,9 +660,11 @@ function stripChainExpression(node: any): any {
   return current;
 }
 
-function isIdentifierNamed(node: any, name: string): boolean {
+function identifierName(node: any): string | undefined {
   const current = stripChainExpression(node);
-  return current?.type === "Identifier" && current.name === name;
+  return current?.type === "Identifier" && typeof current.name === "string"
+    ? current.name
+    : undefined;
 }
 
 function isNativeChildNode(value: unknown): value is RangedNode {

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
@@ -99,13 +99,7 @@ describe("CorsaProjectSession", () => {
     }
   });
 
-  // Regression for GH#206: upstream Corsa occasionally drops a type handle
-  // from its snapshot registry after a base-types query on a class with no
-  // explicit `extends` clause, which then makes a follow-up
-  // `getImplementedTypesOfType` on the same handle throw "type handle ...
-  // not found in snapshot registry". The wrapper should treat that as "no
-  // base types" so the caller can still see the type's own `implements`.
-  it("treats a 'handle not found in snapshot registry' error from getBaseTypes as no bases", () => {
+  it("uses the client-normalized base-types result", () => {
     clients.length = 0;
     const runtime = {
       executable: "/tmp/corsa",
@@ -128,11 +122,7 @@ describe("CorsaProjectSession", () => {
     if (!client) {
       throw new Error("expected a fake client");
     }
-    client.callJson.mockImplementationOnce(() => {
-      throw new Error(
-        'protocol error: api: client error: type handle "t0000000000000057" not found in snapshot registry',
-      );
-    });
+    client.callJson.mockImplementationOnce(() => [] as never);
 
     const result = session.getBaseTypes({
       id: "type-1",
@@ -179,12 +169,7 @@ describe("CorsaProjectSession", () => {
     ).toThrow(/unexpected failure/);
   });
 
-  // Regression for GH#211 crash site 1: implemented-interface handles have
-  // empty `texts`, and upstream Corsa sometimes evicts the handle from its
-  // snapshot registry before typeToString runs. The checker warms the cache
-  // with the `implements` identifier via rememberTypeText, so typeToString
-  // should return that name instead of rethrowing the stale-handle error.
-  it("returns a remembered type text when typeToString hits a stale handle", () => {
+  it("returns a server-rendered cached type text when typeToString later hits a stale handle", () => {
     clients.length = 0;
     const runtime = {
       executable: "/tmp/corsa",
@@ -209,7 +194,8 @@ describe("CorsaProjectSession", () => {
     }
 
     const type = { id: "type-7", flags: 0, texts: [] as string[] };
-    session.rememberTypeText(type.id, "Serializable");
+    client.typeToString.mockReturnValueOnce("Serializable");
+    expect(session.typeToString(type as never)).toBe("Serializable");
     client.typeToString.mockImplementationOnce(() => {
       throw new Error(
         'protocol error: api: client error: type handle "type-7" not found in snapshot registry',

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -3,6 +3,7 @@ import { readFileSync, statSync } from "node:fs";
 import { type ProjectResponse, CorsaApiClient } from "@corsa-bind/napi";
 
 import type {
+  CorsaCallSignatureFacts,
   CorsaNode,
   CorsaSignature,
   CorsaSymbol,
@@ -38,11 +39,6 @@ type TypeLookup = {
   sourceText?: string;
 };
 
-type ParameterInfo = {
-  name: string;
-  node: CorsaNode;
-};
-
 const typeFlags = {
   object: 1 << 20,
   index: 1 << 21,
@@ -68,7 +64,6 @@ export class CorsaProjectSession {
   #projects: ProjectResponse[] = [];
   #files = new Map<string, FileCache>();
   #symbolsById = new Map<string, CorsaSymbol>();
-  #syntheticSymbolsById = new Map<string, CorsaSymbol>();
   #symbolTypeById = new Map<string, string>();
   #nodesById = new Map<string, CorsaNode>();
   #typeLookupById = new Map<string, TypeLookup>();
@@ -182,10 +177,6 @@ export class CorsaProjectSession {
     if (typeof symbol !== "string") {
       return this.rememberSymbol(symbol);
     }
-    const synthetic = this.#syntheticSymbolsById.get(symbol);
-    if (synthetic) {
-      return synthetic;
-    }
     const cached = this.#symbolsById.get(symbol);
     if (cached) {
       return cached;
@@ -266,18 +257,6 @@ export class CorsaProjectSession {
     }
   }
 
-  // Seeds the type-text cache from a name the caller already knows (for
-  // example the identifier in an `implements` clause). Implemented-interface
-  // handles come back with empty `texts`, and upstream Corsa sometimes evicts
-  // them from its snapshot registry before `typeToString` runs, so warming the
-  // cache here lets `typeToString` fall back to the source name instead of
-  // throwing (GH#211). Never overwrites a value the server already provided.
-  rememberTypeText(typeId: string, text: string): void {
-    if (!this.#typeTextById.has(typeId)) {
-      this.#typeTextById.set(typeId, text);
-    }
-  }
-
   getBaseTypeOfLiteralType(type: CorsaType): CorsaType | undefined {
     return this.rememberType(
       this.client().callJson("getBaseTypeOfLiteralType", {
@@ -299,14 +278,38 @@ export class CorsaProjectSession {
   }
 
   getSignaturesOfType(type: CorsaType, kind: number): readonly CorsaSignature[] {
+    const source = this.sourceContextForType(type);
     return this.rememberSignatures(
       this.client().callJson("getSignaturesOfType", {
         snapshot: this.#snapshot,
         project: this.projectId(),
         type: type.id,
         kind,
+        ...source,
       }) ?? [],
     );
+  }
+
+  getCallSignatureFacts(
+    type: CorsaType,
+    kind: number,
+    argumentTypeTexts: readonly (readonly string[])[],
+    explicitTypeArgumentTexts: readonly string[],
+  ): CorsaCallSignatureFacts {
+    const source = this.sourceContextForType(type);
+    const facts = this.client().callJson<CorsaCallSignatureFacts>("getCallSignatureFacts", {
+      snapshot: this.#snapshot,
+      project: this.projectId(),
+      type: type.id,
+      kind,
+      ...source,
+      argumentTypeTexts,
+      explicitTypeArgumentTexts,
+    });
+    if (facts?.signature) {
+      this.rememberSignature(facts.signature);
+    }
+    return facts ?? {};
   }
 
   getReturnTypeOfSignature(signature: CorsaSignature): CorsaType | undefined {
@@ -338,26 +341,14 @@ export class CorsaProjectSession {
     if (isArrayOrTupleLikeType(this, type)) {
       return [];
     }
-    try {
-      return this.rememberTypes(
-        this.client().callJson("getBaseTypes", {
-          snapshot: this.#snapshot,
-          project: this.projectId(),
-          type: type.id,
-          texts: this.typeTexts(type),
-        }) ?? [],
-      );
-    } catch (error) {
-      // Upstream Corsa occasionally drops a type handle from its snapshot
-      // registry after the first base-types query on a class that has no
-      // explicit `extends` clause. Treating that as "no base types" lets a
-      // follow-up `getImplementedTypesOfType` on the same handle still report
-      // the type's own `implements` clause instead of throwing (GH#206).
-      if (isProtocolPanicError(error) || isStaleHandleError(error)) {
-        return [];
-      }
-      throw error;
-    }
+    return this.rememberTypes(
+      this.client().callJson("getBaseTypes", {
+        snapshot: this.#snapshot,
+        project: this.projectId(),
+        type: type.id,
+        texts: this.typeTexts(type),
+      }) ?? [],
+    );
   }
 
   getTypeArguments(type: CorsaType): readonly CorsaType[] {
@@ -604,15 +595,25 @@ export class CorsaProjectSession {
     return cached === undefined ? [] : [cached];
   }
 
+  private sourceContextForType(type: CorsaType): { file?: string; sourceText?: string } {
+    const lookup = this.#typeLookupById.get(type.id);
+    if (lookup) {
+      const sourceText = lookup.sourceText ?? this.sourceTextForPath(lookup.fileName);
+      return sourceText ? { file: lookup.fileName, sourceText } : {};
+    }
+    const source = this.#typeSourceById.get(type.id);
+    if (source) {
+      const sourceText = this.sourceTextForPath(source.node.fileName);
+      return sourceText ? { file: source.node.fileName, sourceText } : {};
+    }
+    return {};
+  }
+
   private rememberSymbol<T extends CorsaSymbol | undefined>(symbol: T): T {
     if (!symbol) {
       return symbol;
     }
     this.#snapshotHasIssuedHandles = true;
-    const synthetic = this.#syntheticSymbolsById.get(symbol.id);
-    if (synthetic) {
-      return synthetic as T;
-    }
     this.#symbolsById.set(symbol.id, symbol);
     for (const declaration of symbol.declarations ?? []) {
       this.rememberNode(declaration);
@@ -645,43 +646,13 @@ export class CorsaProjectSession {
     if (signature.declaration) {
       this.rememberNode(signature.declaration);
     }
-    const parameterIds = Array.isArray(signature.parameters) ? signature.parameters : [];
-    const parameters = signature.declaration
-      ? this.parameterInfosForDeclaration(signature.declaration, parameterIds.length)
-      : [];
-    parameterIds.forEach((id, index) => {
-      this.rememberSyntheticSymbol(id, parameters[index]);
-    });
-    if (signature.thisParameter) {
-      this.rememberSyntheticSymbol(signature.thisParameter, undefined, "this");
+    for (const symbol of signature.parameterSymbols ?? []) {
+      this.rememberSymbol(symbol);
+    }
+    if (signature.thisParameterSymbol) {
+      this.rememberSymbol(signature.thisParameterSymbol);
     }
     return signature;
-  }
-
-  private rememberSyntheticSymbol(
-    id: string,
-    parameter?: ParameterInfo,
-    fallbackName = "",
-  ): CorsaSymbol {
-    const cached = this.#syntheticSymbolsById.get(id);
-    if (cached && (cached.name || !parameter?.name)) {
-      return cached;
-    }
-    const declaration = parameter?.node.id;
-    const symbol: CorsaSymbol = {
-      id,
-      name: parameter?.name ?? fallbackName,
-      flags: cached?.flags ?? 0,
-      checkFlags: cached?.checkFlags ?? 0,
-      declarations: declaration ? [declaration] : (cached?.declarations ?? []),
-      valueDeclaration: declaration ?? cached?.valueDeclaration,
-    };
-    this.#syntheticSymbolsById.set(id, symbol);
-    this.#symbolsById.set(id, symbol);
-    if (declaration) {
-      this.#nodesById.set(declaration, parameter.node);
-    }
-    return symbol;
   }
 
   private rememberNode(handle: string): CorsaNode | undefined {
@@ -695,7 +666,6 @@ export class CorsaProjectSession {
 
   private clearHandleCaches(): void {
     this.#symbolsById.clear();
-    this.#syntheticSymbolsById.clear();
     this.#symbolTypeById.clear();
     this.#nodesById.clear();
     this.#typeLookupById.clear();
@@ -703,50 +673,18 @@ export class CorsaProjectSession {
     this.#snapshotHasIssuedHandles = false;
   }
 
-  private parameterInfosForDeclaration(
-    handle: string,
-    expectedCount: number,
-  ): readonly ParameterInfo[] {
-    const source = this.sourceSliceForHandle(handle);
-    if (!source) {
-      return this.parameterInfosForUtf8ByteDeclaration(handle);
-    }
-    const parameters = parameterInfosForSource(source);
-    if (parameters.length >= expectedCount || expectedCount === 0) {
-      return parameters;
-    }
-    const utf8Parameters = this.parameterInfosForUtf8ByteDeclaration(handle);
-    return utf8Parameters.length > parameters.length ? utf8Parameters : parameters;
-  }
-
-  private parameterInfosForUtf8ByteDeclaration(handle: string): readonly ParameterInfo[] {
-    const source = this.sourceSliceForHandle(handle, "utf8-byte");
-    return source ? parameterInfosForSource(source) : [];
-  }
-
-  private sourceSliceForHandle(
-    handle: string,
-    offsetUnit: "utf16" | "utf8-byte" = "utf16",
-  ): SourceSlice | undefined {
+  private sourceSliceForHandle(handle: string): SourceSlice | undefined {
     const node = this.getNode(handle);
     if (!node) {
       return undefined;
     }
     const sourceText = this.sourceTextForPath(node.fileName);
-    const normalizedNode =
-      offsetUnit === "utf8-byte" ? nodeFromUtf8ByteOffsets(node, sourceText) : node;
-    if (
-      !sourceText ||
-      !normalizedNode ||
-      normalizedNode.pos < 0 ||
-      normalizedNode.end > sourceText.length ||
-      normalizedNode.pos >= normalizedNode.end
-    ) {
+    if (!sourceText || node.pos < 0 || node.end > sourceText.length || node.pos >= node.end) {
       return undefined;
     }
     return {
-      node: normalizedNode,
-      text: sourceText.slice(normalizedNode.pos, normalizedNode.end),
+      node,
+      text: sourceText.slice(node.pos, node.end),
     };
   }
 
@@ -916,21 +854,6 @@ export class CorsaProjectSession {
   }
 }
 
-function parameterInfosForSource(source: SourceSlice): readonly ParameterInfo[] {
-  const open = findConstructorParameterOpen(source.text);
-  if (open < 0) {
-    return [];
-  }
-  const close = matchingCloseParen(source.text, open);
-  if (close < 0) {
-    return [];
-  }
-  const parametersText = source.text.slice(open + 1, close);
-  return splitTopLevelRanges(parametersText, ",")
-    .map((range) => parameterInfoForText(source.node, parametersText, range, open + 1))
-    .filter((parameter): parameter is ParameterInfo => parameter !== undefined);
-}
-
 function isArrayOrTupleLikeType(session: CorsaProjectSession, type: CorsaType): boolean {
   const texts =
     Array.isArray(type.texts) && type.texts.length > 0 ? type.texts : [session.typeToString(type)];
@@ -946,19 +869,6 @@ function isUsableSymbol(symbol: CorsaSymbol | null | undefined): symbol is Corsa
   return symbol != null && !symbol.name.includes("\ufffd");
 }
 
-function findConstructorParameterOpen(text: string): number {
-  const constructorPattern = /\bconstructor\s*\(/g;
-  let match: RegExpExecArray | null;
-  let open = -1;
-  while ((match = constructorPattern.exec(text)) !== null) {
-    open = match.index + match[0].lastIndexOf("(");
-  }
-  if (open >= 0) {
-    return open;
-  }
-  return text.indexOf("(");
-}
-
 function overlayTextFor(fileName: string, sourceText?: string): string | undefined {
   if (sourceText === undefined) {
     return undefined;
@@ -968,16 +878,6 @@ function overlayTextFor(fileName: string, sourceText?: string): string | undefin
   } catch {
     return sourceText;
   }
-}
-
-function isProtocolPanicError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes("protocol error: panic:") || message.includes("panic: runtime error");
-}
-
-function isStaleHandleError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return /handle "[^"]*" not found in snapshot registry/.test(message);
 }
 
 function statMtimeMs(fileName: string): number {
@@ -1010,233 +910,6 @@ function parseNodeHandle(value: string): CorsaNode | undefined {
     return undefined;
   }
   return { id: value, fileName, pos, end, range: [pos, end] };
-}
-
-function nodeFromUtf8ByteOffsets(
-  node: CorsaNode,
-  sourceText: string | undefined,
-): CorsaNode | undefined {
-  if (sourceText === undefined) {
-    return undefined;
-  }
-  const pos = utf16IndexFromUtf8ByteOffset(sourceText, node.pos);
-  const end = utf16IndexFromUtf8ByteOffset(sourceText, node.end);
-  if (pos === undefined || end === undefined || end < pos) {
-    return undefined;
-  }
-  return {
-    ...node,
-    pos,
-    end,
-    range: [pos, end],
-  };
-}
-
-function utf16IndexFromUtf8ByteOffset(text: string, byteOffset: number): number | undefined {
-  if (!Number.isInteger(byteOffset) || byteOffset < 0) {
-    return undefined;
-  }
-  let bytes = 0;
-  for (let index = 0; index < text.length; ) {
-    if (bytes === byteOffset) {
-      return index;
-    }
-    const codePoint = text.codePointAt(index);
-    if (codePoint === undefined) {
-      break;
-    }
-    const nextBytes = bytes + utf8ByteLengthOfCodePoint(codePoint);
-    if (nextBytes > byteOffset) {
-      return undefined;
-    }
-    bytes = nextBytes;
-    index += codePoint > 0xffff ? 2 : 1;
-  }
-  return bytes === byteOffset ? text.length : undefined;
-}
-
-function utf8ByteLengthOfCodePoint(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1;
-  }
-  if (codePoint <= 0x7ff) {
-    return 2;
-  }
-  if (codePoint <= 0xffff) {
-    return 3;
-  }
-  return 4;
-}
-
-function parameterInfoForText(
-  declarationNode: CorsaNode,
-  parametersText: string,
-  range: { readonly start: number; readonly end: number },
-  parametersStart: number,
-): ParameterInfo | undefined {
-  const raw = parametersText.slice(range.start, range.end);
-  const leading = raw.search(/\S/);
-  if (leading < 0) {
-    return undefined;
-  }
-  const trailing = raw.match(/\s*$/)?.[0].length ?? 0;
-  const text = raw.slice(leading, raw.length - trailing);
-  const name = parameterNameForText(text);
-  if (!name) {
-    return undefined;
-  }
-  const pos = declarationNode.pos + parametersStart + range.start + leading;
-  const end = declarationNode.pos + parametersStart + range.end - trailing;
-  const id = `${pos}.${end}.0.${declarationNode.fileName}`;
-  return {
-    name,
-    node: {
-      id,
-      fileName: declarationNode.fileName,
-      pos,
-      end,
-      range: [pos, end],
-    },
-  };
-}
-
-function parameterNameForText(text: string): string | undefined {
-  let candidate = text.trim().replace(/^\.\.\.\s*/, "");
-  let changed = true;
-  while (changed) {
-    const previous = candidate;
-    candidate = candidate.replace(
-      /^(?:public|private|protected|readonly|override|static|abstract|declare)\s+/,
-      "",
-    );
-    changed = candidate !== previous;
-  }
-  const separator = firstTopLevelIndexOfAny(candidate, [":", "="]);
-  let left = (separator >= 0 ? candidate.slice(0, separator) : candidate).trim();
-  if (left.endsWith("?")) {
-    left = left.slice(0, -1).trim();
-  }
-  if (left.startsWith("{") || left.startsWith("[")) {
-    return left;
-  }
-  return left.split(/\s+/).at(-1);
-}
-
-function matchingCloseParen(text: string, open: number): number {
-  let depth = 0;
-  const scanner = createScanner();
-  for (let index = open; index < text.length; index += 1) {
-    const char = text[index];
-    if (scanner.inQuote(char)) {
-      continue;
-    }
-    if (char === "(") {
-      depth += 1;
-    } else if (char === ")") {
-      depth -= 1;
-      if (depth === 0) {
-        return index;
-      }
-    }
-  }
-  return -1;
-}
-
-function splitTopLevelRanges(
-  text: string,
-  delimiter: string,
-): readonly { readonly start: number; readonly end: number }[] {
-  const ranges: { start: number; end: number }[] = [];
-  const scanner = createScanner();
-  let start = 0;
-  let angleDepth = 0;
-  let parenDepth = 0;
-  let bracketDepth = 0;
-  let braceDepth = 0;
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
-    if (scanner.inQuote(char)) {
-      continue;
-    }
-    if (char === "<") angleDepth += 1;
-    else if (char === ">") angleDepth = Math.max(0, angleDepth - 1);
-    else if (char === "(") parenDepth += 1;
-    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
-    else if (char === "[") bracketDepth += 1;
-    else if (char === "]") bracketDepth = Math.max(0, bracketDepth - 1);
-    else if (char === "{") braceDepth += 1;
-    else if (char === "}") braceDepth = Math.max(0, braceDepth - 1);
-    else if (
-      char === delimiter &&
-      angleDepth === 0 &&
-      parenDepth === 0 &&
-      bracketDepth === 0 &&
-      braceDepth === 0
-    ) {
-      ranges.push({ start, end: index });
-      start = index + 1;
-    }
-  }
-  ranges.push({ start, end: text.length });
-  return ranges;
-}
-
-function firstTopLevelIndexOfAny(text: string, needles: readonly string[]): number {
-  const scanner = createScanner();
-  let angleDepth = 0;
-  let parenDepth = 0;
-  let bracketDepth = 0;
-  let braceDepth = 0;
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
-    if (scanner.inQuote(char)) {
-      continue;
-    }
-    if (char === "<") angleDepth += 1;
-    else if (char === ">") angleDepth = Math.max(0, angleDepth - 1);
-    else if (char === "(") parenDepth += 1;
-    else if (char === ")") parenDepth = Math.max(0, parenDepth - 1);
-    else if (char === "[") bracketDepth += 1;
-    else if (char === "]") bracketDepth = Math.max(0, bracketDepth - 1);
-    else if (char === "{") braceDepth += 1;
-    else if (char === "}") braceDepth = Math.max(0, braceDepth - 1);
-    else if (
-      needles.includes(char) &&
-      angleDepth === 0 &&
-      parenDepth === 0 &&
-      bracketDepth === 0 &&
-      braceDepth === 0
-    ) {
-      return index;
-    }
-  }
-  return -1;
-}
-
-function createScanner(): {
-  inQuote(char: string): boolean;
-} {
-  let quote: string | undefined;
-  let escaped = false;
-  return {
-    inQuote(char) {
-      if (quote) {
-        if (escaped) {
-          escaped = false;
-        } else if (char === "\\") {
-          escaped = true;
-        } else if (char === quote) {
-          quote = undefined;
-        }
-        return true;
-      }
-      if (char === '"' || char === "'" || char === "`") {
-        quote = char;
-        return true;
-      }
-      return false;
-    },
-  };
 }
 
 function readFileOrUndefined(path: string): string | undefined {

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -195,21 +195,21 @@ export class CorsaProjectSession {
       return undefined;
     }
     const resolved = this.client().getSymbolOfType(this.#snapshot, typeId) as CorsaSymbol | null;
-    return resolved?.id === symbol ? this.rememberSymbol(resolved) : undefined;
+    return resolved?.id === symbol ? this.rememberUsableSymbol(resolved) : undefined;
   }
 
   getSymbolOfType(type: CorsaType): CorsaSymbol | undefined {
     if (type.symbol) {
       const symbol = this.getSymbol(type.symbol);
-      if (symbol) {
+      if (isUsableSymbol(symbol)) {
         return symbol;
       }
     }
     if (!this.#snapshot) {
       return undefined;
     }
-    return this.rememberSymbol(
-      this.client().getSymbolOfType(this.#snapshot, type.id) as CorsaSymbol | undefined,
+    return this.rememberUsableSymbol(
+      this.client().getSymbolOfType(this.#snapshot, type.id) as CorsaSymbol | null,
     );
   }
 
@@ -623,6 +623,10 @@ export class CorsaProjectSession {
     return symbol;
   }
 
+  private rememberUsableSymbol(symbol: CorsaSymbol | null | undefined): CorsaSymbol | undefined {
+    return isUsableSymbol(symbol) ? this.rememberSymbol(symbol) : undefined;
+  }
+
   private rememberSymbols<T extends readonly CorsaSymbol[]>(symbols: T): T {
     for (const symbol of symbols) {
       this.rememberSymbol(symbol);
@@ -936,6 +940,10 @@ function isArrayOrTupleLikeType(session: CorsaProjectSession, type: CorsaType): 
       normalized.startsWith("readonly [") || normalized.startsWith("[") || normalized.endsWith("[]")
     );
   });
+}
+
+function isUsableSymbol(symbol: CorsaSymbol | null | undefined): symbol is CorsaSymbol {
+  return symbol != null && !symbol.name.includes("\ufffd");
 }
 
 function findConstructorParameterOpen(text: string): number {

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -802,7 +802,7 @@ describe("corsa oxlint type locations", () => {
     expect(seen.declarationText).toContain("class Construct");
   });
 
-  integrationCase("resolves constructor parameter symbols from dependency declarations", () => {
+  integrationCase("resolves constructor parameter type texts from dependency declarations", () => {
     const workspace = mkdtempSync(resolve(tmpdir(), "corsa-oxlint-external-symbols-"));
     const depDir = resolve(workspace, "node_modules", "external-dep");
     const srcDir = resolve(workspace, "src");
@@ -913,17 +913,12 @@ describe("corsa oxlint type locations", () => {
     expect(constructType ? checker.typeToString(constructType) : undefined).toBe("typeof Stack");
     const signature = constructType ? checker.getSignaturesOfType(constructType, 1)[0] : undefined;
 
-    expect(signature?.parameters.map((id) => checker.getSymbolById(id)?.name)).toEqual([
-      "scope",
-      "id",
-      "props",
+    expect(signature?.parameters).toHaveLength(3);
+    expect(signature?.parameterTypeTexts).toEqual([
+      ["Construct | undefined"],
+      ["string | undefined"],
+      ["StackProps | undefined"],
     ]);
-    expect(
-      signature?.parameters.map((id) => {
-        const type = checker.getTypeOfSymbolById(id) ?? checker.getDeclaredTypeOfSymbolById(id);
-        return type ? checker.typeToString(type) : undefined;
-      }),
-    ).toEqual(["Construct | undefined", "string | undefined", "StackProps | undefined"]);
   });
 
   integrationCase("resolves the symbol type at a location instead of the node type", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -1157,6 +1157,101 @@ describe("corsa oxlint type locations", () => {
     expect(seen.animal).toBe("Animal");
   });
 
+  integrationCase("does not expose corrupted mapped utility type symbols", () => {
+    const seen: Record<
+      string,
+      | {
+          readonly name: string | undefined;
+          readonly codepoints: readonly number[] | null;
+        }
+      | undefined
+    > = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "mapped-utility-type-symbols",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise mapped utility type symbols",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          PropertyDefinition(node: any) {
+            const keyName = node.key?.name;
+            if (!keyName) {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node);
+            const symbol = type ? checker.getSymbolOfType(type) : undefined;
+            seen[keyName] = {
+              name: symbol?.name,
+              codepoints: symbol ? [...symbol.name].map((char) => char.codePointAt(0) ?? 0) : null,
+            };
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("mapped-utility-type-symbols", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Animal {}",
+            "interface IDog {",
+            "  name: string;",
+            "}",
+            "class Dog extends Animal implements IDog {",
+            '  readonly name: string = "Rex";',
+            "}",
+            "interface Box<T> {",
+            "  value: T;",
+            "}",
+            "class Holder {",
+            "  readonly readonlyDog: Readonly<Dog> = {} as Readonly<Dog>;",
+            "  readonly partialDog: Partial<Dog> = {} as Partial<Dog>;",
+            "  readonly requiredDog: Required<Dog> = {} as Required<Dog>;",
+            "  readonly boxedDog: Box<Dog> = { value: {} as Dog };",
+            "  readonly dogList: Dog[] = [];",
+            "  readonly bareDog: Dog = {} as Dog;",
+            '  readonly text: string = "";',
+            "}",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    for (const key of ["readonlyDog", "partialDog", "requiredDog"] as const) {
+      expect(seen[key]?.codepoints ?? []).not.toContain(0xfffd);
+    }
+    expect([undefined, "Readonly"]).toContain(seen.readonlyDog?.name);
+    expect([undefined, "Partial"]).toContain(seen.partialDog?.name);
+    expect([undefined, "Required"]).toContain(seen.requiredDog?.name);
+    expect(seen.boxedDog?.name).toBe("Box");
+    expect(seen.dogList?.name).toBe("Array");
+    expect(seen.bareDog?.name).toBe("Dog");
+    expect(seen.text?.name).toBeUndefined();
+  });
+
   it("sends linted source text overlay changes when it differs from disk", () => {
     const workspace = mkdtempSync(resolve(tmpdir(), "corsa-oxlint-overlay-"));
     const srcDir = resolve(workspace, "src");

--- a/src/bindings/nodejs/corsa_oxlint/ts/types.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/types.ts
@@ -69,8 +69,19 @@ export interface CorsaSignature {
   readonly declaration?: string;
   readonly typeParameters: readonly string[];
   readonly parameters: readonly string[];
+  readonly parameterSymbols?: readonly CorsaSymbol[];
+  readonly parameterTypeTexts?: readonly (readonly string[])[];
   readonly thisParameter?: string;
+  readonly thisParameterSymbol?: CorsaSymbol;
+  readonly thisParameterTypeTexts?: readonly string[];
   readonly target?: string;
+  readonly typeParameterDefaultTexts?: readonly string[];
+}
+
+export interface CorsaCallSignatureFacts {
+  readonly signature?: CorsaSignature;
+  readonly expectedArgumentTypeTexts?: readonly (readonly string[])[];
+  readonly explicitTypeArgumentsRequired?: boolean;
 }
 
 export enum SignatureKind {
@@ -118,6 +129,12 @@ export interface CorsaTypeCheckerShape {
   getBaseTypeOfLiteralType(type: CorsaType): CorsaType | undefined;
   getPropertiesOfType(type: CorsaType): readonly CorsaSymbol[];
   getSignaturesOfType(type: CorsaType, kind: SignatureKind): readonly CorsaSignature[];
+  getCallSignatureFacts(
+    type: CorsaType,
+    kind: SignatureKind,
+    argumentTypeTexts: readonly (readonly string[])[],
+    explicitTypeArgumentTexts: readonly string[],
+  ): CorsaCallSignatureFacts;
   getReturnTypeOfSignature(signature: CorsaSignature): CorsaType | undefined;
   getTypePredicateOfSignature(signature: CorsaSignature): CorsaTypePredicate | undefined;
   getBaseTypes(type: CorsaType): readonly CorsaType[];

--- a/src/core/corsa_client/src/api/responses.rs
+++ b/src/core/corsa_client/src/api/responses.rs
@@ -142,12 +142,27 @@ pub struct SignatureResponse {
     /// Parameter symbols in declaration order.
     #[serde(default)]
     pub parameters: Vec<SymbolHandle>,
+    /// Full parameter symbol metadata in declaration order when available.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parameter_symbols: Vec<SymbolResponse>,
+    /// Rendered parameter type texts aligned with [`Self::parameters`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parameter_type_texts: Vec<Vec<String>>,
     /// `this` parameter symbol when explicitly modeled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub this_parameter: Option<SymbolHandle>,
+    /// Full `this` parameter symbol metadata when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub this_parameter_symbol: Option<SymbolResponse>,
+    /// Rendered `this` parameter type texts when available.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub this_parameter_type_texts: Vec<String>,
     /// Target signature for instantiated or wrapped signatures.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<SignatureHandle>,
+    /// Rendered default type argument texts aligned with [`Self::type_parameters`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub type_parameter_default_texts: Vec<String>,
 }
 
 /// Type predicate metadata such as `value is Foo`.

--- a/src/core/corsa_core/src/lint/host_facts.rs
+++ b/src/core/corsa_core/src/lint/host_facts.rs
@@ -1,0 +1,373 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde_json::{Map, Value, json};
+
+use super::{LintNode, TextRange};
+
+pub(crate) fn prepare_node_for_rule(node: &LintNode) -> LintNode {
+    let mut prepared = node.clone();
+    apply_ancestor_facts(&mut prepared);
+    apply_call_facts(&mut prepared);
+    apply_symbol_facts(&mut prepared);
+    apply_type_parameter_facts(&mut prepared);
+    apply_return_type_facts(&mut prepared);
+    prepared
+}
+
+fn apply_ancestor_facts(node: &mut LintNode) {
+    let Some(ancestors) = node
+        .fields
+        .get("__ancestorFacts")
+        .and_then(Value::as_array)
+        .cloned()
+    else {
+        return;
+    };
+
+    if let Some(function) = ancestors
+        .iter()
+        .rev()
+        .find(|ancestor| field_str(ancestor, "kind").is_some_and(|kind| kind.contains("Function")))
+    {
+        if let Some(async_value) = field_bool(function, "async") {
+            insert_if_absent(
+                &mut node.fields,
+                "__nearestFunctionAsync",
+                json!(async_value),
+            );
+        }
+    }
+
+    if let Some(class_name) = ancestors
+        .iter()
+        .rev()
+        .find_map(|ancestor| field_str(ancestor, "className"))
+    {
+        insert_if_absent(&mut node.fields, "__nearestClassName", json!(class_name));
+    }
+
+    if node.kind == "ReturnStatement"
+        && ancestors
+            .iter()
+            .any(|ancestor| try_contains(ancestor, node.range))
+    {
+        insert_if_absent(&mut node.fields, "__returnAwaitRequiresAwait", json!(true));
+    }
+
+    if node.kind == "CallExpression" && is_promise_executor_reject_call(node, ancestors.as_slice())
+    {
+        insert_if_absent(&mut node.fields, "__promiseExecutorRejectCall", json!(true));
+    }
+}
+
+fn apply_call_facts(node: &mut LintNode) {
+    let Some(call_facts) = node
+        .fields
+        .get("__callFacts")
+        .and_then(Value::as_object)
+        .cloned()
+    else {
+        return;
+    };
+    if let Some(expected) = call_facts.get("expectedArgumentTypeTexts") {
+        insert_if_absent(
+            &mut node.fields,
+            "__expectedArgumentTypeTexts",
+            expected.clone(),
+        );
+    }
+    if let Some(required) = call_facts.get("explicitTypeArgumentsRequired") {
+        insert_if_absent(
+            &mut node.fields,
+            "__explicitTypeArgumentsRequired",
+            required.clone(),
+        );
+    }
+    copy_call_fact(
+        node,
+        &call_facts,
+        "typeArgumentRanges",
+        "__typeArgumentRanges",
+    );
+    copy_call_fact(
+        node,
+        &call_facts,
+        "typeArgumentListRange",
+        "__typeArgumentListRange",
+    );
+    copy_call_fact(
+        node,
+        &call_facts,
+        "typeParameterCount",
+        "__typeParameterCount",
+    );
+    copy_call_fact(
+        node,
+        &call_facts,
+        "lastTypeParameterHasDefault",
+        "__lastTypeParameterHasDefault",
+    );
+    copy_call_fact(
+        node,
+        &call_facts,
+        "lastTypeArgumentEqualsDefault",
+        "__lastTypeArgumentEqualsDefault",
+    );
+    copy_call_fact(
+        node,
+        &call_facts,
+        "lastTypeArgumentSameTypeFlagsAsDefault",
+        "__lastTypeArgumentSameTypeFlagsAsDefault",
+    );
+    copy_call_fact(
+        node,
+        &call_facts,
+        "lastTypeArgumentIdenticalToDefault",
+        "__lastTypeArgumentIdenticalToDefault",
+    );
+}
+
+fn apply_symbol_facts(node: &mut LintNode) {
+    let Some(symbol_facts) = node.fields.get("__symbolFacts").and_then(Value::as_object) else {
+        return;
+    };
+    if symbol_facts
+        .get("deprecated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || declaration_has_deprecated_jsdoc(symbol_facts)
+    {
+        insert_if_absent(&mut node.fields, "__deprecated", json!(true));
+    }
+}
+
+fn apply_type_parameter_facts(node: &mut LintNode) {
+    let Some(type_parameter_facts) = node
+        .fields
+        .get("__typeParameterFacts")
+        .and_then(Value::as_object)
+    else {
+        return;
+    };
+    let Some(name) = type_parameter_facts.get("name").and_then(Value::as_str) else {
+        return;
+    };
+    let Some(owner_text) = type_parameter_facts
+        .get("ownerText")
+        .and_then(Value::as_str)
+    else {
+        return;
+    };
+    if count_identifier_occurrences(owner_text, name) <= 2 {
+        insert_if_absent(&mut node.fields, "__hasSingleUseTypeParameter", json!(true));
+    }
+}
+
+fn apply_return_type_facts(node: &mut LintNode) {
+    let Some(return_type_facts) = node
+        .fields
+        .get("__returnTypeFacts")
+        .and_then(Value::as_object)
+        .cloned()
+    else {
+        return;
+    };
+    if let Some(texts) = return_type_facts.get("texts") {
+        insert_if_absent(&mut node.fields, "__returnTypeTexts", texts.clone());
+    }
+}
+
+fn is_promise_executor_reject_call(node: &LintNode, ancestors: &[Value]) -> bool {
+    let Some(call_facts) = node.fields.get("__callFacts").and_then(Value::as_object) else {
+        return false;
+    };
+    let Some(callee_name) = call_facts.get("calleeName").and_then(Value::as_str) else {
+        return false;
+    };
+    let Some(function) = ancestors
+        .iter()
+        .rev()
+        .find(|ancestor| field_str(ancestor, "kind").is_some_and(|kind| kind.contains("Function")))
+    else {
+        return false;
+    };
+    let Some(params) = function.get("paramNames").and_then(Value::as_array) else {
+        return false;
+    };
+    if params
+        .get(1)
+        .and_then(Value::as_str)
+        .is_none_or(|reject| reject != callee_name)
+    {
+        return false;
+    }
+    (field_str(function, "parentKind") == Some("NewExpression")
+        && field_str(function, "parentCalleeName") == Some("Promise"))
+        || (field_str(function, "parentParentKind") == Some("NewExpression")
+            && field_str(function, "parentParentCalleeName") == Some("Promise"))
+}
+
+fn try_contains(value: &Value, range: TextRange) -> bool {
+    if field_str(value, "kind") != Some("TryStatement") {
+        return false;
+    }
+    let Some(start) = value.get("start").and_then(Value::as_u64) else {
+        return false;
+    };
+    let Some(end) = value.get("end").and_then(Value::as_u64) else {
+        return false;
+    };
+    start as u32 <= range.start && range.end <= end as u32
+}
+
+fn count_identifier_occurrences(text: &str, needle: &str) -> usize {
+    if needle.is_empty() {
+        return 0;
+    }
+    text.match_indices(needle)
+        .filter(|(index, _)| {
+            !identifier_part_before(text, *index)
+                && !identifier_part_at(text, index.saturating_add(needle.len()))
+        })
+        .count()
+}
+
+fn identifier_part_before(text: &str, index: usize) -> bool {
+    text.get(..index)
+        .and_then(|prefix| prefix.chars().next_back())
+        .is_some_and(is_identifier_part)
+}
+
+fn identifier_part_at(text: &str, index: usize) -> bool {
+    text.get(index..)
+        .and_then(|suffix| suffix.chars().next())
+        .is_some_and(is_identifier_part)
+}
+
+fn is_identifier_part(ch: char) -> bool {
+    ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()
+}
+
+fn field_str<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
+    value.get(key).and_then(Value::as_str)
+}
+
+fn field_bool(value: &Value, key: &str) -> Option<bool> {
+    value.get(key).and_then(Value::as_bool)
+}
+
+fn insert_if_absent(fields: &mut BTreeMap<String, Value>, key: &str, value: Value) {
+    fields.entry(key.to_owned()).or_insert(value);
+}
+
+fn copy_call_fact(
+    node: &mut LintNode,
+    call_facts: &Map<String, Value>,
+    source_key: &str,
+    target_key: &str,
+) {
+    if let Some(value) = call_facts.get(source_key) {
+        insert_if_absent(&mut node.fields, target_key, value.clone());
+    }
+}
+
+struct ParsedNodeHandle {
+    pos: usize,
+    path: String,
+}
+
+fn declaration_has_deprecated_jsdoc(symbol_facts: &Map<String, Value>) -> bool {
+    let Some(declarations) = symbol_facts.get("declarations").and_then(Value::as_array) else {
+        return false;
+    };
+    declarations.iter().any(|declaration| {
+        declaration
+            .as_str()
+            .and_then(parse_node_handle)
+            .and_then(|handle| source_for_handle(symbol_facts, handle))
+            .is_some_and(|(source, pos)| has_deprecated_marker_before(&source, pos))
+    })
+}
+
+fn parse_node_handle(value: &str) -> Option<ParsedNodeHandle> {
+    let mut parts = value.split('.');
+    let pos = parts.next()?.parse().ok()?;
+    parts.next()?;
+    parts.next()?;
+    let path = parts.collect::<Vec<_>>().join(".");
+    Some(ParsedNodeHandle { pos, path })
+}
+
+fn source_for_handle(
+    symbol_facts: &Map<String, Value>,
+    handle: ParsedNodeHandle,
+) -> Option<(String, usize)> {
+    let filename = symbol_facts
+        .get("filename")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if path_matches_current_source(handle.path.as_str(), filename) {
+        let source = symbol_facts
+            .get("sourceText")
+            .and_then(Value::as_str)?
+            .to_owned();
+        let pos = utf16_offset_to_byte_index(&source, handle.pos)?;
+        return Some((source, pos));
+    }
+
+    let cwd = symbol_facts
+        .get("cwd")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let path = resolve_source_path(cwd, handle.path.as_str())?;
+    let source = fs::read_to_string(path).ok()?;
+    let pos = utf16_offset_to_byte_index(&source, handle.pos)?;
+    Some((source, pos))
+}
+
+fn path_matches_current_source(path: &str, filename: &str) -> bool {
+    path.is_empty() || path == filename || filename.ends_with(path)
+}
+
+fn resolve_source_path(cwd: &str, path: &str) -> Option<PathBuf> {
+    if path.is_empty() {
+        return None;
+    }
+    let direct = Path::new(path);
+    if direct.exists() {
+        return Some(direct.to_path_buf());
+    }
+    if cwd.is_empty() {
+        return None;
+    }
+    let joined = Path::new(cwd).join(path);
+    joined.exists().then_some(joined)
+}
+
+fn has_deprecated_marker_before(source: &str, pos: usize) -> bool {
+    let start = source[..pos]
+        .char_indices()
+        .rev()
+        .nth(500)
+        .map(|(index, _)| index)
+        .unwrap_or(0);
+    source[start..pos].contains("@deprecated")
+}
+
+fn utf16_offset_to_byte_index(source: &str, offset: usize) -> Option<usize> {
+    let mut utf16_units = 0usize;
+    for (byte_index, ch) in source.char_indices() {
+        if utf16_units == offset {
+            return Some(byte_index);
+        }
+        utf16_units = utf16_units.saturating_add(ch.len_utf16());
+        if utf16_units > offset {
+            return None;
+        }
+    }
+    (utf16_units == offset).then_some(source.len())
+}

--- a/src/core/corsa_core/src/lint/mod.rs
+++ b/src/core/corsa_core/src/lint/mod.rs
@@ -2,6 +2,7 @@
 
 mod context;
 mod helpers;
+mod host_facts;
 mod registry;
 mod rules;
 mod stylistic;

--- a/src/core/corsa_core/src/lint/registry.rs
+++ b/src/core/corsa_core/src/lint/registry.rs
@@ -17,7 +17,7 @@ use super::{
     RequireArraySortCompareRule, RequireAwaitRule, RestrictPlusOperandsRule,
     RestrictTemplateExpressionsRule, ReturnAwaitRule, RuleContext, RuleMeta, RustLintRule,
     StrictBooleanExpressionsRule, StrictVoidReturnRule, SwitchExhaustivenessCheckRule,
-    UnboundMethodRule, UseUnknownInCatchCallbackVariableRule,
+    UnboundMethodRule, UseUnknownInCatchCallbackVariableRule, host_facts,
 };
 
 /// Collection of Rust-authored lint rules addressable by stable rule name.
@@ -121,7 +121,8 @@ impl LintRuleRegistry {
             .iter()
             .find(|candidate| candidate.name() == rule_name)?;
         let mut ctx = RuleContext::new(rule.as_ref());
-        rule.check(&mut ctx, node);
+        let prepared = host_facts::prepare_node_for_rule(node);
+        rule.check(&mut ctx, &prepared);
         Some(ctx.finish())
     }
 }


### PR DESCRIPTION
## Summary
- remove TS-side stale-handle/type-text and signature parameter synthesis fallbacks by moving normalization/enrichment into the Corsa API wrapper
- enrich signatures with parameter symbols, parameter type texts, call signature facts, and default type argument text for oxlint consumers
- move native rule host fact expansion into Rust while TS passes generic ancestor/call/symbol/type/return facts
- keep the existing smart corsa-oxlint defaults and corrupted built-in symbol filtering fixes

Closes #281
Closes #282
Closes #283
Closes #284
Closes #292
Closes #297

## Testing
- PASS: node_modules/.bin/vitest run --config ./vite.config.ts src/bindings/nodejs/corsa_node/ts/index.test.ts src/bindings/nodejs/corsa_oxlint/ts/session.test.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts src/bindings/nodejs/corsa_oxlint/ts/native_diagnostics_snapshot.test.ts
- PASS: node_modules/.bin/vp run -w build_ci
- PASS: node_modules/.bin/vp fmt --check
- PASS: cargo fmt --all --check
- PASS: cargo test -p corsa_core lint::
- PASS: cargo clippy --workspace --all-targets -- -D warnings
- PASS: node_modules/.bin/tsc -p src/bindings/nodejs/corsa_node/tsconfig.json --noEmit --pretty false
- PASS: git diff --check
- NOTE: node_modules/.bin/tsc -p src/bindings/nodejs/corsa_oxlint/tsconfig.json --noEmit --pretty false still hits the existing rootDir/source-alias issue for @corsa-bind/napi
- NOTE: src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts still has existing pending-parity failures for no-duplicate-type-constituents, return-await, and no-unnecessary-type-conversion under the local real Corsa integration environment; no-unnecessary-type-arguments now passes
