### PR TITLE
fix: preserve ESTree tuple ranges

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/index.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/index.ts
@@ -50,13 +50,13 @@ export namespace ESTree {
     ? BindingIdentifier
     : Value extends readonly [unknown, ...unknown[]]
       ? RemapTuple<Value>
-    : Value extends OxlintNode
-      ? NodeByType<Extract<Value["type"], string>>
-      : Value extends readonly (infer Item)[]
-        ? readonly RemapNodeField<Item>[]
-        : Value extends (infer Item)[]
-          ? RemapNodeField<Item>[]
-          : Value;
+      : Value extends OxlintNode
+        ? NodeByType<Extract<Value["type"], string>>
+        : Value extends readonly (infer Item)[]
+          ? readonly RemapNodeField<Item>[]
+          : Value extends (infer Item)[]
+            ? RemapNodeField<Item>[]
+            : Value;
   type RemapNodeShape<Candidate> = Candidate extends object
     ? {
         [Key in keyof Candidate]: RemapNodeField<Candidate[Key]>;

--- a/src/bindings/nodejs/corsa_oxlint/ts/index.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/index.ts
@@ -39,8 +39,17 @@ export namespace ESTree {
       ? Candidate & { readonly type: Kind }
       : never
     : never;
+  type RemapTuple<Value extends readonly unknown[]> = Value extends []
+    ? []
+    : Value extends [infer Head, ...infer Tail]
+      ? [RemapNodeField<Head>, ...RemapTuple<Tail>]
+      : Value extends readonly [infer Head, ...infer Tail]
+        ? readonly [RemapNodeField<Head>, ...RemapTuple<Tail>]
+        : never;
   type RemapNodeField<Value> = Value extends OxlintESTree.BindingIdentifier
     ? BindingIdentifier
+    : Value extends readonly [unknown, ...unknown[]]
+      ? RemapTuple<Value>
     : Value extends OxlintNode
       ? NodeByType<Extract<Value["type"], string>>
       : Value extends readonly (infer Item)[]

--- a/src/bindings/nodejs/corsa_oxlint/ts/public_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/public_types.test.ts
@@ -152,10 +152,7 @@ describe("corsa oxlint public types", () => {
       }
     }
 
-    function reportLiteral(
-      context: RuleContext<"x", readonly []>,
-      node: ESTree.Literal,
-    ): void {
+    function reportLiteral(context: RuleContext<"x", readonly []>, node: ESTree.Literal): void {
       acceptNode(node);
       acceptRange(node.range);
       context.report({ node, messageId: "x" });

--- a/src/bindings/nodejs/corsa_oxlint/ts/public_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/public_types.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 
-import { AST_NODE_TYPES, defineRule, OxlintUtils, type ESTree, type RuleDocs } from "./index";
+import {
+  AST_NODE_TYPES,
+  defineRule,
+  OxlintUtils,
+  type ESTree,
+  type RuleContext,
+  type RuleDocs,
+} from "./index";
 
 describe("corsa oxlint public types", () => {
   it("surfaces requiresTypeChecking on rule docs", () => {
@@ -124,5 +131,37 @@ describe("corsa oxlint public types", () => {
     expect(visitStatement).toBeTypeOf("function");
     expect(visitExpression).toBeTypeOf("function");
     expect(visitClassElement).toBeTypeOf("function");
+  });
+
+  it("keeps public ESTree nodes assignable to node and report helpers", () => {
+    function acceptNode(node: ESTree.Node): void {
+      void node;
+    }
+
+    function acceptRange(range: [number, number]): void {
+      void range;
+    }
+
+    function visitNestedNodes(
+      method: ESTree.MethodDefinition,
+      klass: ESTree.ClassDeclaration,
+    ): void {
+      acceptNode(method.value);
+      if (klass.superClass) {
+        acceptNode(klass.superClass);
+      }
+    }
+
+    function reportLiteral(
+      context: RuleContext<"x", readonly []>,
+      node: ESTree.Literal,
+    ): void {
+      acceptNode(node);
+      acceptRange(node.range);
+      context.report({ node, messageId: "x" });
+    }
+
+    expect(visitNestedNodes).toBeTypeOf("function");
+    expect(reportLiteral).toBeTypeOf("function");
   });
 });


### PR DESCRIPTION
## Summary
- preserve tuple fields when remapping public `ESTree` node shapes
- keep `range` compatible with Oxlint's mutable `Ranged.range`
- add a public type regression test covering nested node fields and `context.report({ node })`

## Why
Issue #353 reported that public `ESTree` nodes could fail `context.report({ node })` because tuple fields like `range` widened to `readonly number[]`. I could reproduce that regression locally. I could not reproduce the separate `MethodDefinition.value` and `ClassDeclaration.superClass` claims in a minimal `tsc --noEmit` repro, so this PR stays focused on the reproducible public type break.

## Validation
- `pnpm exec tsc -p tsconfig.json --noEmit`

Closes #353.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->