### PR TITLE
fix(corsa-oxlint): map stylistic ranges to UTF-16 offsets

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/stylistic.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/stylistic.test.ts
@@ -159,4 +159,55 @@ describe("corsa stylistic rules", () => {
       "requireSpaceBefore",
     ]);
   });
+
+  it("maps native stylistic byte ranges to Oxlint UTF-16 source ranges", () => {
+    const sourceText = "// 日本語\nconst a = [\n  1\n]\n";
+    const sourceCode = {
+      text: sourceText,
+      getText() {
+        return this.text;
+      },
+    };
+    const reports: Array<{
+      node?: { range?: [number, number] };
+      suggest?: Array<{
+        fix(fixer: {
+          replaceTextRange(range: [number, number], replacementText: string): unknown;
+        }): unknown;
+      }>;
+    }> = [];
+    const context = {
+      sourceCode,
+      cwd: process.cwd(),
+      languageOptions: {},
+      settings: {
+        corsaStylistic: {
+          rules: {
+            "comma-dangle": ["always"],
+          },
+        },
+      },
+      options: [],
+      report(descriptor: (typeof reports)[number]) {
+        reports.push(descriptor);
+      },
+    };
+    const rule = corsaStylisticRules["comma-dangle"] as {
+      create(context: unknown): { Program(node: { type: string; range: [number, number] }): void };
+    };
+
+    rule.create(context).Program({ type: "Program", range: [0, sourceText.length] });
+
+    const insertAt = sourceText.indexOf("1") + 1;
+    expect(reports).toHaveLength(1);
+    const [report] = reports as [(typeof reports)[number]];
+    expect(report.node?.range).toEqual([insertAt, insertAt]);
+    expect(
+      report.suggest?.[0]?.fix({
+        replaceTextRange(range, replacementText) {
+          return { range, replacementText };
+        },
+      }),
+    ).toEqual([{ range: [insertAt, insertAt], replacementText: "," }]);
+  });
 });

--- a/src/bindings/nodejs/corsa_oxlint/ts/stylistic.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/stylistic.ts
@@ -2,8 +2,10 @@ import {
   nativeStylisticRuleMetas,
   runNativeStylisticLint,
   type NativeLintDiagnostic,
+  type NativeLintFix,
   type NativeLintRange,
   type NativeLintRuleMeta,
+  type NativeLintSuggestion,
   type NativeStylisticRuleConfig,
 } from "@corsa-bind/napi";
 
@@ -77,6 +79,15 @@ const stylisticMetasByName = new Map(stylisticMetas.map((meta) => [meta.name, me
 type CachedStylisticDiagnostics = {
   readonly sourceText: string;
   readonly diagnostics: readonly NativeLintDiagnostic[];
+};
+
+type ByteToUtf16Mapper = (offset: number) => number;
+
+type NonAsciiSpan = {
+  readonly byteStart: number;
+  readonly byteEnd: number;
+  readonly utf16Start: number;
+  readonly deltaAfter: number;
 };
 
 const diagnosticsCache = new WeakMap<object, Map<string, CachedStylisticDiagnostics>>();
@@ -202,7 +213,10 @@ function diagnosticsForRule(
     return cached.diagnostics;
   }
 
-  const diagnostics = runNativeStylisticLint(sourceText, { rules: config });
+  const diagnostics = mapNativeDiagnosticRanges(
+    runNativeStylisticLint(sourceText, { rules: config }),
+    sourceText,
+  );
   sourceCache.set(key, { sourceText, diagnostics });
   return diagnostics;
 }
@@ -267,6 +281,129 @@ function rangeNode(program: ProgramNode, range: NativeLintRange): ProgramNode {
 
 function oxlintRange(range: NativeLintRange): [number, number] {
   return [range.start, range.end];
+}
+
+function mapNativeDiagnosticRanges(
+  diagnostics: readonly NativeLintDiagnostic[],
+  sourceText: string,
+): readonly NativeLintDiagnostic[] {
+  const byteToUtf16 = createByteToUtf16Mapper(sourceText);
+  return diagnostics.map((diagnostic) => ({
+    ...diagnostic,
+    range: mapNativeRange(diagnostic.range, byteToUtf16),
+    ...(diagnostic.suggestions?.length
+      ? {
+          suggestions: diagnostic.suggestions.map((suggestion) =>
+            mapNativeSuggestion(suggestion, byteToUtf16),
+          ),
+        }
+      : {}),
+  }));
+}
+
+function mapNativeSuggestion(
+  suggestion: NativeLintSuggestion,
+  byteToUtf16: ByteToUtf16Mapper,
+): NativeLintSuggestion {
+  return {
+    ...suggestion,
+    fixes: suggestion.fixes.map((fix) => mapNativeFix(fix, byteToUtf16)),
+  };
+}
+
+function mapNativeFix(fix: NativeLintFix, byteToUtf16: ByteToUtf16Mapper): NativeLintFix {
+  return {
+    ...fix,
+    range: mapNativeRange(fix.range, byteToUtf16),
+  };
+}
+
+function mapNativeRange(range: NativeLintRange, byteToUtf16: ByteToUtf16Mapper): NativeLintRange {
+  return {
+    start: byteToUtf16(range.start),
+    end: byteToUtf16(range.end),
+  };
+}
+
+function createByteToUtf16Mapper(sourceText: string): ByteToUtf16Mapper {
+  const nonAsciiSpans: NonAsciiSpan[] = [];
+  let byteOffset = 0;
+  let utf16Offset = 0;
+
+  while (utf16Offset < sourceText.length) {
+    const codePoint = sourceText.codePointAt(utf16Offset);
+    if (codePoint === undefined) {
+      break;
+    }
+    const utf16Length = codePoint > 0xffff ? 2 : 1;
+    const byteLength = utf8ByteLength(codePoint);
+    const byteEnd = byteOffset + byteLength;
+    const utf16End = utf16Offset + utf16Length;
+    if (byteLength !== utf16Length) {
+      nonAsciiSpans.push({
+        byteStart: byteOffset,
+        byteEnd,
+        utf16Start: utf16Offset,
+        deltaAfter: byteEnd - utf16End,
+      });
+    }
+    byteOffset = byteEnd;
+    utf16Offset = utf16End;
+  }
+
+  if (nonAsciiSpans.length === 0) {
+    return (offset) => clampOffset(offset, sourceText.length);
+  }
+
+  const totalBytes = byteOffset;
+  return (offset) => {
+    const byteOffset = clampOffset(offset, totalBytes);
+    let low = 0;
+    let high = nonAsciiSpans.length;
+    while (low < high) {
+      const mid = Math.floor((low + high) / 2);
+      if (nonAsciiSpans[mid].byteEnd <= byteOffset) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+
+    const nextSpan = nonAsciiSpans[low];
+    if (nextSpan && byteOffset >= nextSpan.byteStart && byteOffset < nextSpan.byteEnd) {
+      return nextSpan.utf16Start;
+    }
+
+    const previousSpan = nonAsciiSpans[low - 1];
+    const delta = previousSpan?.deltaAfter ?? 0;
+    return clampOffset(byteOffset - delta, sourceText.length);
+  };
+}
+
+function utf8ByteLength(codePoint: number): number {
+  if (codePoint <= 0x7f) {
+    return 1;
+  }
+  if (codePoint <= 0x7ff) {
+    return 2;
+  }
+  if (codePoint <= 0xffff) {
+    return 3;
+  }
+  return 4;
+}
+
+function clampOffset(offset: number, max: number): number {
+  if (!Number.isFinite(offset)) {
+    return 0;
+  }
+  if (offset <= 0) {
+    return 0;
+  }
+  if (offset >= max) {
+    return max;
+  }
+  return Math.trunc(offset);
 }
 
 function sourceTextForContext(context: ContextWithParserOptions): string {


### PR DESCRIPTION
## Summary

- Convert native stylistic diagnostic ranges from UTF-8 byte offsets to Oxlint's UTF-16 source offsets.
- Apply the same mapping to suggestion fix ranges before reporting diagnostics.
- Add coverage for non-ASCII source text before a native comma-dangle diagnostic.

## Root Cause

Native stylistic diagnostics are produced with byte offsets, but the JavaScript plugin reports ranges to Oxlint using source-text offsets. When non-ASCII text appeared before a diagnostic, reported ranges could point past the JavaScript source length and break downstream formatting on Windows.

## Validation

- `pnpm exec vite-plus fmt src/bindings/nodejs/corsa_oxlint/ts/stylistic.ts src/bindings/nodejs/corsa_oxlint/ts/stylistic.test.ts --write`
- `pnpm exec vite-plus run -w build_corsa_oxlint`
- `pnpm exec vitest run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/stylistic.test.ts`
- `git diff --check`
- Reproduced `pnpm lint` against `misskey-dev/oxlint-fmt-config-misskey-dev` branch `wip-20260607` with local package link; the panic no longer occurs.

Fixes #313.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783436217&installation_id=136613492&pr_number=314&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F314&signature=5bbbb1821804a3da98cedb233d7112047522d2533ae1ec80215c523c5ef69b26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->