### PR TITLE
fix(corsa-oxlint): align defineRule visitors with public ESTree

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/oxlint_utils.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/oxlint_utils.ts
@@ -1,8 +1,6 @@
-import type { Visitor } from "@oxlint/plugins";
-
 import { getParserServices } from "./parser_services";
 import { decorateRule } from "./plugin";
-import type { Rule, RuleMetaWithMessages } from "./plugin";
+import type { Rule, RuleMetaWithMessages, Visitor } from "./plugin";
 import type { ContextWithParserOptions } from "./types";
 
 export type RuleCreatorRule<

--- a/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
@@ -9,6 +9,9 @@ import type {
 } from "./types";
 
 const parserServices = new WeakMap<object, ParserServices>();
+type ParserServicesContext = Omit<ContextWithParserOptions, "options"> & {
+  readonly options?: readonly unknown[];
+};
 
 /**
  * Returns type-aware parser services backed by Corsa.
@@ -20,32 +23,33 @@ const parserServices = new WeakMap<object, ParserServices>();
  * ```
  */
 export function getParserServices(
-  context: ContextWithParserOptions,
+  context: ParserServicesContext,
   allowWithoutFullTypeInformation = false,
 ): ParserServices {
   const current = parserServices.get(context);
   if (current) {
     return current;
   }
-  const parserOptions = resolveTypeAwareParserOptions(context);
-  const eslintParserServices = resolveEslintParserServices(context);
+  const typedContext = context as ContextWithParserOptions;
+  const parserOptions = resolveTypeAwareParserOptions(typedContext);
+  const eslintParserServices = resolveEslintParserServices(typedContext);
   if (!parserOptions.corsa && eslintParserServices) {
     const services = createEslintParserServices(eslintParserServices);
     parserServices.set(context, services);
     return services;
   }
   try {
-    const maps = createNodeMaps(context);
-    const program = createProgram(context);
+    const maps = createNodeMaps(typedContext);
+    const program = createProgram(typedContext);
     const services: ParserServicesWithTypeInformation = {
       program,
       ...maps,
       hasFullTypeInformation: true,
       getTypeAtLocation(node) {
-        return createTypeChecker(context).getTypeAtLocation(node);
+        return createTypeChecker(typedContext).getTypeAtLocation(node);
       },
       getSymbolAtLocation(node) {
-        return createTypeChecker(context).getSymbolAtLocation(node);
+        return createTypeChecker(typedContext).getSymbolAtLocation(node);
       },
     };
     parserServices.set(context, services);
@@ -55,8 +59,8 @@ export function getParserServices(
       throw error;
     }
     const fallback: ParserServices = {
-      program: createProgram(context),
-      ...createNodeMaps(context),
+      program: createProgram(typedContext),
+      ...createNodeMaps(typedContext),
       hasFullTypeInformation: false,
       getTypeAtLocation() {
         return undefined;

--- a/src/bindings/nodejs/corsa_oxlint/ts/plugin.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/plugin.ts
@@ -5,11 +5,11 @@ import type {
   Plugin as OxlintPlugin,
   Rule as OxlintRule,
   RuleMeta as OxlintRuleMeta,
-  Visitor,
-  VisitorWithHooks,
 } from "@oxlint/plugins";
 
+import { AST_NODE_TYPES } from "./compat";
 import { resolveTypeAwareParserOptions } from "./context";
+import type { ESTree as PublicESTree } from "./index";
 import { getParserServices } from "./parser_services";
 import type { ContextWithParserOptions, ParserServices } from "./types";
 
@@ -44,6 +44,24 @@ export type RuleMetaWithMessages<MessageId extends string = string> = Omit<
 > & {
   readonly docs?: RuleDocs;
   readonly messages?: Record<MessageId, string>;
+};
+type CorsaAstNodeType = keyof typeof AST_NODE_TYPES;
+type BivariantVisitorHandler<Handler extends (...args: any[]) => any> = {
+  bivarianceHack(...args: Parameters<Handler>): ReturnType<Handler>;
+}["bivarianceHack"];
+type VisitorNode<Kind extends CorsaAstNodeType> = PublicESTree[Kind];
+
+export type Visitor = {
+  [Kind in CorsaAstNodeType]?: BivariantVisitorHandler<(node: VisitorNode<Kind>) => void>;
+} & {
+  [Kind in CorsaAstNodeType as `${Kind}:exit`]?: BivariantVisitorHandler<
+    (node: VisitorNode<Kind>) => void
+  >;
+} & Record<string, BivariantVisitorHandler<(node: PublicESTree.Node) => void> | undefined>;
+
+export type VisitorWithHooks = Visitor & {
+  readonly before?: () => boolean | void;
+  readonly after?: () => void;
 };
 export type RuleDefinition<
   MessageId extends string = string,
@@ -94,8 +112,8 @@ export function defineRule<
   MessageId extends string = string,
   const Options extends readonly unknown[] = readonly unknown[],
 >(rule: RuleDefinition<MessageId, Options>): Rule;
-export function defineRule(rule: Rule): Rule {
-  return defineOxlintRule(decorateRule(rule) as OxlintRule) as Rule;
+export function defineRule(rule: RuleDefinition): Rule {
+  return defineOxlintRule(decorateRule(rule as unknown as Rule) as OxlintRule) as Rule;
 }
 
 export function compatPlugin(plugin: Plugin): Plugin {

--- a/src/bindings/nodejs/corsa_oxlint/ts/public_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/public_types.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import {
   AST_NODE_TYPES,
   defineRule,
+  getParserServices,
   OxlintUtils,
   type ESTree,
   type RuleContext,
@@ -160,5 +161,41 @@ describe("corsa oxlint public types", () => {
 
     expect(visitNestedNodes).toBeTypeOf("function");
     expect(reportLiteral).toBeTypeOf("function");
+  });
+
+  it("types visitor callback nodes with public ESTree aliases", () => {
+    type MyClass = ESTree.ClassDeclaration | ESTree.ClassExpression;
+
+    const acceptClass = (node: MyClass): void => {
+      void node;
+    };
+    const acceptNewExpression = (node: ESTree.NewExpression): void => {
+      void node;
+    };
+
+    defineRule({
+      meta: {
+        schema: [],
+        messages: { x: "x" },
+        docs: { requiresTypeChecking: true },
+      },
+      create(context) {
+        const services = getParserServices(context);
+        return {
+          ClassDeclaration(node) {
+            acceptClass(node);
+          },
+          MethodDefinition(node) {
+            services.getTypeAtLocation(node.value);
+          },
+          NewExpression(node) {
+            acceptNewExpression(node);
+          },
+        };
+      },
+    });
+
+    expect(acceptClass).toBeTypeOf("function");
+    expect(acceptNewExpression).toBeTypeOf("function");
   });
 });


### PR DESCRIPTION
## Summary
- align `defineRule` visitor callback typing with the public `ESTree.*` aliases instead of the upstream `@oxlint/plugins` node declarations
- allow `getParserServices(context)` to accept `defineRule` contexts without an options-type mismatch
- add a public types regression covering the `ClassDeclaration`, `MethodDefinition.value`, and `NewExpression` cases from issue #357

## Validation
- `pnpm exec tsc --noEmit --pretty false`

Fixes #357.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->