### PR TITLE
fix: isolate RuleTester case projects

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -795,6 +795,87 @@ describe("corsa oxlint", () => {
       ],
     });
   });
+
+  integrationCase("isolates type-aware RuleTester cases from sibling declarations", () => {
+    const seen = new Map<string, string[]>();
+    const rule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`)({
+      name: "constructor-parameter-probe",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "record constructor parameter symbols per case",
+          recommended: "recommended",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          fired: "type-aware probe fired",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          NewExpression(node: any) {
+            const constructType = services.getTypeAtLocation(node.callee);
+            const signature = constructType
+              ? checker.getSignaturesOfType(constructType, 1)[0]
+              : undefined;
+            seen.set(
+              context.filename,
+              (signature?.parameterSymbols ?? []).map((symbol: any) => symbol.name),
+            );
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester({
+      settings: {
+        corsaOxlint: {
+          parserOptions: {
+            corsa: {
+              executable: realCorsaBinary,
+            },
+          },
+        },
+      },
+    });
+
+    tester.run("constructor-parameter-probe", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Base {}",
+            "class Foo extends Base {",
+            "  constructor(first: any, siblingParam: string) {",
+            "    super();",
+            "  }",
+            "}",
+            'new Foo("a", "b");',
+          ].join("\n"),
+        },
+        {
+          code: [
+            "class Base {}",
+            "class Foo extends Base {",
+            "  constructor(first: any, actualParam: string) {",
+            "    super();",
+            "  }",
+            "}",
+            'new Foo("a", "b");',
+          ].join("\n"),
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(Array.from(seen.values())).toEqual([
+      ["first", "siblingParam"],
+      ["first", "actualParam"],
+    ]);
+  });
 });
 
 function createNativePreviewPackage(): string {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
@@ -71,7 +71,6 @@ export class RuleTester {
 
   run(ruleName: string, rule: Record<string, unknown>, tests: TestCases): void {
     const workspace = createWorkspace();
-    writeWorkspaceConfig(workspace);
     const transformed = {
       valid: tests.valid.map((test, index) =>
         prepareTestCase(workspace, test, this.#config, "valid", index),
@@ -101,7 +100,7 @@ function prepareTestCase(
   const caseWorkspace = resolve(workspace, `${group}-${index}`);
   const normalized = typeof test === "string" ? ({ code: test } as TestCase) : test;
   const filename = resolveCaseFilename(caseWorkspace, normalized.filename, "case.ts");
-  const projectRoot = isAbsolute(normalized.filename ?? "") ? dirname(filename) : workspace;
+  const projectRoot = isAbsolute(normalized.filename ?? "") ? dirname(filename) : caseWorkspace;
   writeFixture(filename, normalized.code, projectRoot);
   const testerConfig = config;
   const baseSettings = testerConfig?.settings?.corsaOxlint;
@@ -192,10 +191,6 @@ function optionalDefaultCorsaExecutable(rootDir: string): string | undefined {
   } catch {
     return undefined;
   }
-}
-
-function writeWorkspaceConfig(workspace: string): void {
-  writeProjectConfig(resolve(workspace, "tsconfig.json"));
 }
 
 function writeFixture(filename: string, code: string, projectRoot: string): void {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rule_tester_cleanup.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rule_tester_cleanup.test.ts
@@ -83,10 +83,12 @@ describe("RuleTester cleanup", () => {
       const filename = runCalls[0]?.tests.valid[0]?.filename;
       expect(filename).toBeDefined();
 
-      const workspace = resolve(dirname(filename ?? ""), "..");
+      const caseWorkspace = dirname(filename ?? "");
+      const workspace = resolve(caseWorkspace, "..");
       expect(tempWorkspaces(tempRoot)).toHaveLength(1);
       expect(existsSync(filename ?? "")).toBe(true);
-      expect(existsSync(join(workspace, "tsconfig.json"))).toBe(true);
+      expect(existsSync(join(caseWorkspace, "tsconfig.json"))).toBe(true);
+      expect(existsSync(join(workspace, "tsconfig.json"))).toBe(false);
 
       cleanupCallbacks[0]?.();
 


### PR DESCRIPTION
## Summary
- isolate each `RuleTester` case in its own generated project root
- stop writing an unused workspace-level `tsconfig.json`
- add a regression test for sibling declaration leakage across type-aware cases

## Why
`RuleTester` was writing relative-path cases into one shared temporary project. That allowed sibling fixtures in the same `run()` to bleed declarations into each other, which could make type-aware lookups disagree with the CLI for the same source.

## Validation
- `pnpm exec vitest run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->