### PR TITLE
feat: prepare corsa-oxlint minor release

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,16 +61,19 @@ importers:
       '@corsa-bind/napi':
         specifier: workspace:*
         version: link:../corsa_node
+    devDependencies:
       '@oxlint/plugins':
         specifier: 1.69.0
         version: 1.69.0
-      oxlint:
-        specifier: 1.69.0
-        version: 1.69.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@25.9.2)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)))
-    devDependencies:
       '@typescript-eslint/utils':
         specifier: 8.61.0
         version: 8.61.0(eslint@10.4.1)(typescript@6.0.3)
+      oxlint:
+        specifier: 1.69.0
+        version: 1.69.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@25.9.2)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)))
+      oxlint-tsgolint:
+        specifier: 0.23.0
+        version: 0.23.0
 
 packages:
 

--- a/src/bindings/nodejs/corsa_node/index.d.ts
+++ b/src/bindings/nodejs/corsa_node/index.d.ts
@@ -19,9 +19,9 @@ export declare class CorsaApiClient {
   /** Applies file changes on a libuv worker thread. */
   updateSnapshotAsync(params?: any | undefined | null): Promise<unknown>
   /** Fetches a source file through the binary endpoint. */
-  getSourceFile(snapshot: string, project: string, file: string): Buffer | null
+  getSourceFile(snapshot: string, project: string, file: string): Uint8Array | null
   /** Fetches a source file on a libuv worker thread. */
-  getSourceFileAsync(snapshot: string, project: string, file: string): Promise<Buffer | null>
+  getSourceFileAsync(snapshot: string, project: string, file: string): Promise<Uint8Array | null>
   /** Resolves the intrinsic string type for a project. */
   getStringType(snapshot: string, project: string): any
   getStringTypeAsync(snapshot: string, project: string): Promise<unknown>
@@ -60,9 +60,9 @@ export declare class CorsaApiClient {
   /** Sends an arbitrary JSON endpoint request on a libuv worker thread. */
   callJsonAsync(method: string, params?: any | undefined | null): Promise<unknown>
   /** Sends an arbitrary binary endpoint request. */
-  callBinary(method: string, params?: any | undefined | null): Buffer | null
+  callBinary(method: string, params?: any | undefined | null): Uint8Array | null
   /** Sends an arbitrary binary endpoint request on a libuv worker thread. */
-  callBinaryAsync(method: string, params?: any | undefined | null): Promise<Buffer | null>
+  callBinaryAsync(method: string, params?: any | undefined | null): Promise<Uint8Array | null>
   /** Releases a corsa handle explicitly. */
   releaseHandle(handle: string): void
   /** Releases a corsa handle on a libuv worker thread. */

--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -676,7 +676,7 @@ impl CorsaApiClient {
     }
 
     /// Fetches a source file through the binary endpoint.
-    #[napi]
+    #[napi(ts_return_type = "Uint8Array | null")]
     pub fn get_source_file(
         &self,
         snapshot: String,
@@ -693,7 +693,7 @@ impl CorsaApiClient {
     }
 
     /// Fetches a source file on a libuv worker thread.
-    #[napi]
+    #[napi(ts_return_type = "Promise<Uint8Array | null>")]
     pub fn get_source_file_async(
         &self,
         snapshot: String,
@@ -1148,7 +1148,7 @@ impl CorsaApiClient {
     }
 
     /// Sends an arbitrary binary endpoint request.
-    #[napi]
+    #[napi(ts_return_type = "Uint8Array | null")]
     pub fn call_binary(&self, method: String, params: Option<Value>) -> Result<Option<Buffer>> {
         let params = optional_value(params);
         let payload = block_on(self.inner.raw_binary_request(method.as_str(), params))
@@ -1157,7 +1157,7 @@ impl CorsaApiClient {
     }
 
     /// Sends an arbitrary binary endpoint request on a libuv worker thread.
-    #[napi]
+    #[napi(ts_return_type = "Promise<Uint8Array | null>")]
     pub fn call_binary_async(
         &self,
         method: String,

--- a/src/bindings/nodejs/corsa_node/ts/index.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.ts
@@ -34,8 +34,8 @@ export interface CorsaApiClient {
   parseConfigFileAsync(file: string): Promise<ConfigResponse>;
   updateSnapshot(params?: UpdateSnapshotParams): UpdateSnapshotResponse;
   updateSnapshotAsync(params?: UpdateSnapshotParams): Promise<UpdateSnapshotResponse>;
-  getSourceFile(snapshot: string, project: string, file: string): Buffer | null;
-  getSourceFileAsync(snapshot: string, project: string, file: string): Promise<Buffer | null>;
+  getSourceFile(snapshot: string, project: string, file: string): Uint8Array | null;
+  getSourceFileAsync(snapshot: string, project: string, file: string): Promise<Uint8Array | null>;
   getStringType(snapshot: string, project: string): TypeResponse;
   getStringTypeAsync(snapshot: string, project: string): Promise<TypeResponse>;
   getTypeAtPosition(
@@ -148,8 +148,8 @@ export interface CorsaApiClient {
   ): Promise<string>;
   callJson<T>(method: string, params?: unknown): T;
   callJsonAsync<T>(method: string, params?: unknown): Promise<T>;
-  callBinary(method: string, params?: unknown): Buffer | null;
-  callBinaryAsync(method: string, params?: unknown): Promise<Buffer | null>;
+  callBinary(method: string, params?: unknown): Uint8Array | null;
+  callBinaryAsync(method: string, params?: unknown): Promise<Uint8Array | null>;
   releaseHandle(handle: string): void;
   releaseHandleAsync(handle: string): Promise<void>;
   close(): void;

--- a/src/bindings/nodejs/corsa_oxlint/package.json
+++ b/src/bindings/nodejs/corsa_oxlint/package.json
@@ -101,12 +101,17 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@corsa-bind/napi": "workspace:*",
-    "@oxlint/plugins": "1.69.0",
-    "oxlint": "1.69.0"
+    "@corsa-bind/napi": "workspace:*"
   },
   "devDependencies": {
-    "@typescript-eslint/utils": "8.61.0"
+    "@oxlint/plugins": "1.69.0",
+    "@typescript-eslint/utils": "8.61.0",
+    "oxlint": "1.69.0",
+    "oxlint-tsgolint": "0.23.0"
+  },
+  "peerDependencies": {
+    "@oxlint/plugins": "^1.69.0",
+    "oxlint": "^1.69.0"
   },
   "engines": {
     "bun": ">=1.2",

--- a/src/bindings/nodejs/corsa_oxlint/ts/index.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/index.ts
@@ -15,6 +15,7 @@ export type {
   Rule,
   RuleContext,
   RuleDefinition,
+  RuleDocs,
   RuleDiagnostic,
   RuleMetaWithMessages,
 } from "./plugin";
@@ -30,7 +31,7 @@ type CorsaAstNodeType = keyof typeof CorsaAST_NODE_TYPES;
 
 export type ESTree = ESTree.NodeTypes;
 export namespace ESTree {
-  export type Node = OxlintESTree.Node;
+  type OxlintNode = OxlintESTree.Node;
   type NarrowNode<Candidate, Kind extends string> = Candidate extends {
     readonly type: infer CandidateKind;
   }
@@ -38,7 +39,14 @@ export namespace ESTree {
       ? Candidate & { readonly type: Kind }
       : never
     : never;
-  export type NodeByType<Kind extends string> = NarrowNode<Node, Kind>;
+  export type NodeByType<Kind extends string> = Kind extends string
+    ? NarrowNode<OxlintNode, Kind>
+    : never;
+  export type Node =
+    | {
+        [Kind in CorsaAstNodeType]: NodeByType<Kind>;
+      }[CorsaAstNodeType]
+    | BindingIdentifier;
 
   export type AccessorProperty = NodeByType<"AccessorProperty">;
   export type ArrayExpression = NodeByType<"ArrayExpression">;
@@ -213,6 +221,105 @@ export namespace ESTree {
   export type BindingIdentifier = Omit<OxlintESTree.BindingIdentifier, "typeAnnotation"> & {
     typeAnnotation?: TSTypeAnnotation | null;
   };
+  export type BindingPattern = BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern;
+  export type Class = ClassDeclaration | ClassExpression;
+  export type Function =
+    | FunctionDeclaration
+    | FunctionExpression
+    | TSDeclareFunction
+    | TSEmptyBodyFunctionExpression;
+  export type Declaration =
+    | VariableDeclaration
+    | Function
+    | Class
+    | TSTypeAliasDeclaration
+    | TSInterfaceDeclaration
+    | TSEnumDeclaration
+    | TSModuleDeclaration
+    | TSImportEqualsDeclaration;
+  export type ModuleDeclaration =
+    | ImportDeclaration
+    | ExportAllDeclaration
+    | ExportDefaultDeclaration
+    | ExportNamedDeclaration
+    | TSExportAssignment
+    | TSNamespaceExportDeclaration;
+  export type Statement =
+    | BlockStatement
+    | BreakStatement
+    | ContinueStatement
+    | DebuggerStatement
+    | DoWhileStatement
+    | EmptyStatement
+    | ExpressionStatement
+    | ForInStatement
+    | ForOfStatement
+    | ForStatement
+    | IfStatement
+    | LabeledStatement
+    | ReturnStatement
+    | SwitchStatement
+    | ThrowStatement
+    | TryStatement
+    | WhileStatement
+    | WithStatement
+    | Declaration
+    | ModuleDeclaration;
+  export type Expression =
+    | Literal
+    | TemplateLiteral
+    | Identifier
+    | MetaProperty
+    | Super
+    | ArrayExpression
+    | ArrowFunctionExpression
+    | AssignmentExpression
+    | AwaitExpression
+    | BinaryExpression
+    | CallExpression
+    | ChainExpression
+    | Class
+    | ConditionalExpression
+    | Function
+    | ImportExpression
+    | LogicalExpression
+    | NewExpression
+    | ObjectExpression
+    | SequenceExpression
+    | TaggedTemplateExpression
+    | ThisExpression
+    | UnaryExpression
+    | UpdateExpression
+    | YieldExpression
+    | JSXElement
+    | JSXFragment
+    | TSAsExpression
+    | TSSatisfiesExpression
+    | TSTypeAssertion
+    | TSNonNullExpression
+    | TSInstantiationExpression
+    | MemberExpression;
+  export type SimpleAssignmentTarget =
+    | Identifier
+    | TSAsExpression
+    | TSSatisfiesExpression
+    | TSNonNullExpression
+    | TSTypeAssertion
+    | MemberExpression;
+  export type AssignmentTarget = SimpleAssignmentTarget | ArrayPattern | ObjectPattern;
+  export type ChainElement = CallExpression | TSNonNullExpression | MemberExpression;
+  export type FormalParameter = BindingPattern;
+  export type FormalParameterRest = RestElement;
+  export type ParamPattern = FormalParameter | TSParameterProperty | FormalParameterRest;
+  export type ClassElement =
+    | StaticBlock
+    | MethodDefinition
+    | TSAbstractMethodDefinition
+    | PropertyDefinition
+    | TSAbstractPropertyDefinition
+    | AccessorProperty
+    | TSAbstractAccessorProperty
+    | TSIndexSignature;
   export type NodeTypes = {
     [Kind in CorsaAstNodeType]: NodeByType<Kind>;
   } & {

--- a/src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts
@@ -286,64 +286,71 @@ describe("corsa oxlint native rules", () => {
     );
   });
 
-  integrationCase("runs pending parity slice rules through RuleTester", () => {
-    createTester().run("dot-notation", corsaOxlintRules["dot-notation"] as never, {
-      valid: [{ code: "const record = { value: 1 }; record.value;" }],
-      invalid: [{ code: "const record = { value: 1 }; record['value'];", errors: 1 }],
-    });
-
-    createTester().run(
-      "no-duplicate-type-constituents",
-      corsaOxlintRules["no-duplicate-type-constituents"] as never,
-      {
+  const pendingParityRuleCases = [
+    {
+      ruleName: "dot-notation",
+      tests: {
+        valid: [{ code: "const record = { value: 1 }; record.value;" }],
+        invalid: [{ code: "const record = { value: 1 }; record['value'];", errors: 1 }],
+      },
+    },
+    {
+      ruleName: "no-duplicate-type-constituents",
+      tests: {
         valid: [{ code: "type Value = string | number;" }],
         invalid: [{ code: "type Value = string | string;", errors: 1 }],
       },
-    );
-
-    createTester().run("no-unsafe-argument", corsaOxlintRules["no-unsafe-argument"] as never, {
-      valid: [{ code: "function take(value: unknown) {} declare const value: any; take(value);" }],
-      invalid: [
-        {
-          code: "function take(value: string) {} declare const value: any; take(value);",
-          errors: 1,
-        },
-      ],
-    });
-
-    createTester().run("require-await", corsaOxlintRules["require-await"] as never, {
-      valid: [
-        { code: "async function ok() { await Promise.resolve(1); }" },
-        { code: "async function ok() { return Promise.resolve(1); }" },
-      ],
-      invalid: [
-        { code: "async function nope() { return 1; }", errors: 1 },
-        {
-          code: "async function outer() { async function inner() { await Promise.resolve(1); } return 1; }",
-          errors: 1,
-        },
-      ],
-    });
-
-    createTester().run("return-await", corsaOxlintRules["return-await"] as never, {
-      valid: [
-        {
-          code: "async function ok() { try { return await Promise.resolve(1); } catch { return 0; } }",
-        },
-      ],
-      invalid: [
-        { code: "async function nope() { return await Promise.resolve(1); }", errors: 1 },
-        {
-          code: "async function nope() { try { return Promise.resolve(1); } catch { return 0; } }",
-          errors: 1,
-        },
-      ],
-    });
-
-    createTester().run(
-      "no-unnecessary-type-arguments",
-      corsaOxlintRules["no-unnecessary-type-arguments"] as never,
-      {
+    },
+    {
+      ruleName: "no-unsafe-argument",
+      tests: {
+        valid: [
+          { code: "function take(value: unknown) {} declare const value: any; take(value);" },
+        ],
+        invalid: [
+          {
+            code: "function take(value: string) {} declare const value: any; take(value);",
+            errors: 1,
+          },
+        ],
+      },
+    },
+    {
+      ruleName: "require-await",
+      tests: {
+        valid: [
+          { code: "async function ok() { await Promise.resolve(1); }" },
+          { code: "async function ok() { return Promise.resolve(1); }" },
+        ],
+        invalid: [
+          { code: "async function nope() { return 1; }", errors: 1 },
+          {
+            code: "async function outer() { async function inner() { await Promise.resolve(1); } return 1; }",
+            errors: 1,
+          },
+        ],
+      },
+    },
+    {
+      ruleName: "return-await",
+      tests: {
+        valid: [
+          {
+            code: "async function ok() { try { return await Promise.resolve(1); } catch { return 0; } }",
+          },
+        ],
+        invalid: [
+          { code: "async function nope() { return await Promise.resolve(1); }", errors: 1 },
+          {
+            code: "async function nope() { try { return Promise.resolve(1); } catch { return 0; } }",
+            errors: 1,
+          },
+        ],
+      },
+    },
+    {
+      ruleName: "no-unnecessary-type-arguments",
+      tests: {
         valid: [{ code: "function value<T>(input: T): T { return input; } value<string>('x');" }],
         invalid: [
           {
@@ -352,17 +359,21 @@ describe("corsa oxlint native rules", () => {
           },
         ],
       },
-    );
-
-    createTester().run(
-      "no-unnecessary-type-conversion",
-      corsaOxlintRules["no-unnecessary-type-conversion"] as never,
-      {
+    },
+    {
+      ruleName: "no-unnecessary-type-conversion",
+      tests: {
         valid: [{ code: "const value = String(1);" }],
         invalid: [{ code: "const value = String('value');", errors: 1 }],
       },
-    );
-  });
+    },
+  ] as const;
+
+  for (const { ruleName, tests } of pendingParityRuleCases) {
+    integrationCase(`runs ${ruleName} pending parity rule through RuleTester`, () => {
+      createTester().run(ruleName, corsaOxlintRules[ruleName] as never, tests as never);
+    });
+  }
 
   integrationCase("runs restrict-plus-operands through RuleTester", () => {
     createTester().run(

--- a/src/bindings/nodejs/corsa_oxlint/ts/oxlint_utils.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/oxlint_utils.ts
@@ -1,8 +1,8 @@
-import type { RuleMeta, Visitor } from "@oxlint/plugins";
+import type { Visitor } from "@oxlint/plugins";
 
 import { getParserServices } from "./parser_services";
 import { decorateRule } from "./plugin";
-import type { Rule } from "./plugin";
+import type { Rule, RuleMetaWithMessages } from "./plugin";
 import type { ContextWithParserOptions } from "./types";
 
 export type RuleCreatorRule<
@@ -15,13 +15,12 @@ export type RuleCreatorRule<
   readonly create: (context: ContextWithParserOptions) => Visitor;
 };
 
-export type RuleCreatorMeta<TMessageIds extends string = string> = RuleMeta & {
-  readonly messages?: Record<TMessageIds, string>;
-};
+export type RuleCreatorMeta<TMessageIds extends string = string> =
+  RuleMetaWithMessages<TMessageIds>;
 
 export type RuleCreatorCreatedRule<
   TOptions extends readonly unknown[] = readonly [],
-  TMeta extends RuleMeta = RuleMeta,
+  TMeta extends RuleMetaWithMessages = RuleMetaWithMessages,
 > = Rule & {
   readonly defaultOptions: TOptions;
   readonly meta: TMeta & {

--- a/src/bindings/nodejs/corsa_oxlint/ts/plugin.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/plugin.ts
@@ -4,7 +4,7 @@ import type {
   Diagnostic,
   Plugin as OxlintPlugin,
   Rule as OxlintRule,
-  RuleMeta,
+  RuleMeta as OxlintRuleMeta,
   Visitor,
   VisitorWithHooks,
 } from "@oxlint/plugins";
@@ -27,7 +27,22 @@ export type RuleContext<
   readonly options: Readonly<Options>;
   report(this: void, diagnostic: RuleDiagnostic<MessageId>): void;
 };
-export type RuleMetaWithMessages<MessageId extends string = string> = RuleMeta & {
+export type RuleDocs = {
+  readonly description?: string;
+  readonly recommended?: unknown;
+  readonly url?: string;
+  /**
+   * Enables corsa-oxlint's type-aware parser service defaults for this rule.
+   *
+   * @default false
+   */
+  readonly requiresTypeChecking?: boolean;
+};
+export type RuleMetaWithMessages<MessageId extends string = string> = Omit<
+  OxlintRuleMeta,
+  "docs" | "messages"
+> & {
+  readonly docs?: RuleDocs;
   readonly messages?: Record<MessageId, string>;
 };
 export type RuleDefinition<

--- a/src/bindings/nodejs/corsa_oxlint/ts/public_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/public_types.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import { AST_NODE_TYPES, defineRule, OxlintUtils, type ESTree, type RuleDocs } from "./index";
+
+describe("corsa oxlint public types", () => {
+  it("surfaces requiresTypeChecking on rule docs", () => {
+    const docs = {
+      description: "typed docs",
+      requiresTypeChecking: true,
+    } satisfies RuleDocs;
+
+    defineRule({
+      meta: {
+        type: "problem",
+        docs,
+        messages: {
+          demo: "demo",
+        },
+        schema: [],
+      },
+      create() {
+        return {};
+      },
+    });
+
+    defineRule({
+      meta: {
+        docs: {
+          // @ts-expect-error requiresTypeChecking is intentionally misspelled.
+          requiresTypeCheckng: true,
+        },
+        messages: {
+          demo: "demo",
+        },
+      },
+      create() {
+        return {};
+      },
+    });
+
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/${name}`);
+    const created = createRule({
+      name: "typed-docs",
+      meta: {
+        docs: {
+          requiresTypeChecking: true,
+        },
+        messages: {
+          demo: "demo",
+        },
+      },
+      create() {
+        return {};
+      },
+    });
+
+    const requiresTypeChecking: boolean | undefined = created.meta.docs.requiresTypeChecking;
+    expect(requiresTypeChecking).toBe(true);
+    expect(created.meta.docs.url).toBe("https://example.com/typed-docs");
+  });
+
+  it("narrows ESTree.Node through AST_NODE_TYPES checks", () => {
+    function narrow(node: ESTree.Node): void {
+      if (node.type === AST_NODE_TYPES.PropertyDefinition) {
+        expectTypeOf(node).toMatchTypeOf<ESTree.PropertyDefinition>();
+      }
+      if (node.type === AST_NODE_TYPES.ClassDeclaration) {
+        expectTypeOf(node).toMatchTypeOf<ESTree.ClassDeclaration>();
+      }
+    }
+
+    expect(narrow).toBeTypeOf("function");
+  });
+
+  it("exports common ESTree union aliases", () => {
+    function visitStatement<T extends ESTree.Statement>(statement: T): T {
+      return statement;
+    }
+    function visitExpression<T extends ESTree.Expression>(expression: T): T {
+      return expression;
+    }
+    function visitClassElement<T extends ESTree.ClassElement>(element: T): T {
+      return element;
+    }
+
+    expectTypeOf<ESTree.Class>().toMatchTypeOf<ESTree.ClassDeclaration | ESTree.ClassExpression>();
+    expectTypeOf<ESTree.Function>().toMatchTypeOf<
+      | ESTree.FunctionDeclaration
+      | ESTree.FunctionExpression
+      | ESTree.TSDeclareFunction
+      | ESTree.TSEmptyBodyFunctionExpression
+    >();
+    expectTypeOf<ESTree.ParamPattern>().toMatchTypeOf<
+      ESTree.FormalParameter | ESTree.TSParameterProperty | ESTree.FormalParameterRest
+    >();
+    expect(visitStatement).toBeTypeOf("function");
+    expect(visitExpression).toBeTypeOf("function");
+    expect(visitClassElement).toBeTypeOf("function");
+  });
+});

--- a/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 
 import { RuleTester as OxlintRuleTester } from "oxlint/plugins-dev";
 
@@ -17,6 +17,10 @@ export type RuleTesterConfig = TesterConfig & {
     readonly corsaOxlint?: CorsaOxlintSettings;
     readonly [key: string]: unknown;
   };
+};
+type TestLifecycleGlobal = typeof globalThis & {
+  after?: (callback: () => void) => unknown;
+  afterAll?: (callback: () => void) => unknown;
 };
 
 const cleanupDirs = new Set<string>();
@@ -66,20 +70,26 @@ export class RuleTester {
   }
 
   run(ruleName: string, rule: Record<string, unknown>, tests: TestCases): void {
+    const workspace = createWorkspace();
     const transformed = {
       valid: tests.valid.map((test, index) =>
-        prepareTestCase(createWorkspace(), test, this.#config, "valid", index),
+        prepareTestCase(workspace, test, this.#config, "valid", index),
       ),
       invalid: tests.invalid.map((test, index) =>
-        prepareTestCase(createWorkspace(), test, this.#config, "invalid", index),
+        prepareTestCase(workspace, test, this.#config, "invalid", index),
       ),
     };
-    this.#inner.run(ruleName, decorateRule(rule as never) as never, transformed as TestCases);
+    try {
+      this.#inner.run(ruleName, decorateRule(rule as never) as never, transformed as TestCases);
+    } finally {
+      cleanupWorkspace(workspace);
+    }
   }
 }
 
 function createWorkspace(): string {
-  const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-"));
+  const root = process.env.CORSA_OXLINT_RULE_TESTER_TMPDIR ?? tmpdir();
+  const workspace = mkdtempSync(join(root, "corsa-oxlint-"));
   registerCleanup(workspace);
   return workspace;
 }
@@ -91,12 +101,14 @@ function prepareTestCase(
   group: "valid" | "invalid",
   index: number,
 ): string | TestCase {
+  const caseWorkspace = resolve(workspace, `${group}-${index}`);
   if (typeof test === "string") {
-    const filename = resolve(workspace, `${group}-${index}.ts`);
+    const filename = resolve(caseWorkspace, "case.ts");
     writeFixture(filename, test);
     return test;
   }
-  const filename = resolve(workspace, test.filename ?? `${group}-${index}.ts`);
+  const filename = resolveCaseFilename(caseWorkspace, test.filename, "case.ts");
+  const projectRoot = isAbsolute(test.filename ?? "") ? dirname(filename) : caseWorkspace;
   writeFixture(filename, test.code);
   const testerConfig = config;
   const baseSettings = testerConfig?.settings?.corsaOxlint;
@@ -112,7 +124,7 @@ function prepareTestCase(
         mergeTypeAwareParserOptions(caseSettings, caseSettings?.parserOptions),
       ),
       {
-        tsconfigRootDir: workspace,
+        tsconfigRootDir: projectRoot,
         projectService: {
           allowDefaultProject: ["*.ts", "*.tsx", "*.js", "*.jsx"],
         },
@@ -144,6 +156,17 @@ function prepareTestCase(
       } as never,
     },
   };
+}
+
+function resolveCaseFilename(
+  caseWorkspace: string,
+  filename: string | undefined,
+  fallback: string,
+): string {
+  if (!filename) {
+    return resolve(caseWorkspace, fallback);
+  }
+  return isAbsolute(filename) ? filename : resolve(caseWorkspace, filename);
 }
 
 function applyRuleTesterRuntimeDefaults(
@@ -197,13 +220,36 @@ function writeFixture(filename: string, code: string): void {
 
 function registerCleanup(workspace: string): void {
   cleanupDirs.add(workspace);
+  const afterAll = lifecycleCleanup();
+  if (afterAll) {
+    afterAll(() => cleanupWorkspace(workspace));
+  }
   if (cleanupInstalled) {
     return;
   }
   cleanupInstalled = true;
-  process.on("exit", () => {
-    for (const dir of cleanupDirs) {
-      rmSync(dir, { force: true, recursive: true });
-    }
-  });
+  process.once("beforeExit", cleanupAllWorkspaces);
+  process.once("exit", cleanupAllWorkspaces);
+}
+
+function lifecycleCleanup(): ((callback: () => void) => unknown) | undefined {
+  const testGlobal = globalThis as TestLifecycleGlobal;
+  return typeof testGlobal.afterAll === "function"
+    ? testGlobal.afterAll
+    : typeof testGlobal.after === "function"
+      ? testGlobal.after
+      : undefined;
+}
+
+function cleanupWorkspace(workspace: string): void {
+  if (!cleanupDirs.delete(workspace)) {
+    return;
+  }
+  rmSync(workspace, { force: true, recursive: true });
+}
+
+function cleanupAllWorkspaces(): void {
+  for (const dir of cleanupDirs) {
+    cleanupWorkspace(dir);
+  }
 }

--- a/src/bindings/nodejs/corsa_oxlint/ts/rule_tester_cleanup.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rule_tester_cleanup.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { defineRule } from "./plugin";
+import { RuleTester } from "./rule_tester";
+
+describe("RuleTester cleanup", () => {
+  it("cleans up the workspace created for a run", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-cleanup-root-"));
+    const previousRoot = process.env.CORSA_OXLINT_RULE_TESTER_TMPDIR;
+    process.env.CORSA_OXLINT_RULE_TESTER_TMPDIR = tempRoot;
+    try {
+      const before = tempWorkspaces(tempRoot);
+      const rule = defineRule({
+        meta: {
+          type: "problem",
+          docs: {
+            description: "noop",
+          },
+          messages: {
+            demo: "demo",
+          },
+          schema: [],
+        },
+        create() {
+          return {};
+        },
+      });
+
+      new RuleTester().run("noop", rule, {
+        valid: ["const one = 1;", "const two = 2;"],
+        invalid: [],
+      });
+
+      expect(tempWorkspaces(tempRoot)).toEqual(before);
+    } finally {
+      if (previousRoot === undefined) {
+        delete process.env.CORSA_OXLINT_RULE_TESTER_TMPDIR;
+      } else {
+        process.env.CORSA_OXLINT_RULE_TESTER_TMPDIR = previousRoot;
+      }
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+});
+
+function tempWorkspaces(root: string): string[] {
+  return readdirSync(root)
+    .filter((name) => name.startsWith("corsa-oxlint-"))
+    .sort();
+}

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const clients: FakeClient[] = [];
+const clientSetups: ((client: FakeClient) => void)[] = [];
 
 class FakeClient {
   readonly initialize = vi.fn();
@@ -27,6 +28,10 @@ class FakeClient {
     }
     return undefined;
   });
+
+  constructor() {
+    clientSetups.shift()?.(this);
+  }
 }
 
 vi.mock("@corsa-bind/napi", () => ({
@@ -42,6 +47,10 @@ vi.mock("@corsa-bind/napi", () => ({
 const { CorsaProjectSession } = await import("./session");
 
 describe("CorsaProjectSession", () => {
+  beforeEach(() => {
+    clientSetups.length = 0;
+  });
+
   it("reuses the current snapshot when visiting a new unchanged file", () => {
     clients.length = 0;
     const runtime = {
@@ -203,5 +212,69 @@ describe("CorsaProjectSession", () => {
     });
 
     expect(session.typeToString(type as never)).toBe("Serializable");
+  });
+
+  it("restarts the client once when a type lookup sees a closed transport", () => {
+    clients.length = 0;
+    clientSetups.push((client) => {
+      client.getTypeAtPosition.mockImplementationOnce(() => {
+        throw new Error("process is closed: msgpack stdout");
+      });
+    });
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    const type = session.getTypeAtPosition("/tmp/one.ts", 0);
+
+    expect(type?.id).toBe("type-1");
+    expect(clients).toHaveLength(2);
+    expect(clients[0]?.close).toHaveBeenCalled();
+    expect(clients[1]?.updateSnapshot).toHaveBeenCalledTimes(1);
+    expect(clients[1]?.getTypeAtPosition).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses transport-close errors while closing the session", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+    session.getTypeAtPosition("/tmp/one.ts", 0);
+    const client = clients[0];
+    if (!client) {
+      throw new Error("expected a fake client");
+    }
+    client.releaseHandle.mockImplementationOnce(() => {
+      throw new Error("process is closed: msgpack stdin");
+    });
+    client.close.mockImplementationOnce(() => {
+      throw new Error("Broken pipe (os error 32)");
+    });
+
+    expect(() => session.close()).not.toThrow();
   });
 });

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -72,6 +72,7 @@ export class CorsaProjectSession {
   #lastRefreshMs = 0;
   #snapshotHasIssuedHandles = false;
   #supportsOverlayChanges?: boolean;
+  #fatalTransportError?: Error;
 
   constructor(
     readonly project: ResolvedProjectConfig,
@@ -80,10 +81,10 @@ export class CorsaProjectSession {
 
   close(): void {
     if (this.#snapshot) {
-      this.#client?.releaseHandle(this.#snapshot);
+      this.tryReleaseHandle(this.#snapshot);
       this.#snapshot = undefined;
     }
-    this.#client?.close();
+    this.tryCloseClient();
     this.#client = undefined;
     this.#supportsOverlayChanges = undefined;
     this.#files.clear();
@@ -92,14 +93,25 @@ export class CorsaProjectSession {
   }
 
   getCompilerOptions(): unknown {
-    return this.config().options;
+    return this.withTransportRecovery(() => this.config().options, "reading compiler options");
   }
 
   getRootFileNames(): readonly string[] {
-    return this.config().fileNames;
+    return this.withTransportRecovery(() => this.config().fileNames, "reading root file names");
   }
 
   getTypeAtPosition(
+    fileName: string,
+    position: number,
+    sourceText?: string,
+  ): CorsaType | undefined {
+    return this.withTransportRecovery(
+      () => this.getTypeAtPositionUnchecked(fileName, position, sourceText),
+      "looking up a type",
+    );
+  }
+
+  private getTypeAtPositionUnchecked(
     fileName: string,
     position: number,
     sourceText?: string,
@@ -127,8 +139,21 @@ export class CorsaProjectSession {
     sourceText: string | undefined,
     kind: string | undefined,
   ): CorsaType | undefined {
+    return this.withTransportRecovery(
+      () => this.getTypeAtSourceRangeUnchecked(fileName, start, end, sourceText, kind),
+      "looking up a type",
+    );
+  }
+
+  private getTypeAtSourceRangeUnchecked(
+    fileName: string,
+    start: number,
+    end: number,
+    sourceText: string | undefined,
+    kind: string | undefined,
+  ): CorsaType | undefined {
     if (!sourceText || end <= start) {
-      return this.getTypeAtPosition(fileName, start, sourceText);
+      return this.getTypeAtPositionUnchecked(fileName, start, sourceText);
     }
     const state = this.fileState(fileName, sourceText);
     const key = `${start}:${end}:${kind ?? ""}`;
@@ -157,6 +182,17 @@ export class CorsaProjectSession {
   }
 
   getSymbolAtPosition(
+    fileName: string,
+    position: number,
+    sourceText?: string,
+  ): CorsaSymbol | undefined {
+    return this.withTransportRecovery(
+      () => this.getSymbolAtPositionUnchecked(fileName, position, sourceText),
+      "looking up a symbol",
+    );
+  }
+
+  private getSymbolAtPositionUnchecked(
     fileName: string,
     position: number,
     sourceText?: string,
@@ -697,6 +733,67 @@ export class CorsaProjectSession {
     return readFileOrUndefined(path) ?? readFileOrUndefined(`${this.runtime.cwd}/${path}`);
   }
 
+  private withTransportRecovery<T>(operation: () => T, action: string): T {
+    if (this.#fatalTransportError) {
+      throw this.#fatalTransportError;
+    }
+    try {
+      return operation();
+    } catch (error) {
+      if (!isRecoverableTransportError(error)) {
+        throw error;
+      }
+      this.resetClientAfterTransportFailure();
+      try {
+        return operation();
+      } catch (retryError) {
+        if (!isRecoverableTransportError(retryError)) {
+          throw retryError;
+        }
+        const fatal = new Error(
+          `corsa type-aware backend exited while ${action}; restarted the session, but the retry failed`,
+        );
+        (fatal as Error & { cause?: unknown }).cause = retryError;
+        this.#fatalTransportError = fatal;
+        throw fatal;
+      }
+    }
+  }
+
+  private resetClientAfterTransportFailure(): void {
+    this.tryCloseClient();
+    this.#client = undefined;
+    this.#config = undefined;
+    this.#snapshot = undefined;
+    this.#projects = [];
+    this.#files.clear();
+    this.clearHandleCaches();
+    this.#typeTextById.clear();
+    this.#lastRefreshMs = 0;
+    this.#supportsOverlayChanges = undefined;
+    this.#fatalTransportError = undefined;
+  }
+
+  private tryReleaseHandle(handle: string): void {
+    try {
+      this.#client?.releaseHandle(handle);
+    } catch (error) {
+      if (!isRecoverableTransportError(error)) {
+        throw error;
+      }
+    }
+  }
+
+  private tryCloseClient(): void {
+    try {
+      this.#client?.close();
+    } catch (error) {
+      if (!isRecoverableTransportError(error)) {
+        throw error;
+      }
+    }
+  }
+
   private client(): CorsaApiClient {
     if (!this.#client) {
       this.#client = CorsaApiClient.spawn({
@@ -778,7 +875,7 @@ export class CorsaProjectSession {
     this.#files.clear();
     this.clearHandleCaches();
     if (previous && previous !== this.#snapshot) {
-      this.client().releaseHandle(previous);
+      this.tryReleaseHandle(previous);
     }
     return prepared;
   }
@@ -910,6 +1007,26 @@ function parseNodeHandle(value: string): CorsaNode | undefined {
     return undefined;
   }
   return { id: value, fileName, pos, end, range: [pos, end] };
+}
+
+function isRecoverableTransportError(error: unknown): boolean {
+  const message = errorMessage(error);
+  return (
+    message.includes("process is closed:") ||
+    message.includes("Broken pipe") ||
+    message.includes("EPIPE") ||
+    message.includes("failed to fill whole buffer") ||
+    message.includes("msgpack worker") ||
+    message.includes("msgpack stdin") ||
+    message.includes("msgpack stdout") ||
+    message.includes("jsonrpc reader") ||
+    message.includes("jsonrpc writer") ||
+    message.includes("jsonrpc connection")
+  );
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function readFileOrUndefined(path: string): string | undefined {

--- a/src/core/corsa_client/src/api/msgpack_codec.rs
+++ b/src/core/corsa_client/src/api/msgpack_codec.rs
@@ -1,6 +1,6 @@
 use crate::{CorsaError, Result};
 use corsa_core::fast::compact_format;
-use std::io::{Read, Write};
+use std::io::{ErrorKind, Read, Write};
 
 pub(crate) const MSG_REQUEST: u8 = 1;
 pub(crate) const MSG_CALL_RESPONSE: u8 = 2;
@@ -19,7 +19,7 @@ pub(crate) struct MsgpackTuple {
 
 pub(crate) fn read_tuple<R: Read>(reader: &mut R) -> Result<MsgpackTuple> {
     let mut tag = [0_u8; 1];
-    reader.read_exact(&mut tag)?;
+    read_exact(reader, &mut tag)?;
     if tag[0] != 0x93 {
         return Err(CorsaError::Protocol(compact_format(format_args!(
             "expected tuple marker, got {:x}",
@@ -42,16 +42,16 @@ pub(crate) fn write_tuple<W: Write>(
     method: &[u8],
     payload: &[u8],
 ) -> Result<()> {
-    writer.write_all(&[0x93, kind])?;
+    write_all(writer, &[0x93, kind])?;
     write_bin(writer, method)?;
     write_bin(writer, payload)?;
-    writer.flush()?;
+    flush(writer)?;
     Ok(())
 }
 
 fn read_int<R: Read>(reader: &mut R) -> Result<u8> {
     let mut buf = [0_u8; 1];
-    reader.read_exact(&mut buf)?;
+    read_exact(reader, &mut buf)?;
     if buf[0] <= 0x7f {
         return Ok(buf[0]);
     }
@@ -61,13 +61,13 @@ fn read_int<R: Read>(reader: &mut R) -> Result<u8> {
             buf[0]
         ))));
     }
-    reader.read_exact(&mut buf)?;
+    read_exact(reader, &mut buf)?;
     Ok(buf[0])
 }
 
 fn read_bin<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
     let mut tag = [0_u8; 1];
-    reader.read_exact(&mut tag)?;
+    read_exact(reader, &mut tag)?;
     let len = match tag[0] {
         0xc4 => read_len::<1, _>(reader)?,
         0xc5 => read_len::<2, _>(reader)?,
@@ -91,7 +91,7 @@ fn read_bin<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
         )))
     })?;
     buf.resize(len, 0);
-    reader.read_exact(&mut buf)?;
+    read_exact(reader, &mut buf)?;
     Ok(buf)
 }
 
@@ -99,17 +99,17 @@ fn read_len<const N: usize, R: Read>(reader: &mut R) -> Result<usize> {
     match N {
         1 => {
             let mut buf = [0_u8; 1];
-            reader.read_exact(&mut buf)?;
+            read_exact(reader, &mut buf)?;
             Ok(buf[0] as usize)
         }
         2 => {
             let mut buf = [0_u8; 2];
-            reader.read_exact(&mut buf)?;
+            read_exact(reader, &mut buf)?;
             Ok(u16::from_be_bytes(buf) as usize)
         }
         4 => {
             let mut buf = [0_u8; 4];
-            reader.read_exact(&mut buf)?;
+            read_exact(reader, &mut buf)?;
             Ok(u32::from_be_bytes(buf) as usize)
         }
         _ => Err(CorsaError::Protocol(compact_format(format_args!(
@@ -126,18 +126,40 @@ fn write_bin<W: Write>(writer: &mut W, bytes: &[u8]) -> Result<()> {
         ))));
     }
     match bytes.len() {
-        0..=255 => writer.write_all(&[0xc4, bytes.len() as u8])?,
+        0..=255 => write_all(writer, &[0xc4, bytes.len() as u8])?,
         256..=65535 => {
-            writer.write_all(&[0xc5])?;
-            writer.write_all(&(bytes.len() as u16).to_be_bytes())?;
+            write_all(writer, &[0xc5])?;
+            write_all(writer, &(bytes.len() as u16).to_be_bytes())?;
         }
         _ => {
-            writer.write_all(&[0xc6])?;
-            writer.write_all(&(bytes.len() as u32).to_be_bytes())?;
+            write_all(writer, &[0xc6])?;
+            write_all(writer, &(bytes.len() as u32).to_be_bytes())?;
         }
     }
-    writer.write_all(bytes)?;
+    write_all(writer, bytes)?;
     Ok(())
+}
+
+fn read_exact<R: Read>(reader: &mut R, buf: &mut [u8]) -> Result<()> {
+    reader.read_exact(buf).map_err(|error| match error.kind() {
+        ErrorKind::UnexpectedEof => CorsaError::Closed("msgpack stdout"),
+        _ => CorsaError::Io(error),
+    })
+}
+
+fn write_all<W: Write>(writer: &mut W, buf: &[u8]) -> Result<()> {
+    writer.write_all(buf).map_err(map_write_error)
+}
+
+fn flush<W: Write>(writer: &mut W) -> Result<()> {
+    writer.flush().map_err(map_write_error)
+}
+
+fn map_write_error(error: std::io::Error) -> CorsaError {
+    match error.kind() {
+        ErrorKind::BrokenPipe | ErrorKind::ConnectionReset => CorsaError::Closed("msgpack stdin"),
+        _ => CorsaError::Io(error),
+    }
 }
 
 #[cfg(test)]

--- a/src/core/corsa_client/src/api/msgpack_codec_tests.rs
+++ b/src/core/corsa_client/src/api/msgpack_codec_tests.rs
@@ -67,6 +67,12 @@ fn rejects_oversized_bin_length_before_allocation() {
 }
 
 #[test]
+fn treats_truncated_tuple_as_closed_stdout() {
+    let err = read_tuple(&mut Cursor::new([])).unwrap_err();
+    assert!(matches!(err, CorsaError::Closed("msgpack stdout")));
+}
+
+#[test]
 fn write_tuple_selects_bin_threshold_markers() {
     let mut bin8 = Vec::new();
     write_tuple(&mut bin8, MSG_CALL, &[b'a'; 255], b"").unwrap();

--- a/src/core/corsa_core/src/lint/host_facts.rs
+++ b/src/core/corsa_core/src/lint/host_facts.rs
@@ -39,6 +39,9 @@ fn apply_ancestor_facts(node: &mut LintNode) {
                 "__nearestFunctionAsync",
                 json!(async_value),
             );
+            if node.kind == "ReturnStatement" && async_value {
+                insert_if_absent(&mut node.fields, "__inAsyncScope", json!(true));
+            }
         }
     }
 

--- a/src/core/corsa_core/src/lint/rules/no_duplicate_type_constituents.rs
+++ b/src/core/corsa_core/src/lint/rules/no_duplicate_type_constituents.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeSet;
 
+use serde_json::Value;
+
 use super::super::{LintFix, LintNode, LintSuggestion, RuleContext, RuleMessage, RustLintRule};
 use crate::lint::helpers::{child_list, rule_option_bool};
 
@@ -201,6 +203,7 @@ fn resolved_type_id(node: &LintNode) -> Option<String> {
     node.field_str("__resolvedTypeId")
         .filter(|id| !id.is_empty())
         .map(str::to_owned)
+        .or_else(|| syntax_type_id(node))
 }
 
 /// Reads whether the constituent's resolved type has the `undefined` type flag.
@@ -209,7 +212,77 @@ fn resolved_type_id(node: &LintNode) -> Option<String> {
 /// `utils.isTypeFlagSet(checker.getTypeAtLocation(constituentNode),
 /// ts.TypeFlags.Undefined)`.
 fn is_undefined_type(node: &LintNode) -> bool {
-    node.field_bool("__isUndefinedType").unwrap_or(false)
+    node.field_bool("__isUndefinedType").unwrap_or(false) || node.kind == "TSUndefinedKeyword"
+}
+
+fn syntax_type_id(node: &LintNode) -> Option<String> {
+    let node = skip_type_parentheses(node);
+    if let Some(keyword) = keyword_type_id(node.kind.as_str()) {
+        return Some(keyword.to_owned());
+    }
+    if node.kind == "TSLiteralType" {
+        return literal_type_id(node);
+    }
+    if node.kind == "TSTemplateLiteralType" {
+        return node
+            .text
+            .as_deref()
+            .filter(|text| !text.is_empty())
+            .map(|text| format!("template:{text}"));
+    }
+    None
+}
+
+fn keyword_type_id(kind: &str) -> Option<&'static str> {
+    match kind {
+        "TSAnyKeyword" => Some("keyword:any"),
+        "TSBigIntKeyword" => Some("keyword:bigint"),
+        "TSBooleanKeyword" => Some("keyword:boolean"),
+        "TSNeverKeyword" => Some("keyword:never"),
+        "TSNullKeyword" => Some("keyword:null"),
+        "TSNumberKeyword" => Some("keyword:number"),
+        "TSObjectKeyword" => Some("keyword:object"),
+        "TSStringKeyword" => Some("keyword:string"),
+        "TSSymbolKeyword" => Some("keyword:symbol"),
+        "TSUndefinedKeyword" => Some("keyword:undefined"),
+        "TSUnknownKeyword" => Some("keyword:unknown"),
+        "TSVoidKeyword" => Some("keyword:void"),
+        _ => None,
+    }
+}
+
+fn literal_type_id(node: &LintNode) -> Option<String> {
+    let Some(literal) = node.child("literal") else {
+        return node
+            .text
+            .as_deref()
+            .filter(|text| !text.is_empty())
+            .map(|text| format!("literal:{text}"));
+    };
+    if literal.kind == "TemplateLiteral" || literal.kind == "TSTemplateLiteralType" {
+        return literal
+            .text
+            .as_deref()
+            .filter(|text| !text.is_empty())
+            .map(|text| format!("template:{text}"));
+    }
+    match literal.kind.as_str() {
+        "Literal" => match literal.fields.get("value") {
+            Some(Value::Bool(value)) => Some(format!("literal:bool:{value}")),
+            Some(Value::Number(value)) => Some(format!("literal:number:{value}")),
+            Some(Value::String(value)) => Some(format!("literal:string:{value}")),
+            _ => literal
+                .field_str("bigint")
+                .map(|bigint| format!("literal:bigint:{bigint}")),
+        },
+        "TSTrueKeyword" => Some("literal:bool:true".to_owned()),
+        "TSFalseKeyword" => Some("literal:bool:false".to_owned()),
+        _ => node
+            .text
+            .as_deref()
+            .filter(|text| !text.is_empty())
+            .map(|text| format!("literal:{text}")),
+    }
 }
 
 fn report(ctx: &mut RuleContext<'_>, constituent: &LintNode) {
@@ -280,6 +353,29 @@ mod tests {
         assert_eq!(diagnostics[0].message_id, "duplicate");
         assert_eq!(diagnostics[0].range.start, 13);
         assert_eq!(diagnostics[0].range.end, 14);
+    }
+
+    // `type T = string | string;` -> reports duplicate even when the host does
+    // not provide checker-backed type ids for syntax-only keyword nodes.
+    #[test]
+    fn reports_duplicate_primitive_keyword_without_checker_fact() {
+        let node: LintNode = serde_json::from_value(json!({
+            "kind": "TSUnionType",
+            "range": { "start": 9, "end": 24 },
+            "childLists": {
+                "types": [
+                    { "kind": "TSStringKeyword", "range": { "start": 9, "end": 15 } },
+                    { "kind": "TSStringKeyword", "range": { "start": 18, "end": 24 } }
+                ]
+            }
+        }))
+        .unwrap();
+
+        let diagnostics = run(&node);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].message_id, "duplicate");
+        assert_eq!(diagnostics[0].range.start, 18);
+        assert_eq!(diagnostics[0].range.end, 24);
     }
 
     // `type T = true & true;` -> reports duplicate on intersection.

--- a/src/core/corsa_core/src/lint/rules/no_unnecessary_type_conversion.rs
+++ b/src/core/corsa_core/src/lint/rules/no_unnecessary_type_conversion.rs
@@ -370,9 +370,10 @@ fn report_builtin_conversion_call(ctx: &mut RuleContext<'_>, node: &LintNode) {
         _ => return,
     };
 
-    // The callee must resolve to the global builtin, not a shadowing local. The
-    // host computes this via `IsBuiltinSymbolLike` and reports `__calleeIsGlobalBuiltin`.
-    if node.field_bool("__calleeIsGlobalBuiltin") != Some(true) {
+    // The host may explicitly mark a shadowing local. When no symbol fact is
+    // available, keep linting the known global constructor names instead of
+    // silently dropping syntax-only cases like `String('value')`.
+    if node.field_bool("__calleeIsGlobalBuiltin") == Some(false) {
         return;
     }
 
@@ -709,6 +710,35 @@ mod tests {
             }
         }));
         assert!(run(&node).is_empty());
+    }
+
+    #[test]
+    fn reports_string_call_when_builtin_fact_is_absent() {
+        let node = from(json!({
+            "kind": "CallExpression",
+            "range": { "start": 0, "end": 14 },
+            "children": {
+                "callee": {
+                    "kind": "Identifier",
+                    "range": { "start": 0, "end": 6 },
+                    "fields": { "name": "String" },
+                    "text": "String"
+                }
+            },
+            "childLists": {
+                "arguments": [
+                    {
+                        "kind": "Literal",
+                        "range": { "start": 7, "end": 13 },
+                        "typeTexts": ["string"],
+                        "text": "'asdf'"
+                    }
+                ]
+            }
+        }));
+        let diags = run(&node);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].message_id, "unnecessaryTypeConversion");
     }
 
     #[test]

--- a/src/core/corsa_core/src/lint/rules/return_await.rs
+++ b/src/core/corsa_core/src/lint/rules/return_await.rs
@@ -1,5 +1,7 @@
 use super::super::{LintFix, LintNode, LintSuggestion, RuleContext, RuleMessage, RustLintRule};
-use crate::lint::helpers::strip_chain_expression;
+use crate::lint::helpers::{
+    is_obviously_promise_like, is_promise_like_node, strip_chain_expression,
+};
 
 /// Type-aware rule that enforces consistent use of `return await` based on the
 /// configured option and whether the awaited value affects error handling.
@@ -146,7 +148,13 @@ impl RustLintRule for ReturnAwaitRule {
                 let Some(argument) = node.child("argument") else {
                     return;
                 };
-                test_each_possibly_returned_node(ctx, argument, option);
+                test_each_possibly_returned_node(
+                    ctx,
+                    argument,
+                    option,
+                    node.field_bool("__returnAwaitRequiresAwait")
+                        .unwrap_or(false),
+                );
             }
             "ArrowFunctionExpression" => {
                 // Only concise-body (non-block) async arrow functions return a
@@ -160,7 +168,7 @@ impl RustLintRule for ReturnAwaitRule {
                 if body.kind == "BlockStatement" {
                     return;
                 }
-                test_each_possibly_returned_node(ctx, body, option);
+                test_each_possibly_returned_node(ctx, body, option, false);
             }
             _ => {}
         }
@@ -183,22 +191,28 @@ fn test_each_possibly_returned_node(
     ctx: &mut RuleContext<'_>,
     node: &LintNode,
     option: ReturnAwaitOption,
+    affects_error_handling: bool,
 ) {
     let node = strip_chain_expression(node);
     if node.kind == "ConditionalExpression" {
         if let Some(when_false) = node.child("alternate") {
-            test_each_possibly_returned_node(ctx, when_false, option);
+            test_each_possibly_returned_node(ctx, when_false, option, affects_error_handling);
         }
         if let Some(when_true) = node.child("consequent") {
-            test_each_possibly_returned_node(ctx, when_true, option);
+            test_each_possibly_returned_node(ctx, when_true, option, affects_error_handling);
         }
     } else {
-        test(ctx, node, option);
+        test(ctx, node, option, affects_error_handling);
     }
 }
 
 /// Mirror of the Go `test` closure.
-fn test(ctx: &mut RuleContext<'_>, node: &LintNode, option: ReturnAwaitOption) {
+fn test(
+    ctx: &mut RuleContext<'_>,
+    node: &LintNode,
+    option: ReturnAwaitOption,
+    affects_error_handling: bool,
+) {
     let is_await = node.kind == "AwaitExpression";
 
     // `child` is the value whose type matters: the awaited operand for an await
@@ -209,7 +223,7 @@ fn test(ctx: &mut RuleContext<'_>, node: &LintNode, option: ReturnAwaitOption) {
         node
     };
 
-    let certainty = AwaitableCertainty::parse(value_node.field_str("__awaitableCertainty"));
+    let certainty = awaitable_certainty(value_node);
 
     if certainty != AwaitableCertainty::Always {
         if is_await {
@@ -227,7 +241,9 @@ fn test(ctx: &mut RuleContext<'_>, node: &LintNode, option: ReturnAwaitOption) {
     }
 
     // At this point the value is definitely a thenable.
-    let affects_error_handling = node.field_bool("__affectsErrorHandling").unwrap_or(false);
+    let affects_error_handling = node
+        .field_bool("__affectsErrorHandling")
+        .unwrap_or(affects_error_handling);
     let use_auto_fix = !affects_error_handling;
 
     match get_whether_to_await(affects_error_handling, option) {
@@ -245,6 +261,19 @@ fn test(ctx: &mut RuleContext<'_>, node: &LintNode, option: ReturnAwaitOption) {
             report_disallowed(ctx, node, use_auto_fix);
         }
     }
+}
+
+fn awaitable_certainty(node: &LintNode) -> AwaitableCertainty {
+    if let Some(certainty) = node.field_str("__awaitableCertainty") {
+        return AwaitableCertainty::parse(Some(certainty));
+    }
+    if is_obviously_promise_like(node) || is_promise_like_node(node) {
+        return AwaitableCertainty::Always;
+    }
+    if node.type_texts.is_empty() && node.property_names.is_empty() {
+        return AwaitableCertainty::May;
+    }
+    AwaitableCertainty::Never
 }
 
 /// Emits the `requiredPromiseAwait` diagnostic, inserting `await` before `node`.
@@ -371,6 +400,32 @@ mod tests {
         })
     }
 
+    fn promise_resolve_value(start: u32, end: u32) -> serde_json::Value {
+        json!({
+            "kind": "CallExpression",
+            "range": { "start": start, "end": end },
+            "fields": { "__isHigherPrecedenceThanAwait": true },
+            "children": {
+                "callee": {
+                    "kind": "MemberExpression",
+                    "range": { "start": start, "end": start + 15 },
+                    "children": {
+                        "object": {
+                            "kind": "Identifier",
+                            "range": { "start": start, "end": start + 7 },
+                            "fields": { "name": "Promise" }
+                        },
+                        "property": {
+                            "kind": "Identifier",
+                            "range": { "start": start + 8, "end": start + 15 },
+                            "fields": { "name": "resolve" }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
     fn await_promise(start: u32, end: u32, affects_error_handling: bool) -> serde_json::Value {
         json!({
             "kind": "AwaitExpression",
@@ -448,12 +503,39 @@ mod tests {
     }
 
     #[test]
+    fn uses_return_statement_error_handling_context() {
+        // Host facts attach try/catch context to the return statement; the Rust
+        // rule carries that context to the returned promise expression.
+        let mut node = return_stmt(promise_value(7, 33), None);
+        node.fields
+            .insert("__returnAwaitRequiresAwait".to_owned(), json!(true));
+        let diagnostics = run(&node);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].message_id, "requiredPromiseAwait");
+    }
+
+    #[test]
     fn allows_bare_promise_in_default_outside_try() {
         // `return Promise.resolve(1)` at top level of async fn, default option,
         // not in try/catch => NoAwait but it isn't an await, so no report.
         let node = return_stmt(promise_value(7, 33), None);
         let diagnostics = run(&node);
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn treats_obvious_promise_call_as_awaitable_without_checker_fact() {
+        let await_node = json!({
+            "kind": "AwaitExpression",
+            "range": { "start": 7, "end": 33 },
+            "children": {
+                "argument": promise_resolve_value(13, 33),
+            },
+        });
+        let node = return_stmt(await_node, None);
+        let diagnostics = run(&node);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].message_id, "disallowedPromiseAwait");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix @corsa-bind/napi binary/source-file public types to use Uint8Array.
- Expose RuleDocs.requiresTypeChecking and improve ESTree.Node narrowing/union aliases.
- Move oxlint packages to peer dependencies and harden RuleTester cleanup.
- Recover from closed tsgo transports and normalize msgpack closed-pipe errors.

Closes #330
Closes #331
Closes #333
Closes #334
Closes #335
Closes #336

## Validation
- pnpm exec vp run -w test
- pnpm exec vp run -w build_corsa_oxlint_ci
- pnpm exec tsc --noEmit
- cargo test -p corsa_core --lib
- cargo test -p corsa_client msgpack_codec
- pnpm exec vp check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->