### PR TITLE
fix: normalize stale getSymbolOfType lookups

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
@@ -15,6 +15,10 @@ class FakeClient {
     flags: 0,
     texts: ["string"],
   }));
+  readonly getSymbolOfType = vi.fn(() => ({
+    id: "symbol-1",
+    name: "value",
+  }));
   readonly typeToString = vi.fn(() => "type:string");
   readonly releaseHandle = vi.fn();
   readonly close = vi.fn();
@@ -212,6 +216,45 @@ describe("CorsaProjectSession", () => {
     });
 
     expect(session.typeToString(type as never)).toBe("Serializable");
+  });
+
+  it("returns undefined when getSymbolOfType hits a stale handle", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    session.getTypeAtPosition("/tmp/one.ts", 0);
+    const client = clients[0];
+    if (!client) {
+      throw new Error("expected a fake client");
+    }
+
+    client.getSymbolOfType.mockImplementationOnce(() => {
+      throw new Error(
+        'protocol error: api: client error: type handle "synthetic-type-argument:1:0:T" not found in snapshot registry',
+      );
+    });
+
+    expect(
+      session.getSymbolOfType({
+        id: "synthetic-type-argument:1:0:T",
+        flags: 0,
+        texts: ["T"],
+      } as never),
+    ).toBeUndefined();
   });
 
   it("restarts the client once when a type lookup sees a closed transport", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -210,6 +210,10 @@ export class CorsaProjectSession {
   }
 
   getSymbol(symbol: string | CorsaSymbol): CorsaSymbol | undefined {
+    return this.withTransportRecovery(() => this.getSymbolUnchecked(symbol), "looking up a symbol");
+  }
+
+  private getSymbolUnchecked(symbol: string | CorsaSymbol): CorsaSymbol | undefined {
     if (typeof symbol !== "string") {
       return this.rememberSymbol(symbol);
     }
@@ -221,23 +225,41 @@ export class CorsaProjectSession {
     if (!typeId || !this.#snapshot) {
       return undefined;
     }
-    const resolved = this.client().getSymbolOfType(this.#snapshot, typeId) as CorsaSymbol | null;
-    return resolved?.id === symbol ? this.rememberUsableSymbol(resolved) : undefined;
+    const resolved = this.getSymbolOfTypeById(typeId);
+    return resolved?.id === symbol ? resolved : undefined;
   }
 
   getSymbolOfType(type: CorsaType): CorsaSymbol | undefined {
+    return this.withTransportRecovery(
+      () => this.getSymbolOfTypeUnchecked(type),
+      "looking up a symbol",
+    );
+  }
+
+  private getSymbolOfTypeUnchecked(type: CorsaType): CorsaSymbol | undefined {
     if (type.symbol) {
       const symbol = this.getSymbol(type.symbol);
       if (isUsableSymbol(symbol)) {
         return symbol;
       }
     }
+    return this.getSymbolOfTypeById(type.id);
+  }
+
+  private getSymbolOfTypeById(typeId: string): CorsaSymbol | undefined {
     if (!this.#snapshot) {
       return undefined;
     }
-    return this.rememberUsableSymbol(
-      this.client().getSymbolOfType(this.#snapshot, type.id) as CorsaSymbol | null,
-    );
+    try {
+      return this.rememberUsableSymbol(
+        this.client().getSymbolOfType(this.#snapshot, typeId) as CorsaSymbol | null,
+      );
+    } catch (error) {
+      if (isStaleHandleError(error)) {
+        return undefined;
+      }
+      throw error;
+    }
   }
 
   getNode(node: string | CorsaNode): CorsaNode | undefined {
@@ -1023,6 +1045,10 @@ function isRecoverableTransportError(error: unknown): boolean {
     message.includes("jsonrpc writer") ||
     message.includes("jsonrpc connection")
   );
+}
+
+function isStaleHandleError(error: unknown): boolean {
+  return errorMessage(error).includes("not found in snapshot registry");
 }
 
 function errorMessage(error: unknown): string {


### PR DESCRIPTION
## Summary
- normalize stale `getSymbolOfType` snapshot-registry misses to `undefined`
- route symbol lookups through the existing transport-recovery wrapper
- add a regression test for synthetic type argument handles

## Why
`CorsaProjectSession.getSymbolOfType` was surfacing `type handle ... not found in snapshot registry` for synthetic type arguments even though the public API already advertises `CorsaSymbol | undefined`.

Fixes #364.

## Validation
- `pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/session.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->