### PR TITLE
feat: add typed rule context wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `corsa-oxlint` now exposes a `RuleContext<MessageId, Options>` type and generic `defineRule` wrapper for narrowing rule options and report message IDs.
 - `corsa-oxlint` now exposes per-node-type `ESTree.*` aliases from the root entrypoint.
 
 ### Fixed

--- a/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts
@@ -51,6 +51,57 @@ describe("api surface", () => {
     >();
   });
 
+  it("narrows defineRule context by message ids and options", () => {
+    type Options = readonly [{ readonly ignore?: readonly string[] }?];
+    const node = { range: [0, 1] } as any;
+
+    const typedRule = main.defineRule<"unused" | "duplicate", Options>({
+      meta: {
+        type: "problem",
+        messages: {
+          duplicate: "'{{ name }}' is declared twice.",
+          unused: "'{{ name }}' is declared but never used.",
+        },
+        schema: [],
+      },
+      create(context) {
+        expectTypeOf(context).toMatchTypeOf<main.RuleContext<"unused" | "duplicate", Options>>();
+        expectTypeOf(context.options[0]).toEqualTypeOf<
+          { readonly ignore?: readonly string[] } | undefined
+        >();
+
+        context.report({ node, message: "custom message" });
+        context.report({ node, messageId: "unused" });
+        // @ts-expect-error unknown message ids are rejected.
+        context.report({ node, messageId: "typo" });
+
+        return {};
+      },
+    });
+
+    const inferredRule = main.defineRule({
+      defaultOptions: [{ ignore: [] as string[] }],
+      meta: {
+        type: "problem",
+        messages: {
+          unused: "'{{ name }}' is declared but never used.",
+        },
+        schema: [],
+      },
+      create(context) {
+        expectTypeOf(context.options[0].ignore).toEqualTypeOf<string[]>();
+        context.report({ node, messageId: "unused" });
+        // @ts-expect-error inferred message ids are rejected when not declared in meta.messages.
+        context.report({ node, messageId: "typo" });
+
+        return {};
+      },
+    });
+
+    expect(typedRule).toBeDefined();
+    expect(inferredRule).toBeDefined();
+  });
+
   it(
     "emits declarations for inferred visitor callback node types",
     () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/index.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/index.ts
@@ -10,7 +10,14 @@ export * as Utils from "./utils";
 
 export { ESLintUtils, OxlintUtils, RuleCreator } from "./oxlint_utils";
 export { compatPlugin, definePlugin, defineRule } from "./plugin";
-export type { Plugin, Rule } from "./plugin";
+export type {
+  Plugin,
+  Rule,
+  RuleContext,
+  RuleDefinition,
+  RuleDiagnostic,
+  RuleMetaWithMessages,
+} from "./plugin";
 export { getParserServices } from "./parser_services";
 export { RuleTester } from "./rule_tester";
 export { SignatureKind } from "./types";

--- a/src/bindings/nodejs/corsa_oxlint/ts/plugin.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/plugin.ts
@@ -1,8 +1,12 @@
 import * as oxlintPluginApi from "@oxlint/plugins";
 import type {
   Context as OxlintContext,
+  Diagnostic,
   Plugin as OxlintPlugin,
   Rule as OxlintRule,
+  RuleMeta,
+  Visitor,
+  VisitorWithHooks,
 } from "@oxlint/plugins";
 
 import { resolveTypeAwareParserOptions } from "./context";
@@ -13,6 +17,35 @@ export type Plugin = Omit<OxlintPlugin, "rules"> & {
   readonly rules: Record<string, Rule>;
 } & Record<string, unknown>;
 export type Rule = OxlintRule & Record<string, unknown>;
+export type RuleDiagnostic<MessageId extends string = string> = Diagnostic & {
+  readonly messageId?: MessageId | null | undefined;
+};
+export type RuleContext<
+  MessageId extends string = string,
+  Options extends readonly unknown[] = readonly unknown[],
+> = Omit<ContextWithParserOptions, "options" | "report"> & {
+  readonly options: Readonly<Options>;
+  report(this: void, diagnostic: RuleDiagnostic<MessageId>): void;
+};
+export type RuleMetaWithMessages<MessageId extends string = string> = RuleMeta & {
+  readonly messages?: Record<MessageId, string>;
+};
+export type RuleDefinition<
+  MessageId extends string = string,
+  Options extends readonly unknown[] = readonly unknown[],
+> = Record<string, unknown> & {
+  readonly defaultOptions?: Options;
+  readonly meta?: RuleMetaWithMessages<MessageId>;
+} & (
+    | {
+        readonly create: (context: RuleContext<MessageId, Options>) => Visitor;
+        readonly createOnce?: never;
+      }
+    | {
+        readonly create?: (context: RuleContext<MessageId, Options>) => Visitor;
+        readonly createOnce: (context: RuleContext<MessageId, Options>) => VisitorWithHooks;
+      }
+  );
 
 const defineOxlintPlugin = oxlintPluginApi.definePlugin;
 const defineOxlintRule = oxlintPluginApi.defineRule;
@@ -42,6 +75,10 @@ export function definePlugin(plugin: Plugin): Plugin {
  * });
  * ```
  */
+export function defineRule<
+  MessageId extends string = string,
+  const Options extends readonly unknown[] = readonly unknown[],
+>(rule: RuleDefinition<MessageId, Options>): Rule;
 export function defineRule(rule: Rule): Rule {
   return defineOxlintRule(decorateRule(rule) as OxlintRule) as Rule;
 }


### PR DESCRIPTION
## Summary
- add a generic RuleContext<MessageId, Options> type for corsa-oxlint rules
- thread message IDs and option tuple types through defineRule create/createOnce callbacks
- add API surface type coverage for messageId rejection and options inference

Closes #319.

## Verification
- pnpm -s exec tsc --noEmit
- pnpm -s vitest run src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts --maxWorkers 1 --testTimeout 60000
- vp fmt --check
- vp check --no-fmt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783518990&installation_id=136613492&pr_number=321&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F321&signature=87df4c927fbe8b5b8a1187668ab4072f679722118ea1130c062fb73dcc002e49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->