### PR TITLE
feat(corsa-oxlint): support plugin-owned runtime anchors

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/README.md
+++ b/src/bindings/nodejs/corsa_oxlint/README.md
@@ -24,6 +24,30 @@ The design goal is simple: performance-critical pieces live in Rust, `napi-rs`
 bridges them into Node, and end users still get to author custom plugins and
 custom rules in plain JS/TS.
 
+## Plugin-Owned Runtime Resolution
+
+If a plugin ships its own `@typescript/native-preview` dependency, pass a
+module anchor to `definePlugin()` so `corsa-oxlint` can resolve that runtime
+even when package managers like pnpm do not hoist it to the consumer root.
+
+```ts
+import { definePlugin } from "corsa-oxlint";
+
+export default definePlugin({
+  meta: {
+    name: "example-plugin",
+  },
+  resolveFrom: import.meta.url,
+  rules: {
+    // ...
+  },
+});
+```
+
+Consumer overrides still win. `CORSA_EXECUTABLE`,
+`parserOptions.corsa.executable`, and `settings.corsaOxlint` continue to take
+priority over the plugin anchor.
+
 ## Configuration
 
 Oxlint does not expose arbitrary parser options at runtime, so

--- a/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -133,5 +134,34 @@ describe("context", () => {
     writeFileSync(binPath, "#!/usr/bin/env node\n");
 
     expect(defaultCorsaExecutable(workspace)).toBe(realpathSync(binPath));
+  });
+
+  it("falls back to a plugin anchor when native-preview is only installed next to the plugin", () => {
+    const consumerRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-consumer-"));
+    const pluginRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-plugin-"));
+    cleanupDirs.add(consumerRoot);
+    cleanupDirs.add(pluginRoot);
+
+    const packageDir = resolve(pluginRoot, "node_modules/@typescript/native-preview");
+    const binPath = resolve(packageDir, "bin/tsgo.js");
+    mkdirSync(dirname(binPath), { recursive: true });
+    writeFileSync(
+      resolve(packageDir, "package.json"),
+      JSON.stringify({
+        name: "@typescript/native-preview",
+        bin: {
+          tsgo: "bin/tsgo.js",
+        },
+      }),
+    );
+    writeFileSync(binPath, "#!/usr/bin/env node\n");
+
+    const pluginEntry = resolve(pluginRoot, "dist/plugin.js");
+    mkdirSync(dirname(pluginEntry), { recursive: true });
+    writeFileSync(pluginEntry, "export default {};\n");
+
+    expect(defaultCorsaExecutable(consumerRoot, "linux", pathToFileURL(pluginEntry).href)).toBe(
+      realpathSync(binPath),
+    );
   });
 });

--- a/src/bindings/nodejs/corsa_oxlint/ts/context.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.ts
@@ -188,7 +188,10 @@ function asArray(value: string | string[] | undefined): string[] {
 
 function resolveNativePreviewExecutableFrom(anchor: string): string | undefined {
   const requireFromRoot = createRequire(anchor);
-  const packageJsonPath = resolveOptional(requireFromRoot, "@typescript/native-preview/package.json");
+  const packageJsonPath = resolveOptional(
+    requireFromRoot,
+    "@typescript/native-preview/package.json",
+  );
   if (packageJsonPath) {
     const binPath = nativePreviewBinPath(packageJsonPath);
     if (binPath && existsSync(binPath)) {
@@ -252,7 +255,8 @@ function applyTypeAwareParserOptionDefaults(
   if (defaults.corsa === true && resolved.corsa?.executable === undefined) {
     resolved = mergeTypeAwareParserOptions(resolved, {
       corsa: {
-        executable: process.env.CORSA_EXECUTABLE ?? defaultCorsaExecutable(rootDir, undefined, resolveFrom),
+        executable:
+          process.env.CORSA_EXECUTABLE ?? defaultCorsaExecutable(rootDir, undefined, resolveFrom),
       },
     });
   }

--- a/src/bindings/nodejs/corsa_oxlint/ts/context.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.ts
@@ -21,8 +21,14 @@ const DEFAULT_TS_CONFIG = {
   },
 };
 
-export function defaultCorsaExecutable(rootDir: string, platform = process.platform): string {
-  const nativePreview = resolveNativePreviewExecutable(rootDir);
+export function defaultCorsaExecutable(
+  rootDir: string,
+  platform = process.platform,
+  resolveFrom?: string,
+): string {
+  const nativePreview =
+    resolveNativePreviewExecutableFrom(resolve(rootDir, "package.json")) ??
+    (resolveFrom ? resolveNativePreviewExecutableFrom(resolveFrom) : undefined);
   if (nativePreview) {
     return nativePreview;
   }
@@ -33,7 +39,7 @@ export function defaultCorsaExecutable(rootDir: string, platform = process.platf
   throw new Error(
     [
       "corsa-oxlint could not locate a Corsa runtime executable.",
-      "Install `@typescript/native-preview`, set `CORSA_EXECUTABLE`, or configure `parserOptions.corsa.executable`.",
+      "Install `@typescript/native-preview`, set `CORSA_EXECUTABLE`, configure `parserOptions.corsa.executable`, or pass `resolveFrom` to `definePlugin`.",
     ].join(" "),
   );
 }
@@ -70,13 +76,14 @@ export function resolveProjectConfig(context: ContextWithParserOptions): Resolve
 export function resolveTypeAwareParserOptions(
   context: ContextWithParserOptions,
   defaults: TypeAwareParserOptionDefaults = {},
+  resolveFrom?: string,
 ): TypeAwareParserOptions {
   const parserOptions = mergeTypeAwareParserOptions(
     resolveSettingsParserOptions(context.settings?.corsaOxlint),
     mergeTypeAwareParserOptions(context.parserOptions, context.languageOptions?.parserOptions),
   );
   const rootDir = resolve(parserOptions.tsconfigRootDir ?? context.cwd);
-  return applyTypeAwareParserOptionDefaults(parserOptions, defaults, rootDir);
+  return applyTypeAwareParserOptionDefaults(parserOptions, defaults, rootDir, resolveFrom);
 }
 
 type TypeAwareParserOptionDefaults = {
@@ -179,12 +186,9 @@ function asArray(value: string | string[] | undefined): string[] {
   return value ? (Array.isArray(value) ? value : [value]) : [];
 }
 
-function resolveNativePreviewExecutable(rootDir: string): string | undefined {
-  const requireFromRoot = createRequire(resolve(rootDir, "package.json"));
-  const packageJsonPath = resolveOptional(
-    requireFromRoot,
-    "@typescript/native-preview/package.json",
-  );
+function resolveNativePreviewExecutableFrom(anchor: string): string | undefined {
+  const requireFromRoot = createRequire(anchor);
+  const packageJsonPath = resolveOptional(requireFromRoot, "@typescript/native-preview/package.json");
   if (packageJsonPath) {
     const binPath = nativePreviewBinPath(packageJsonPath);
     if (binPath && existsSync(binPath)) {
@@ -232,6 +236,7 @@ function applyTypeAwareParserOptionDefaults(
   parserOptions: TypeAwareParserOptions,
   defaults: TypeAwareParserOptionDefaults,
   rootDir: string,
+  resolveFrom?: string,
 ): TypeAwareParserOptions {
   let resolved = parserOptions;
   if (
@@ -247,7 +252,7 @@ function applyTypeAwareParserOptionDefaults(
   if (defaults.corsa === true && resolved.corsa?.executable === undefined) {
     resolved = mergeTypeAwareParserOptions(resolved, {
       corsa: {
-        executable: process.env.CORSA_EXECUTABLE ?? defaultCorsaExecutable(rootDir),
+        executable: process.env.CORSA_EXECUTABLE ?? defaultCorsaExecutable(rootDir, undefined, resolveFrom),
       },
     });
   }

--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -161,6 +162,79 @@ describe("corsa oxlint", () => {
         parserProjectService: true,
         languageProjectService: true,
       });
+    } finally {
+      if (previousExecutable == null) {
+        delete process.env.CORSA_EXECUTABLE;
+      } else {
+        process.env.CORSA_EXECUTABLE = previousExecutable;
+      }
+    }
+  });
+
+  it("uses plugin resolveFrom to fill the default corsa executable", () => {
+    const previousExecutable = process.env.CORSA_EXECUTABLE;
+    delete process.env.CORSA_EXECUTABLE;
+    const consumerRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-consumer-"));
+    const pluginRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-plugin-"));
+    cleanupDirs.add(consumerRoot);
+    cleanupDirs.add(pluginRoot);
+
+    const packageDir = resolve(pluginRoot, "node_modules/@typescript/native-preview");
+    const binPath = resolve(packageDir, "bin/tsgo.js");
+    mkdirSync(dirname(binPath), { recursive: true });
+    writeFileSync(
+      resolve(packageDir, "package.json"),
+      JSON.stringify({
+        name: "@typescript/native-preview",
+        bin: {
+          tsgo: "bin/tsgo.js",
+        },
+      }),
+    );
+    writeFileSync(binPath, "#!/usr/bin/env node\n");
+
+    const pluginEntry = resolve(pluginRoot, "dist/plugin.js");
+    mkdirSync(dirname(pluginEntry), { recursive: true });
+    writeFileSync(pluginEntry, "export default {};\n");
+
+    let seen: string | undefined;
+    const plugin = definePlugin({
+      meta: { name: "oxlint-plugin-corsa-demo" },
+      resolveFrom: pathToFileURL(pluginEntry).href,
+      rules: {
+        demo: {
+          meta: {
+            docs: {
+              requiresTypeChecking: true,
+            },
+            messages: {
+              demo: "demo",
+            },
+            schema: [],
+          },
+          create(context: any) {
+            seen = context.parserOptions.corsa?.executable;
+            return {};
+          },
+        },
+      },
+    });
+
+    try {
+      plugin.rules.demo.create!({
+        cwd: consumerRoot,
+        filename: resolve(consumerRoot, "fixture.ts"),
+        languageOptions: {
+          parserOptions: {},
+        },
+        report() {},
+        settings: {},
+        sourceCode: {
+          text: "const fixture = 1;",
+        },
+      } as any);
+
+      expect(seen).toBe(realpathSync(binPath));
     } finally {
       if (previousExecutable == null) {
         delete process.env.CORSA_EXECUTABLE;

--- a/src/bindings/nodejs/corsa_oxlint/ts/plugin.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/plugin.ts
@@ -14,6 +14,11 @@ import { getParserServices } from "./parser_services";
 import type { ContextWithParserOptions, ParserServices } from "./types";
 
 export type Plugin = Omit<OxlintPlugin, "rules"> & {
+  /**
+   * Optional module URL or absolute path used to resolve the plugin's own
+   * runtime dependencies when they are not visible from the consumer root.
+   */
+  readonly resolveFrom?: string;
   readonly rules: Record<string, Rule>;
 } & Record<string, unknown>;
 export type Rule = OxlintRule & Record<string, unknown>;
@@ -88,10 +93,17 @@ const baseCompatPlugin = Reflect.get(
 ) as typeof oxlintPluginApi.definePlugin;
 
 export function definePlugin(plugin: Plugin): Plugin {
-  return defineOxlintPlugin({
+  const defined = defineOxlintPlugin({
     ...plugin,
-    rules: wrapRules(plugin.rules ?? {}),
+    rules: wrapRules(plugin.rules ?? {}, plugin.resolveFrom),
   } as OxlintPlugin) as Plugin;
+  if (plugin.resolveFrom === undefined) {
+    return defined;
+  }
+  return {
+    ...defined,
+    resolveFrom: plugin.resolveFrom,
+  };
 }
 
 /**
@@ -120,12 +132,12 @@ export function compatPlugin(plugin: Plugin): Plugin {
   return baseCompatPlugin(definePlugin(plugin)) as Plugin;
 }
 
-export function decorateRule(rule: Rule): Rule {
+export function decorateRule(rule: Rule, resolveFrom?: string): Rule {
   if (rule.create) {
     return {
       ...rule,
       create(context) {
-        return rule.create!(decorateContext(context, rule));
+        return rule.create!(decorateContext(context, rule, resolveFrom));
       },
     } as Rule;
   }
@@ -133,26 +145,34 @@ export function decorateRule(rule: Rule): Rule {
     return {
       ...rule,
       createOnce(context) {
-        return (rule as any).createOnce(decorateContext(context, rule));
+        return (rule as any).createOnce(decorateContext(context, rule, resolveFrom));
       },
     } as Rule;
   }
   return rule;
 }
 
-function wrapRules(rules: Record<string, Rule>): Record<string, Rule> {
+function wrapRules(rules: Record<string, Rule>, resolveFrom?: string): Record<string, Rule> {
   return Object.fromEntries(
-    Object.entries(rules).map(([name, rule]) => [name, decorateRule(rule)]),
+    Object.entries(rules).map(([name, rule]) => [name, decorateRule(rule, resolveFrom)]),
   );
 }
 
-function decorateContext(context: ContextWithParserOptions, rule: Rule): ContextWithParserOptions {
+function decorateContext(
+  context: ContextWithParserOptions,
+  rule: Rule,
+  resolveFrom?: string,
+): ContextWithParserOptions {
   const typeAware = requiresTypeChecking(rule);
   const parserOptions = Object.freeze(
-    resolveTypeAwareParserOptions(context, {
-      corsa: typeAware,
-      projectService: typeAware,
-    }),
+    resolveTypeAwareParserOptions(
+      context,
+      {
+        corsa: typeAware,
+        projectService: typeAware,
+      },
+      resolveFrom,
+    ),
   );
   const baseLanguageOptions = context.languageOptions;
   const languageOptions = Object.freeze({

--- a/src/bindings/nodejs/corsa_oxlint/ts/public_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/public_types.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 
 import {
   AST_NODE_TYPES,
+  definePlugin,
   defineRule,
   getParserServices,
   OxlintUtils,
@@ -65,6 +66,19 @@ describe("corsa oxlint public types", () => {
     const requiresTypeChecking: boolean | undefined = created.meta.docs.requiresTypeChecking;
     expect(requiresTypeChecking).toBe(true);
     expect(created.meta.docs.url).toBe("https://example.com/typed-docs");
+  });
+
+  it("accepts resolveFrom on plugin definitions", () => {
+    const plugin = definePlugin({
+      meta: {
+        name: "typed-plugin",
+      },
+      resolveFrom: import.meta.url,
+      rules: {},
+    });
+
+    const resolveFrom: string | undefined = plugin.resolveFrom;
+    expect(resolveFrom).toBe(import.meta.url);
   });
 
   it("narrows ESTree.Node through AST_NODE_TYPES checks", () => {


### PR DESCRIPTION
## Summary
- add an optional `resolveFrom` plugin anchor that type-aware rules can use to locate `@typescript/native-preview`
- thread the anchor through `definePlugin()` into parser option defaults without changing existing override precedence
- cover the new fallback with context, framework, and public type tests and document the plugin-side usage

## Why
pnpm can keep a plugin's `@typescript/native-preview` dependency isolated from the consumer root, so the existing root-only lookup fails for valid plugin-owned runtimes.

Closes #363.

## Validation
- `pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/context.test.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts src/bindings/nodejs/corsa_oxlint/ts/public_types.test.ts src/bindings/nodejs/corsa_oxlint/ts/api_surface.test.ts`
- `vp run -w build_corsa_oxlint`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->