### PR TITLE
fix(corsa-oxlint): default RuleTester corsa executable

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -1,7 +1,8 @@
-import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { defaultCorsaExecutable } from "./context";
 import { OxlintUtils } from "./oxlint_utils";
@@ -11,6 +12,14 @@ import { RuleTester } from "./rule_tester";
 
 const workspaceRoot = resolve(import.meta.dirname, "../../../../..");
 const realCorsaBinary = defaultCorsaExecutable(workspaceRoot);
+const cleanupDirs = new Set<string>();
+
+afterEach(() => {
+  for (const dir of cleanupDirs) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+  cleanupDirs.clear();
+});
 
 describe("corsa oxlint", () => {
   it("creates docs URLs through the Oxlint RuleCreator", () => {
@@ -527,6 +536,58 @@ describe("corsa oxlint", () => {
     });
   });
 
+  it("defaults RuleTester corsa executable from the configured cwd", () => {
+    const previousExecutable = process.env.CORSA_EXECUTABLE;
+    delete process.env.CORSA_EXECUTABLE;
+    let seen: Record<string, unknown> | undefined;
+    try {
+      const packageRoot = createNativePreviewPackage();
+      const expectedExecutable = realpathSync(
+        resolve(packageRoot, "node_modules/@typescript/native-preview/bin/tsgo.js"),
+      );
+      const tester = new RuleTester({
+        cwd: packageRoot,
+      });
+      tester.run(
+        "default-executable-roundtrip",
+        {
+          meta: {
+            messages: {
+              demo: "demo",
+            },
+            schema: [],
+          },
+          create(context: any) {
+            seen = {
+              languageExecutable: context.languageOptions?.parserOptions?.corsa?.executable,
+              parserExecutable: context.parserOptions?.corsa?.executable,
+              settingsExecutable: context.settings?.corsaOxlint?.parserOptions?.corsa?.executable,
+              tsconfigRootDir: context.parserOptions?.tsconfigRootDir,
+            };
+            return {};
+          },
+        } as any,
+        {
+          valid: [{ code: "const value = 1;" }],
+          invalid: [],
+        },
+      );
+
+      expect(seen).toEqual({
+        languageExecutable: expectedExecutable,
+        parserExecutable: expectedExecutable,
+        settingsExecutable: expectedExecutable,
+        tsconfigRootDir: expect.not.stringContaining(packageRoot),
+      });
+    } finally {
+      if (previousExecutable === undefined) {
+        delete process.env.CORSA_EXECUTABLE;
+      } else {
+        process.env.CORSA_EXECUTABLE = previousExecutable;
+      }
+    }
+  });
+
   const integrationCase = existsSync(realCorsaBinary) ? it : it.skip;
 
   integrationCase("runs a type-aware custom rule through oxlint RuleTester", () => {
@@ -609,3 +670,22 @@ describe("corsa oxlint", () => {
     });
   });
 });
+
+function createNativePreviewPackage(): string {
+  const packageRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-runtime-"));
+  cleanupDirs.add(packageRoot);
+  const packageDir = resolve(packageRoot, "node_modules/@typescript/native-preview");
+  const binPath = resolve(packageDir, "bin/tsgo.js");
+  mkdirSync(dirname(binPath), { recursive: true });
+  writeFileSync(
+    resolve(packageDir, "package.json"),
+    JSON.stringify({
+      name: "@typescript/native-preview",
+      bin: {
+        tsgo: "bin/tsgo.js",
+      },
+    }),
+  );
+  writeFileSync(binPath, "#!/usr/bin/env node\n");
+  return packageRoot;
+}

--- a/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
@@ -4,7 +4,7 @@ import { dirname, join, resolve } from "node:path";
 
 import { RuleTester as OxlintRuleTester } from "oxlint/plugins-dev";
 
-import { mergeTypeAwareParserOptions } from "./context";
+import { defaultCorsaExecutable, mergeTypeAwareParserOptions } from "./context";
 import { decorateRule } from "./plugin";
 import type { CorsaOxlintSettings, TypeAwareParserOptions } from "./types";
 
@@ -123,6 +123,7 @@ function prepareTestCase(
       test.languageOptions?.parserOptions as TypeAwareParserOptions | undefined,
     ),
   );
+  const parserOptionsWithRuntime = applyRuleTesterRuntimeDefaults(parserOptions, test, config);
   return {
     ...test,
     filename,
@@ -132,17 +133,33 @@ function prepareTestCase(
       corsaOxlint: {
         ...testerConfig?.settings?.corsaOxlint,
         ...(test.settings as { corsaOxlint?: CorsaOxlintSettings })?.corsaOxlint,
-        parserOptions,
+        parserOptions: parserOptionsWithRuntime,
       },
     } as never,
     languageOptions: {
       ...config?.languageOptions,
       ...test.languageOptions,
       parserOptions: {
-        ...parserOptions,
+        ...parserOptionsWithRuntime,
       } as never,
     },
   };
+}
+
+function applyRuleTesterRuntimeDefaults(
+  parserOptions: TypeAwareParserOptions,
+  test: TestCase,
+  config: RuleTesterConfig | undefined,
+): TypeAwareParserOptions {
+  if (parserOptions.corsa?.executable !== undefined) {
+    return parserOptions;
+  }
+  const rootDir = resolve(test.cwd ?? config?.cwd ?? process.cwd());
+  return mergeTypeAwareParserOptions(parserOptions, {
+    corsa: {
+      executable: process.env.CORSA_EXECUTABLE ?? defaultCorsaExecutable(rootDir),
+    },
+  });
 }
 
 function writeFixture(filename: string, code: string): void {


### PR DESCRIPTION
## Summary
- default RuleTester parserOptions.corsa.executable from CORSA_EXECUTABLE or defaultCorsaExecutable using the test/config cwd
- keep temporary RuleTester fixture tsconfigRootDir in place while resolving @typescript/native-preview from the package cwd
- add a regression test with a fake @typescript/native-preview package

## Testing
- PASS: corepack pnpm exec vitest run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/context.test.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
- PASS: corepack pnpm exec vp fmt --check
- PASS: corepack pnpm exec vp run -w build_ci
- PASS: git diff --check
- NOTE: corepack pnpm exec tsc -p src/bindings/nodejs/corsa_oxlint/tsconfig.json --noEmit --pretty false still fails with the existing TS6059 rootDir issue pulling in src/bindings/nodejs/corsa_node/ts files via @corsa-bind/napi

Closes #305

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783250292&installation_id=136613492&pr_number=306&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F306&signature=a4d387f7fb3843994661b58497f969f16a2d9bc2d8546710abb321685f6f9acf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->