### PR TITLE
fix(corsa-oxlint): defer RuleTester workspace cleanup

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
@@ -80,11 +80,7 @@ export class RuleTester {
         prepareTestCase(workspace, test, this.#config, "invalid", index),
       ),
     };
-    try {
-      this.#inner.run(ruleName, decorateRule(rule as never) as never, transformed as TestCases);
-    } finally {
-      cleanupWorkspace(workspace);
-    }
+    this.#inner.run(ruleName, decorateRule(rule as never) as never, transformed as TestCases);
   }
 }
 

--- a/src/bindings/nodejs/corsa_oxlint/ts/rule_tester_cleanup.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rule_tester_cleanup.test.ts
@@ -1,41 +1,96 @@
-import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { defineRule } from "./plugin";
-import { RuleTester } from "./rule_tester";
+const runCalls: Array<{
+  tests: {
+    valid: Array<{ filename?: string }>;
+    invalid: Array<{ filename?: string }>;
+  };
+}> = [];
+
+class FakeOxlintRuleTester {
+  static describe = vi.fn();
+  static it = vi.fn();
+  static only = vi.fn((item) => item);
+
+  run(
+    _ruleName: string,
+    _rule: Record<string, unknown>,
+    tests: {
+      valid: Array<{ filename?: string }>;
+      invalid: Array<{ filename?: string }>;
+    },
+  ): void {
+    runCalls.push({ tests });
+  }
+}
+
+vi.mock("oxlint/plugins-dev", () => ({
+  RuleTester: FakeOxlintRuleTester,
+}));
+
+vi.mock("./context", () => ({
+  defaultCorsaExecutable: vi.fn(() => "/tmp/corsa"),
+  mergeTypeAwareParserOptions: vi.fn(
+    (left: Record<string, unknown> | undefined, right: Record<string, unknown> | undefined) => ({
+      ...(left ?? {}),
+      ...(right ?? {}),
+    }),
+  ),
+}));
+
+vi.mock("./plugin", () => ({
+  decorateRule: vi.fn((rule: Record<string, unknown>) => rule),
+}));
+
+const { RuleTester } = await import("./rule_tester");
 
 describe("RuleTester cleanup", () => {
-  it("cleans up the workspace created for a run", () => {
+  beforeEach(() => {
+    runCalls.length = 0;
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the workspace alive until the lifecycle cleanup runs", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-cleanup-root-"));
     const previousRoot = process.env.CORSA_OXLINT_RULE_TESTER_TMPDIR;
+    const cleanupCallbacks: Array<() => void> = [];
     process.env.CORSA_OXLINT_RULE_TESTER_TMPDIR = tempRoot;
+    vi.stubGlobal(
+      "afterAll",
+      vi.fn((callback: () => void) => cleanupCallbacks.push(callback)),
+    );
     try {
-      const before = tempWorkspaces(tempRoot);
-      const rule = defineRule({
-        meta: {
-          type: "problem",
-          docs: {
-            description: "noop",
-          },
-          messages: {
-            demo: "demo",
-          },
-          schema: [],
+      new RuleTester().run(
+        "noop",
+        {},
+        {
+          valid: ["const one = 1;", "const two = 2;"],
+          invalid: [],
         },
-        create() {
-          return {};
-        },
-      });
+      );
 
-      new RuleTester().run("noop", rule, {
-        valid: ["const one = 1;", "const two = 2;"],
-        invalid: [],
-      });
+      expect(runCalls).toHaveLength(1);
+      expect(cleanupCallbacks).toHaveLength(1);
 
-      expect(tempWorkspaces(tempRoot)).toEqual(before);
+      const filename = runCalls[0]?.tests.valid[0]?.filename;
+      expect(filename).toBeDefined();
+
+      const workspace = resolve(dirname(filename ?? ""), "..");
+      expect(tempWorkspaces(tempRoot)).toHaveLength(1);
+      expect(existsSync(filename ?? "")).toBe(true);
+      expect(existsSync(join(workspace, "tsconfig.json"))).toBe(true);
+
+      cleanupCallbacks[0]?.();
+
+      expect(tempWorkspaces(tempRoot)).toEqual([]);
     } finally {
       if (previousRoot === undefined) {
         delete process.env.CORSA_OXLINT_RULE_TESTER_TMPDIR;


### PR DESCRIPTION
## Summary
- stop deleting the RuleTester workspace synchronously after `oxlint/plugins-dev` only registers deferred test callbacks
- keep the temp workspace alive until the existing lifecycle cleanup hook runs
- cover the lifecycle-based cleanup path with a focused regression test

## Why
`RuleTester#run` was removing the generated fixtures before Vitest executed the registered cases, which broke type-aware runs with `no project found for file ...case.ts`.

Closes #343.

## Validation
- `pnpm exec vitest run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/rule_tester_cleanup.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->