### PR TITLE
fix(corsa-oxlint): avoid stale stylistic diagnostics cache

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/stylistic.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/stylistic.test.ts
@@ -119,4 +119,44 @@ describe("corsa stylistic rules", () => {
       ],
     });
   });
+
+  it("does not reuse native diagnostics across files sharing a sourceCode object", () => {
+    const sourceCode = {
+      text: "const source = { foo: 1 };\n",
+      getText() {
+        return this.text;
+      },
+    };
+    const reports: Array<{ messageId?: string }> = [];
+    const context = {
+      sourceCode,
+      cwd: process.cwd(),
+      languageOptions: {},
+      settings: {
+        corsaStylistic: {
+          rules: {
+            "object-curly-spacing": ["always"],
+          },
+        },
+      },
+      options: [],
+      report(descriptor: { messageId?: string }) {
+        reports.push(descriptor);
+      },
+    };
+    const rule = corsaStylisticRules["object-curly-spacing"] as {
+      create(context: unknown): { Program(node: { type: string; range: [number, number] }): void };
+    };
+
+    rule.create(context).Program({ type: "Program", range: [0, sourceCode.text.length] });
+    expect(reports).toEqual([]);
+
+    sourceCode.text = "const {foo} = source;\n";
+    rule.create(context).Program({ type: "Program", range: [0, sourceCode.text.length] });
+
+    expect(reports.map((report) => report.messageId)).toEqual([
+      "requireSpaceAfter",
+      "requireSpaceBefore",
+    ]);
+  });
 });

--- a/src/bindings/nodejs/corsa_oxlint/ts/stylistic.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/stylistic.ts
@@ -74,7 +74,12 @@ export interface CorsaStylisticSettings {
 
 const stylisticMetas = nativeStylisticRuleMetas();
 const stylisticMetasByName = new Map(stylisticMetas.map((meta) => [meta.name, meta]));
-const diagnosticsCache = new WeakMap<object, Map<string, readonly NativeLintDiagnostic[]>>();
+type CachedStylisticDiagnostics = {
+  readonly sourceText: string;
+  readonly diagnostics: readonly NativeLintDiagnostic[];
+};
+
+const diagnosticsCache = new WeakMap<object, Map<string, CachedStylisticDiagnostics>>();
 
 /**
  * Native stylistic rule names exported by `corsa-oxlint/stylistic`.
@@ -193,12 +198,12 @@ function diagnosticsForRule(
   }
 
   const cached = sourceCache.get(key);
-  if (cached) {
-    return cached;
+  if (cached?.sourceText === sourceText) {
+    return cached.diagnostics;
   }
 
   const diagnostics = runNativeStylisticLint(sourceText, { rules: config });
-  sourceCache.set(key, diagnostics);
+  sourceCache.set(key, { sourceText, diagnostics });
   return diagnostics;
 }
 


### PR DESCRIPTION
## Summary

- keep the shared native stylistic diagnostics cache from reusing diagnostics across different source texts
- preserve the single native scan cache for multiple stylistic rules on the same file
- add regression coverage for Oxlint-style sourceCode object reuse across files

## Root Cause

Oxlint can reuse the same `context.sourceCode` object across files. The Corsa Stylistic bridge keyed its batched native diagnostics cache only by that object and the rule config, so multi-file lint runs could reuse diagnostics computed for a previous file.

## Validation

- `pnpm exec vitest run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/stylistic.test.ts`
- `pnpm exec vite-plus run -w build_corsa_oxlint`
- multi-file Oxlint CLI repro with `object-curly-spacing: ["always"]` now reports `const {foo}` in the second file

Note: `pnpm exec vitest run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/**/*.test.ts` still fails in the existing `native_rules.test.ts` pending parity slice (`expected 1 error, got 0`), outside this Stylistic cache change.

Fixes #311

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783433056&installation_id=136613492&pr_number=312&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F312&signature=7f906b6f7572ba55bf39472b371a1eb5a16af0f7ac07758889b9539a3f8944be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->