### PR TITLE
fix(corsa-oxlint): preserve imported constructor parameter symbols

### DIFF
--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -2025,20 +2025,12 @@ async fn parameter_symbols_for_signature(
         source_override,
     )
     .await?;
-    let Some((start, end)) = utf16_byte_range(&source_text, parsed.pos, parsed.end) else {
-        return Ok(Vec::new());
-    };
-    let Some(declaration_text) = source_text.get(start..end) else {
-        return Ok(Vec::new());
-    };
-    let parameters = parameter_ranges_in_signature_declaration(declaration_text, start)
-        .into_iter()
-        .filter_map(|parameter| {
-            let pos = utf16_index_from_byte(&source_text, parameter.start)?;
-            let end = utf16_index_from_byte(&source_text, parameter.end)?;
-            Some((parameter.name, pos, end))
-        })
-        .collect::<Vec<_>>();
+    let parameters = parameter_ranges_for_signature_declaration(
+        &source_text,
+        parsed.pos,
+        parsed.end,
+        signature.parameters.len(),
+    );
     if parameters.is_empty() {
         return Ok(Vec::new());
     }
@@ -2083,14 +2075,11 @@ async fn type_parameter_default_texts_for_signature(
         source_override,
     )
     .await?;
-    let Some((start, end)) = utf16_byte_range(&source_text, parsed.pos, parsed.end) else {
-        return Ok(Vec::new());
-    };
-    let Some(declaration_text) = source_text.get(start..end) else {
-        return Ok(Vec::new());
-    };
-    Ok(type_parameter_default_texts_in_signature_declaration(
-        declaration_text,
+    Ok(type_parameter_default_texts_for_declaration_range(
+        &source_text,
+        parsed.pos,
+        parsed.end,
+        signature.type_parameters.len(),
     ))
 }
 
@@ -2179,6 +2168,90 @@ fn parameter_ranges_in_signature_declaration(
             })
         })
         .collect()
+}
+
+fn parameter_ranges_for_signature_declaration(
+    source_text: &str,
+    declaration_pos: u32,
+    declaration_end: u32,
+    expected_count: usize,
+) -> Vec<(String, u32, u32)> {
+    let mut fallback = Vec::new();
+    for (start, end) in
+        signature_declaration_byte_ranges(source_text, declaration_pos, declaration_end)
+    {
+        let Some(declaration_text) = source_text.get(start..end) else {
+            continue;
+        };
+        let parameters = parameter_ranges_in_signature_declaration(declaration_text, start)
+            .into_iter()
+            .filter_map(|parameter| {
+                let pos = utf16_index_from_byte(source_text, parameter.start)?;
+                let end = utf16_index_from_byte(source_text, parameter.end)?;
+                Some((parameter.name, pos, end))
+            })
+            .collect::<Vec<_>>();
+        if parameters.len() == expected_count {
+            return parameters;
+        }
+        if fallback.is_empty() && !parameters.is_empty() {
+            fallback = parameters;
+        }
+    }
+    fallback
+}
+
+fn type_parameter_default_texts_for_declaration_range(
+    source_text: &str,
+    declaration_pos: u32,
+    declaration_end: u32,
+    expected_count: usize,
+) -> Vec<String> {
+    let mut fallback = Vec::new();
+    for (start, end) in
+        signature_declaration_byte_ranges(source_text, declaration_pos, declaration_end)
+    {
+        let Some(declaration_text) = source_text.get(start..end) else {
+            continue;
+        };
+        let defaults = type_parameter_default_texts_in_signature_declaration(declaration_text);
+        if defaults.len() == expected_count {
+            return defaults;
+        }
+        if fallback.is_empty() && !defaults.is_empty() {
+            fallback = defaults;
+        }
+    }
+    fallback
+}
+
+fn signature_declaration_byte_ranges(
+    source_text: &str,
+    declaration_pos: u32,
+    declaration_end: u32,
+) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    if let Some(range) = utf16_byte_range(source_text, declaration_pos, declaration_end) {
+        ranges.push(range);
+    }
+    if let Some(range) = raw_byte_range(source_text, declaration_pos, declaration_end)
+        && !ranges.contains(&range)
+    {
+        ranges.push(range);
+    }
+    ranges
+}
+
+fn raw_byte_range(text: &str, start: u32, end: u32) -> Option<(usize, usize)> {
+    if start > end {
+        return None;
+    }
+    let start = usize::try_from(start).ok()?;
+    let end = usize::try_from(end).ok()?;
+    if end > text.len() || !text.is_char_boundary(start) || !text.is_char_boundary(end) {
+        return None;
+    }
+    Some((start, end))
 }
 
 fn parameter_name(text: &str) -> Option<String> {
@@ -2562,4 +2635,64 @@ fn call_json_blocking(client: &ApiClient, method: &str, params: Option<Value>) -
     let response = block_on(client.raw_json_request(method, optional_value(params)))
         .map_err(into_napi_error)?;
     Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        parameter_ranges_for_signature_declaration, raw_byte_range,
+        signature_declaration_byte_ranges,
+    };
+
+    #[test]
+    fn falls_back_to_raw_byte_ranges_for_non_ascii_signature_handles() {
+        let declaration = "constructor(scope: unknown, id: string, props?: ThingProps) {}";
+        let source_text =
+            format!("export class Thing {{\n  /** doesn’t “one” – */\n  {declaration}\n}}");
+        let declaration_start = source_text.find(declaration).unwrap();
+        let declaration_end = declaration_start + declaration.len();
+
+        let ranges = signature_declaration_byte_ranges(
+            &source_text,
+            declaration_start as u32,
+            declaration_end as u32,
+        );
+
+        assert_eq!(
+            ranges.last().copied(),
+            Some((declaration_start, declaration_end))
+        );
+        assert_eq!(
+            raw_byte_range(
+                &source_text,
+                declaration_start as u32,
+                declaration_end as u32
+            ),
+            Some((declaration_start, declaration_end))
+        );
+    }
+
+    #[test]
+    fn resolves_parameter_names_from_raw_byte_declaration_ranges() {
+        let declaration = "constructor(scope: unknown, id: string, props?: ThingProps) {}";
+        let source_text =
+            format!("export class Thing {{\n  /** doesn’t “one” – */\n  {declaration}\n}}");
+        let declaration_start = source_text.find(declaration).unwrap();
+        let declaration_end = declaration_start + declaration.len();
+
+        let parameters = parameter_ranges_for_signature_declaration(
+            &source_text,
+            declaration_start as u32,
+            declaration_end as u32,
+            3,
+        );
+
+        assert_eq!(
+            parameters
+                .into_iter()
+                .map(|(name, _, _)| name)
+                .collect::<Vec<_>>(),
+            vec!["scope", "id", "props"]
+        );
+    }
 }

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -921,6 +921,93 @@ describe("corsa oxlint type locations", () => {
     ]);
   });
 
+  integrationCase("resolves imported constructor parameter symbols after non-ASCII JSDoc", () => {
+    const workspace = mkdtempSync(resolve(tmpdir(), "corsa-oxlint-constructor-params-"));
+    const depDir = resolve(workspace, "src");
+    mkdirSync(depDir, { recursive: true });
+    writeFileSync(
+      resolve(workspace, "tsconfig.json"),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            module: "esnext",
+            moduleResolution: "node",
+            target: "es2022",
+            strict: true,
+          },
+          include: ["src/**/*.ts"],
+        },
+        null,
+        2,
+      ),
+    );
+    writeFileSync(
+      resolve(depDir, "dep.ts"),
+      [
+        "export interface ThingProps {",
+        "  readonly name?: string;",
+        "}",
+        "export abstract class Base {",
+        "  /** doesn’t “one” – */",
+        "  constructor(scope: unknown, id: string) {}",
+        "}",
+        "export class Thing extends Base {",
+        "  /** doesn’t “one” – */",
+        "  constructor(scope: unknown, id: string, props?: ThingProps) {",
+        "    void props;",
+        "    super(scope, id);",
+        "  }",
+        "}",
+      ].join("\n"),
+    );
+    const filename = resolve(depDir, "index.ts");
+    const sourceText = [
+      'import { Thing } from "./dep";',
+      "declare const scope: unknown;",
+      'new Thing(scope, "id");',
+    ].join("\n");
+    writeFileSync(filename, sourceText);
+    const checker = createTypeChecker({
+      cwd: workspace,
+      filename,
+      sourceCode: { text: sourceText },
+      settings: {
+        corsaOxlint: {
+          parserOptions: {
+            project: "tsconfig.json",
+            corsa: {
+              executable: realCorsaBinary,
+              cwd: workspace,
+              mode: "jsonrpc",
+            },
+          },
+        },
+      },
+    } as any);
+    const calleeStart = sourceText.indexOf("Thing(");
+    const callee = {
+      fileName: filename,
+      pos: calleeStart,
+      end: calleeStart + "Thing".length,
+      range: [calleeStart, calleeStart + "Thing".length] as const,
+    };
+    const constructType = checker.getTypeAtLocation(callee);
+    const signature = constructType
+      ? checker.getSignaturesOfType(constructType, 1)[0]
+      : undefined;
+
+    expect(signature?.parameterSymbols?.map((symbol) => symbol.name)).toEqual([
+      "scope",
+      "id",
+      "props",
+    ]);
+    expect(signature?.parameters.map((id) => checker.getSymbolById(id)?.name)).toEqual([
+      "scope",
+      "id",
+      "props",
+    ]);
+  });
+
   integrationCase("resolves the symbol type at a location instead of the node type", () => {
     const seen: Record<string, string | undefined> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -992,9 +992,7 @@ describe("corsa oxlint type locations", () => {
       range: [calleeStart, calleeStart + "Thing".length] as const,
     };
     const constructType = checker.getTypeAtLocation(callee);
-    const signature = constructType
-      ? checker.getSignaturesOfType(constructType, 1)[0]
-      : undefined;
+    const signature = constructType ? checker.getSignaturesOfType(constructType, 1)[0] : undefined;
 
     expect(signature?.parameterSymbols?.map((symbol) => symbol.name)).toEqual([
       "scope",


### PR DESCRIPTION
## Summary
- fall back from UTF-16 declaration ranges to raw-byte ranges when imported constructor declarations include non-ASCII JSDoc
- prefer the declaration range whose parsed parameter or type-parameter default counts match the signature
- add Rust and `corsa-oxlint` regression coverage for imported inherited constructors

Closes #309.

## Validation
- `cargo fmt --all --check`
- `cargo test -p corsa_node --lib`
- `pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts` *(blocked in this environment: npm registry DNS failures)*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783401140&installation_id=136613492&pr_number=310&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F310&signature=36a24ce6196368873ce802e2d42340cecd16f5bcefb9262355a07d52be5f5577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->