### PR TITLE
fix(corsa-oxlint): default type-aware rules to corsa runtime

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/context.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.ts
@@ -59,14 +59,20 @@ export function resolveProjectConfig(context: ContextWithParserOptions): Resolve
  */
 export function resolveTypeAwareParserOptions(
   context: ContextWithParserOptions,
-  defaults: { readonly projectService?: boolean } = {},
+  defaults: TypeAwareParserOptionDefaults = {},
 ): TypeAwareParserOptions {
   const parserOptions = mergeTypeAwareParserOptions(
     resolveSettingsParserOptions(context.settings?.corsaOxlint),
     mergeTypeAwareParserOptions(context.parserOptions, context.languageOptions?.parserOptions),
   );
-  return applyTypeAwareParserOptionDefaults(parserOptions, defaults);
+  const rootDir = resolve(parserOptions.tsconfigRootDir ?? context.cwd);
+  return applyTypeAwareParserOptionDefaults(parserOptions, defaults, rootDir);
 }
+
+type TypeAwareParserOptionDefaults = {
+  readonly corsa?: boolean;
+  readonly projectService?: boolean;
+};
 
 function resolveRuntimeOptions(
   rootDir: string,
@@ -214,19 +220,28 @@ function resolveSettingsParserOptions(
 
 function applyTypeAwareParserOptionDefaults(
   parserOptions: TypeAwareParserOptions,
-  defaults: { readonly projectService?: boolean },
+  defaults: TypeAwareParserOptionDefaults,
+  rootDir: string,
 ): TypeAwareParserOptions {
+  let resolved = parserOptions;
   if (
-    defaults.projectService !== true ||
-    parserOptions.projectService !== undefined ||
-    parserOptions.project !== undefined
+    defaults.projectService === true &&
+    parserOptions.projectService === undefined &&
+    parserOptions.project === undefined
   ) {
-    return parserOptions;
+    resolved = {
+      ...resolved,
+      projectService: true,
+    };
   }
-  return {
-    ...parserOptions,
-    projectService: true,
-  };
+  if (defaults.corsa === true && resolved.corsa?.executable === undefined) {
+    resolved = mergeTypeAwareParserOptions(resolved, {
+      corsa: {
+        executable: process.env.CORSA_EXECUTABLE ?? defaultCorsaExecutable(rootDir),
+      },
+    });
+  }
+  return resolved;
 }
 
 export function mergeTypeAwareParserOptions(

--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -588,6 +588,64 @@ describe("corsa oxlint", () => {
     }
   });
 
+  it("defaults decorated type-aware rules to the corsa executable", () => {
+    const previousExecutable = process.env.CORSA_EXECUTABLE;
+    delete process.env.CORSA_EXECUTABLE;
+    let seen: Record<string, unknown> | undefined;
+    try {
+      const packageRoot = createNativePreviewPackage();
+      const expectedExecutable = realpathSync(
+        resolve(packageRoot, "node_modules/@typescript/native-preview/bin/tsgo.js"),
+      );
+      const rule = decorateRule({
+        meta: {
+          docs: {
+            requiresTypeChecking: true,
+          },
+          messages: {
+            demo: "demo",
+          },
+          schema: [],
+        },
+        create(context: any) {
+          seen = {
+            languageExecutable: context.languageOptions?.parserOptions?.corsa?.executable,
+            parserExecutable: context.parserOptions?.corsa?.executable,
+            settingsExecutable: context.settings?.corsaOxlint?.parserOptions?.corsa?.executable,
+            projectService: context.parserOptions?.projectService,
+          };
+          return {};
+        },
+      } as any);
+
+      rule.create!({
+        cwd: packageRoot,
+        filename: resolve(packageRoot, "fixture.ts"),
+        languageOptions: {
+          parserOptions: {},
+        },
+        report() {},
+        settings: {},
+        sourceCode: {
+          text: "const fixture = 1;",
+        },
+      } as any);
+
+      expect(seen).toEqual({
+        languageExecutable: expectedExecutable,
+        parserExecutable: expectedExecutable,
+        settingsExecutable: undefined,
+        projectService: true,
+      });
+    } finally {
+      if (previousExecutable === undefined) {
+        delete process.env.CORSA_EXECUTABLE;
+      } else {
+        process.env.CORSA_EXECUTABLE = previousExecutable;
+      }
+    }
+  });
+
   const integrationCase = existsSync(realCorsaBinary) ? it : it.skip;
 
   integrationCase("runs a type-aware custom rule through oxlint RuleTester", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/plugin.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/plugin.ts
@@ -77,9 +77,11 @@ function wrapRules(rules: Record<string, Rule>): Record<string, Rule> {
 }
 
 function decorateContext(context: ContextWithParserOptions, rule: Rule): ContextWithParserOptions {
+  const typeAware = requiresTypeChecking(rule);
   const parserOptions = Object.freeze(
     resolveTypeAwareParserOptions(context, {
-      projectService: requiresTypeChecking(rule),
+      corsa: typeAware,
+      projectService: typeAware,
     }),
   );
   const baseLanguageOptions = context.languageOptions;

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -1152,6 +1152,65 @@ describe("corsa oxlint type locations", () => {
     expect(seen.animal).toBe("Animal");
   });
 
+  integrationCase("exposes symbols for type references with the default corsa executable", () => {
+    const seen: Record<string, string | null> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "type-reference-symbol-accessor",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise type reference symbol lookup",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          TSTypeReference(node: any) {
+            const name = node.typeName?.name;
+            if (!name) {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node);
+            seen[name] = type ? (checker.getSymbolOfType(type)?.name ?? null) : null;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("type-reference-symbol-accessor", rule as any, {
+      valid: [
+        {
+          code: [
+            "interface IThing {",
+            "  readonly id: string;",
+            "}",
+            "class Animal {}",
+            "class Dog extends Animal implements IThing {",
+            '  readonly id: string = "rex";',
+            "}",
+            "const animal: Animal = new Dog();",
+            "const thing: IThing = new Dog();",
+          ].join("\n"),
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen).toEqual({
+      Animal: "Animal",
+      IThing: "IThing",
+    });
+  });
+
   integrationCase("does not expose corrupted mapped utility type symbols", () => {
     const seen: Record<
       string,


### PR DESCRIPTION
## Summary

- default decorated type-aware rules to a Corsa runtime executable
- keep Oxlint-provided parserServices fallback for rules that do not request type checking
- add coverage for decorated default runtime options and TSTypeReference symbol lookup

## Root Cause

Rules with `meta.docs.requiresTypeChecking` only received a default `projectService`; they did not get `parserOptions.corsa` unless users provided `settings.corsaOxlint`. Without that runtime marker, `getParserServices` reused Oxlint's parser services, which returned `any` for `TSTypeReference` in this path and made `getSymbolOfType` return `null`.

Closes #307

## Validation

- `pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/context.test.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts`
- temp `oxlint` reproduction with `@typescript/native-preview@7.0.0-dev.20260516.1`: config without `settings.corsaOxlint` and config with explicit `./node_modules/.bin/tsgo` both resolve `Animal` and `IThing` symbols
- `pnpm exec vp fmt --check src/bindings/nodejs/corsa_oxlint/ts/context.ts src/bindings/nodejs/corsa_oxlint/ts/plugin.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts`
- `pnpm exec vp check src/bindings/nodejs/corsa_oxlint/ts/context.ts src/bindings/nodejs/corsa_oxlint/ts/plugin.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts` (exit 0; existing warning in `type_location.test.ts` on string spread)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783338786&installation_id=136613492&pr_number=308&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F308&signature=0389360725f9466f88ff1007584e59048b73ff64686db173d7e22bf0ab54cd9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->