### PR TITLE
fix: support numeric native-preview handles

### DIFF
--- a/src/bindings/c/corsa_ffi/src/api_client.rs
+++ b/src/bindings/c/corsa_ffi/src/api_client.rs
@@ -652,7 +652,7 @@ pub unsafe extern "C" fn corsa_api_client_release_handle(
     match block_on(
         client
             .inner
-            .raw_json_request("release", json!({ "handle": handle })),
+            .raw_json_request("release", release_handle_params(handle.as_str())),
     ) {
         Ok(_) => {
             clear_last_error();
@@ -663,6 +663,23 @@ pub unsafe extern "C" fn corsa_api_client_release_handle(
             false
         }
     }
+}
+
+fn release_handle_params(handle: &str) -> serde_json::Value {
+    match parse_numeric_snapshot_handle(handle) {
+        Some(snapshot) => json!({ "handle": handle, "snapshot": snapshot }),
+        None => json!({ "handle": handle }),
+    }
+}
+
+fn parse_numeric_snapshot_handle(handle: &str) -> Option<u64> {
+    if handle.is_empty() || (handle.len() > 1 && handle.starts_with('0')) {
+        return None;
+    }
+    handle
+        .bytes()
+        .all(|byte| byte.is_ascii_digit())
+        .then(|| handle.parse().ok())?
 }
 
 #[unsafe(no_mangle)]

--- a/src/bindings/elixir/corsa_utils/native/corsa_elixir/src/lib.rs
+++ b/src/bindings/elixir/corsa_utils/native/corsa_elixir/src/lib.rs
@@ -610,11 +610,28 @@ fn api_client_release_handle(
         block_on(
             state
                 .inner
-                .raw_json_request("release", json!({ "handle": handle })),
+                .raw_json_request("release", release_handle_params(handle.as_str())),
         )
         .map_err(|error| Error::Term(Box::new(error.to_string())))?;
         Ok(atoms::ok())
     })
+}
+
+fn release_handle_params(handle: &str) -> serde_json::Value {
+    match parse_numeric_snapshot_handle(handle) {
+        Some(snapshot) => json!({ "handle": handle, "snapshot": snapshot }),
+        None => json!({ "handle": handle }),
+    }
+}
+
+fn parse_numeric_snapshot_handle(handle: &str) -> Option<u64> {
+    if handle.is_empty() || (handle.len() > 1 && handle.starts_with('0')) {
+        return None;
+    }
+    handle
+        .bytes()
+        .all(|byte| byte.is_ascii_digit())
+        .then(|| handle.parse().ok())?
 }
 
 #[rustler::nif(schedule = "DirtyIo")]

--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -558,7 +558,7 @@ impl Task for UnitApiTask {
                 {
                     return block_on(snapshot.release()).map_err(into_napi_error);
                 }
-                let params = serde_json::json!({ "handle": handle });
+                let params = release_handle_params(handle.as_str());
                 let _ = block_on(self.client.raw_json_request("release", params))
                     .map_err(into_napi_error)?;
                 Ok(())
@@ -1180,7 +1180,7 @@ impl CorsaApiClient {
         {
             return block_on(snapshot.release()).map_err(into_napi_error);
         }
-        let params = serde_json::json!({ "handle": handle });
+        let params = release_handle_params(handle.as_str());
         let _ =
             block_on(self.inner.raw_json_request("release", params)).map_err(into_napi_error)?;
         Ok(())
@@ -2637,6 +2637,23 @@ fn call_json_blocking(client: &ApiClient, method: &str, params: Option<Value>) -
     let response = block_on(client.raw_json_request(method, optional_value(params)))
         .map_err(into_napi_error)?;
     Ok(response)
+}
+
+fn release_handle_params(handle: &str) -> Value {
+    match parse_numeric_snapshot_handle(handle) {
+        Some(snapshot) => serde_json::json!({ "handle": handle, "snapshot": snapshot }),
+        None => serde_json::json!({ "handle": handle }),
+    }
+}
+
+fn parse_numeric_snapshot_handle(handle: &str) -> Option<u64> {
+    if handle.is_empty() || (handle.len() > 1 && handle.starts_with('0')) {
+        return None;
+    }
+    handle
+        .bytes()
+        .all(|byte| byte.is_ascii_digit())
+        .then(|| handle.parse().ok())?
 }
 
 #[cfg(test)]

--- a/src/core/corsa_client/src/api/client.rs
+++ b/src/core/corsa_client/src/api/client.rs
@@ -466,7 +466,7 @@ impl ApiClient {
         }
     }
 
-    pub(crate) async fn release_handle(&self, handle: &str) -> Result<()> {
+    pub(crate) async fn release_handle(&self, handle: &super::SnapshotHandle) -> Result<()> {
         self.driver
             .release_handle(handle, self.profiler.as_ref())
             .await?;

--- a/src/core/corsa_client/src/api/driver.rs
+++ b/src/core/corsa_client/src/api/driver.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 use std::{sync::Arc, time::Instant};
 
 use super::{
+    SnapshotHandle,
     msgpack_worker::MsgpackWorker,
     profiling::{ApiProfileEvent, ApiProfilePhase, SharedProfiler, profile},
     requests_core::ReleaseRequest,
@@ -39,7 +40,7 @@ impl ClientDriver {
             Self::JsonRpc { rpc, .. } => {
                 if let Some(profiler) = profiler {
                     let started = Instant::now();
-                    let params = serde_json::to_value(params)?;
+                    let params = serialize_api_params(params)?;
                     record_profile(
                         profiler,
                         method,
@@ -67,13 +68,16 @@ impl ClientDriver {
                     );
                     Ok(response)
                 } else {
-                    rpc.request(method, params).await
+                    let params = serialize_api_params(params)?;
+                    let value = rpc.request_value(method, params).await?;
+                    Ok(serde_json::from_value(value)?)
                 }
             }
             Self::Msgpack { worker } => {
                 let payload = if let Some(profiler) = profiler {
                     let started = Instant::now();
-                    let payload = serde_json::to_vec(params)?;
+                    let params = serialize_api_params(params)?;
+                    let payload = serde_json::to_vec(&params)?;
                     record_profile(
                         profiler,
                         method,
@@ -83,7 +87,8 @@ impl ClientDriver {
                     );
                     payload
                 } else {
-                    serde_json::to_vec(params)?
+                    let params = serialize_api_params(params)?;
+                    serde_json::to_vec(&params)?
                 };
                 let started = profiler.map(|_| Instant::now());
                 let response = worker.request(method, payload).await?;
@@ -129,7 +134,7 @@ impl ClientDriver {
             Self::JsonRpc { rpc, .. } => {
                 let params = if let Some(profiler) = profiler {
                     let started = Instant::now();
-                    let params = serde_json::to_value(params)?;
+                    let params = serialize_api_params(params)?;
                     record_profile(
                         profiler,
                         method,
@@ -139,7 +144,7 @@ impl ClientDriver {
                     );
                     params
                 } else {
-                    serde_json::to_value(params)?
+                    serialize_api_params(params)?
                 };
                 let started = profiler.map(|_| Instant::now());
                 let value = rpc.request_value(method, params).await?;
@@ -176,7 +181,8 @@ impl ClientDriver {
             Self::Msgpack { worker } => {
                 let payload = if let Some(profiler) = profiler {
                     let started = Instant::now();
-                    let payload = serde_json::to_vec(params)?;
+                    let params = serialize_api_params(params)?;
+                    let payload = serde_json::to_vec(&params)?;
                     record_profile(
                         profiler,
                         method,
@@ -186,7 +192,8 @@ impl ClientDriver {
                     );
                     payload
                 } else {
-                    serde_json::to_vec(params)?
+                    let params = serialize_api_params(params)?;
+                    serde_json::to_vec(&params)?
                 };
                 let started = profiler.map(|_| Instant::now());
                 let response = worker.request(method, payload).await?;
@@ -247,10 +254,13 @@ impl ClientDriver {
 
     pub(crate) async fn release_handle(
         &self,
-        handle: &str,
+        handle: &SnapshotHandle,
         profiler: Option<&SharedProfiler>,
     ) -> Result<()> {
-        let request = ReleaseRequest { handle };
+        let request = ReleaseRequest {
+            handle: handle.as_str(),
+            snapshot: handle,
+        };
         let _: Value = self.request_typed("release", &request, profiler).await?;
         Ok(())
     }
@@ -283,6 +293,68 @@ impl ClientDriver {
     }
 }
 
+fn serialize_api_params<P>(params: &P) -> Result<Value>
+where
+    P: Serialize + ?Sized,
+{
+    let mut value = serde_json::to_value(params)?;
+    encode_numeric_api_handles(&mut value);
+    Ok(value)
+}
+
+fn encode_numeric_api_handles(value: &mut Value) {
+    match value {
+        Value::Object(fields) => {
+            for (key, value) in fields {
+                if is_numeric_api_handle_field(key) {
+                    encode_numeric_api_handle_value(value);
+                } else {
+                    encode_numeric_api_handles(value);
+                }
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                encode_numeric_api_handles(value);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn encode_numeric_api_handle_value(value: &mut Value) {
+    match value {
+        Value::String(raw) => {
+            if let Some(number) = parse_numeric_api_handle(raw) {
+                *value = Value::Number(number.into());
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                encode_numeric_api_handle_value(value);
+            }
+        }
+        Value::Object(_) => encode_numeric_api_handles(value),
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+fn is_numeric_api_handle_field(key: &str) -> bool {
+    matches!(
+        key,
+        "snapshot" | "symbol" | "symbols" | "type" | "types" | "signature" | "signatures"
+    )
+}
+
+fn parse_numeric_api_handle(raw: &str) -> Option<u64> {
+    if raw.is_empty() || (raw.len() > 1 && raw.starts_with('0')) {
+        return None;
+    }
+    raw.bytes()
+        .all(|byte| byte.is_ascii_digit())
+        .then(|| raw.parse().ok())?
+}
+
 fn record_profile(
     profiler: &SharedProfiler,
     method: &str,
@@ -299,4 +371,68 @@ fn record_profile(
             duration,
         },
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::serialize_api_params;
+    use crate::api::{
+        NodeHandle, ProjectHandle, SignatureHandle, SnapshotHandle, SymbolHandle, TypeHandle,
+    };
+    use serde::Serialize;
+    use serde_json::json;
+
+    #[derive(Serialize)]
+    struct Params {
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        symbol: SymbolHandle,
+        symbols: Vec<SymbolHandle>,
+        #[serde(rename = "type")]
+        type_handle: TypeHandle,
+        signature: SignatureHandle,
+        location: NodeHandle,
+    }
+
+    #[test]
+    fn serializes_numeric_api_handles_as_numbers_for_wire_requests() {
+        let params = serialize_api_params(&Params {
+            snapshot: SnapshotHandle::from("1"),
+            project: ProjectHandle::from("project-1"),
+            symbol: SymbolHandle::from("2"),
+            symbols: vec![SymbolHandle::from("3")],
+            type_handle: TypeHandle::from("4"),
+            signature: SignatureHandle::from("5"),
+            location: NodeHandle::from("1.2.3./workspace/main.ts"),
+        })
+        .unwrap();
+
+        assert_eq!(params["snapshot"], json!(1));
+        assert_eq!(params["project"], json!("project-1"));
+        assert_eq!(params["symbol"], json!(2));
+        assert_eq!(params["symbols"], json!([3]));
+        assert_eq!(params["type"], json!(4));
+        assert_eq!(params["signature"], json!(5));
+        assert_eq!(params["location"], json!("1.2.3./workspace/main.ts"));
+    }
+
+    #[test]
+    fn leaves_non_numeric_api_handles_as_strings_for_wire_requests() {
+        let params = serialize_api_params(&Params {
+            snapshot: SnapshotHandle::from("snapshot-1"),
+            project: ProjectHandle::from("project-1"),
+            symbol: SymbolHandle::from("s0000000000000001"),
+            symbols: vec![SymbolHandle::from("s0000000000000002")],
+            type_handle: TypeHandle::from("t0000000000000001"),
+            signature: SignatureHandle::from("sig-1"),
+            location: NodeHandle::from("1.2.3./workspace/main.ts"),
+        })
+        .unwrap();
+
+        assert_eq!(params["snapshot"], json!("snapshot-1"));
+        assert_eq!(params["symbol"], json!("s0000000000000001"));
+        assert_eq!(params["symbols"], json!(["s0000000000000002"]));
+        assert_eq!(params["type"], json!("t0000000000000001"));
+        assert_eq!(params["signature"], json!("sig-1"));
+    }
 }

--- a/src/core/corsa_client/src/api/handles.rs
+++ b/src/core/corsa_client/src/api/handles.rs
@@ -1,6 +1,10 @@
 use crate::{CorsaError, Result};
 use corsa_core::fast::CompactString;
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize, Deserializer, Serialize,
+    de::{Unexpected, Visitor},
+};
+use std::fmt;
 
 macro_rules! handle_type {
     ($name:ident) => {
@@ -33,11 +37,100 @@ macro_rules! handle_type {
     };
 }
 
-handle_type!(SnapshotHandle);
+macro_rules! numeric_wire_handle_type {
+    ($name:ident) => {
+        /// Opaque handle returned by Corsa.
+        ///
+        /// Handles are lightweight string wrappers and can be passed back to
+        /// follow-up requests without parsing.
+        #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(pub CompactString);
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                deserialize_string_or_number_handle(deserializer).map(Self)
+            }
+        }
+
+        impl $name {
+            /// Returns the raw string representation of the handle.
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(value: String) -> Self {
+                Self(CompactString::from(value))
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(value: &str) -> Self {
+                Self(CompactString::from(value))
+            }
+        }
+    };
+}
+
+fn deserialize_string_or_number_handle<'de, D>(
+    deserializer: D,
+) -> std::result::Result<CompactString, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct HandleVisitor;
+
+    impl Visitor<'_> for HandleVisitor {
+        type Value = CompactString;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a string or non-negative integer handle")
+        }
+
+        fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(CompactString::from(value))
+        }
+
+        fn visit_string<E>(self, value: String) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(CompactString::from(value))
+        }
+
+        fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(CompactString::from(value.to_string()))
+        }
+
+        fn visit_i64<E>(self, value: i64) -> std::result::Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            let value = u64::try_from(value)
+                .map_err(|_| E::invalid_value(Unexpected::Signed(value), &self))?;
+            self.visit_u64(value)
+        }
+    }
+
+    deserializer.deserialize_any(HandleVisitor)
+}
+
+numeric_wire_handle_type!(SnapshotHandle);
 handle_type!(ProjectHandle);
-handle_type!(SymbolHandle);
-handle_type!(TypeHandle);
-handle_type!(SignatureHandle);
+numeric_wire_handle_type!(SymbolHandle);
+numeric_wire_handle_type!(TypeHandle);
+numeric_wire_handle_type!(SignatureHandle);
 handle_type!(NodeHandle);
 
 /// Parsed representation of a [`NodeHandle`].

--- a/src/core/corsa_client/src/api/handles_tests.rs
+++ b/src/core/corsa_client/src/api/handles_tests.rs
@@ -1,5 +1,48 @@
-use super::NodeHandle;
+use super::{NodeHandle, ProjectHandle, SignatureHandle, SnapshotHandle, SymbolHandle, TypeHandle};
 use crate::CorsaError;
+use serde_json::json;
+
+#[test]
+fn numeric_wire_handles_accept_integer_json() {
+    assert_eq!(
+        serde_json::from_value::<SnapshotHandle>(json!(1))
+            .unwrap()
+            .as_str(),
+        "1"
+    );
+    assert_eq!(
+        serde_json::from_value::<SymbolHandle>(json!(2))
+            .unwrap()
+            .as_str(),
+        "2"
+    );
+    assert_eq!(
+        serde_json::from_value::<TypeHandle>(json!(3))
+            .unwrap()
+            .as_str(),
+        "3"
+    );
+    assert_eq!(
+        serde_json::from_value::<SignatureHandle>(json!(4))
+            .unwrap()
+            .as_str(),
+        "4"
+    );
+}
+
+#[test]
+fn numeric_wire_handles_still_serialize_as_strings() {
+    assert_eq!(
+        serde_json::to_value(SnapshotHandle::from("1")).unwrap(),
+        json!("1")
+    );
+}
+
+#[test]
+fn string_only_handles_reject_integer_json() {
+    assert!(serde_json::from_value::<ProjectHandle>(json!(1)).is_err());
+    assert!(serde_json::from_value::<NodeHandle>(json!(1)).is_err());
+}
 
 #[test]
 fn parse_preserves_dots_in_path_segment() {

--- a/src/core/corsa_client/src/api/requests_core.rs
+++ b/src/core/corsa_client/src/api/requests_core.rs
@@ -26,6 +26,7 @@ pub(crate) struct ParseConfigFileRequest {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ReleaseRequest<'a> {
     pub handle: &'a str,
+    pub snapshot: &'a SnapshotHandle,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/src/core/corsa_client/src/api/snapshot.rs
+++ b/src/core/corsa_client/src/api/snapshot.rs
@@ -98,7 +98,7 @@ fn release_handle(
     profiler: Option<&SharedProfiler>,
     handle: SnapshotHandle,
 ) {
-    if let Err(error) = corsa_runtime::block_on(driver.release_handle(handle.as_str(), profiler)) {
+    if let Err(error) = corsa_runtime::block_on(driver.release_handle(&handle, profiler)) {
         warn!(
             "failed to release corsa snapshot `{}`: {error}",
             handle.as_str()
@@ -201,7 +201,7 @@ impl ManagedSnapshot {
         if self.released.swap(true, Ordering::SeqCst) {
             return Ok(());
         }
-        match self.client.release_handle(self.handle.as_str()).await {
+        match self.client.release_handle(&self.handle).await {
             Ok(()) => Ok(()),
             Err(error) => {
                 self.released.store(false, Ordering::SeqCst);


### PR DESCRIPTION
## Summary
- accept numeric snapshot, symbol, type, and signature handles returned by recent @typescript/native-preview builds
- encode numeric-looking API handle request fields as JSON numbers for typed calls
- send both legacy handle and current snapshot fields for explicit release fallbacks

Fixes #345

## Verification
- cargo fmt --all --check
- cargo test -p corsa_client
- CORSA_EXECUTABLE="$PWD/.cache/native-preview-20260614/node_modules/.bin/tsgo" cargo test -p corsa --no-default-features --test real_corsa_regression -- --nocapture
- cargo test -p corsa --test api_msgpack --test api_async
- cargo clippy -p corsa_client --all-targets -- -D warnings
- cargo check -p corsa_ffi -p corsa_node -p corsa_elixir

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->