### PR TITLE
fix(corsa-oxlint): share the RuleTester default project

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -745,6 +745,56 @@ describe("corsa oxlint", () => {
       ],
     });
   });
+
+  integrationCase("keeps type-aware RuleTester cases in the shared default project", () => {
+    const rule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`)({
+      name: "class-type-probe",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise getTypeAtLocation inside RuleTester",
+          recommended: "recommended",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          fired: "type-aware probe fired",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        return {
+          ClassDeclaration(node: any) {
+            services.getTypeAtLocation(node);
+            context.report({ node, messageId: "fired" });
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester({
+      settings: {
+        corsaOxlint: {
+          parserOptions: {
+            corsa: {
+              executable: realCorsaBinary,
+            },
+          },
+        },
+      },
+    });
+
+    tester.run("class-type-probe", rule as any, {
+      valid: ["const x = 1;"],
+      invalid: [
+        {
+          code: "class C {}",
+          errors: [{ messageId: "fired" }],
+        },
+      ],
+    });
+  });
 });
 
 function createNativePreviewPackage(): string {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
@@ -132,7 +132,11 @@ function prepareTestCase(
       normalized.languageOptions?.parserOptions as TypeAwareParserOptions | undefined,
     ),
   );
-  const parserOptionsWithRuntime = applyRuleTesterRuntimeDefaults(parserOptions, normalized, config);
+  const parserOptionsWithRuntime = applyRuleTesterRuntimeDefaults(
+    parserOptions,
+    normalized,
+    config,
+  );
   return {
     ...normalized,
     filename,

--- a/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
@@ -71,6 +71,7 @@ export class RuleTester {
 
   run(ruleName: string, rule: Record<string, unknown>, tests: TestCases): void {
     const workspace = createWorkspace();
+    writeWorkspaceConfig(workspace);
     const transformed = {
       valid: tests.valid.map((test, index) =>
         prepareTestCase(workspace, test, this.#config, "valid", index),
@@ -100,20 +101,16 @@ function prepareTestCase(
   config: RuleTesterConfig | undefined,
   group: "valid" | "invalid",
   index: number,
-): string | TestCase {
+): TestCase {
   const caseWorkspace = resolve(workspace, `${group}-${index}`);
-  if (typeof test === "string") {
-    const filename = resolve(caseWorkspace, "case.ts");
-    writeFixture(filename, test);
-    return test;
-  }
-  const filename = resolveCaseFilename(caseWorkspace, test.filename, "case.ts");
-  const projectRoot = isAbsolute(test.filename ?? "") ? dirname(filename) : caseWorkspace;
-  writeFixture(filename, test.code);
+  const normalized = typeof test === "string" ? ({ code: test } as TestCase) : test;
+  const filename = resolveCaseFilename(caseWorkspace, normalized.filename, "case.ts");
+  const projectRoot = isAbsolute(normalized.filename ?? "") ? dirname(filename) : workspace;
+  writeFixture(filename, normalized.code, projectRoot);
   const testerConfig = config;
   const baseSettings = testerConfig?.settings?.corsaOxlint;
   const caseSettings = (
-    test.settings as {
+    normalized.settings as {
       corsaOxlint?: CorsaOxlintSettings;
     }
   )?.corsaOxlint;
@@ -132,25 +129,25 @@ function prepareTestCase(
     ),
     mergeTypeAwareParserOptions(
       config?.languageOptions?.parserOptions as TypeAwareParserOptions | undefined,
-      test.languageOptions?.parserOptions as TypeAwareParserOptions | undefined,
+      normalized.languageOptions?.parserOptions as TypeAwareParserOptions | undefined,
     ),
   );
-  const parserOptionsWithRuntime = applyRuleTesterRuntimeDefaults(parserOptions, test, config);
+  const parserOptionsWithRuntime = applyRuleTesterRuntimeDefaults(parserOptions, normalized, config);
   return {
-    ...test,
+    ...normalized,
     filename,
     settings: {
       ...testerConfig?.settings,
-      ...test.settings,
+      ...normalized.settings,
       corsaOxlint: {
         ...testerConfig?.settings?.corsaOxlint,
-        ...(test.settings as { corsaOxlint?: CorsaOxlintSettings })?.corsaOxlint,
+        ...(normalized.settings as { corsaOxlint?: CorsaOxlintSettings })?.corsaOxlint,
         parserOptions: parserOptionsWithRuntime,
       },
     } as never,
     languageOptions: {
       ...config?.languageOptions,
-      ...test.languageOptions,
+      ...normalized.languageOptions,
       parserOptions: {
         ...parserOptionsWithRuntime,
       } as never,
@@ -197,10 +194,18 @@ function optionalDefaultCorsaExecutable(rootDir: string): string | undefined {
   }
 }
 
-function writeFixture(filename: string, code: string): void {
+function writeWorkspaceConfig(workspace: string): void {
+  writeProjectConfig(resolve(workspace, "tsconfig.json"));
+}
+
+function writeFixture(filename: string, code: string, projectRoot: string): void {
   mkdirSync(dirname(filename), { recursive: true });
   writeFileSync(filename, code);
-  const configPath = resolve(dirname(filename), "tsconfig.json");
+  writeProjectConfig(resolve(projectRoot, "tsconfig.json"));
+}
+
+function writeProjectConfig(configPath: string): void {
+  mkdirSync(dirname(configPath), { recursive: true });
   writeFileSync(
     configPath,
     JSON.stringify(


### PR DESCRIPTION
## Summary
- move RuleTester temp fixtures onto one shared default project per run
- normalize shorthand valid cases through the same prepared test path
- add a regression test for type-aware RuleTester class probes

Closes #338

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->