### PR TITLE
chore: pin corsa to TypeScript 7.0.2

### DIFF
--- a/.github/workflows/pr-performance.yml
+++ b/.github/workflows/pr-performance.yml
@@ -36,8 +36,8 @@ jobs:
           - base
           - head
         typescript:
-          - channel: "6"
-            package: "typescript@^6"
+          - channel: "7"
+            package: "typescript@7.0.2"
           - channel: next
             package: "typescript@next"
     steps:
@@ -182,10 +182,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .cache/pr-benchmark
-          benchmark_args=()
-          if [ "${{ matrix.ref-role }}" = "base" ]; then
-            benchmark_args+=(--allow-partial-failures)
-          fi
+          benchmark_args=(--allow-partial-failures)
           cargo run --manifest-path .cache/pr-benchmark/workflow-scripts/src/bindings/rust/corsa/Cargo.toml --release -p corsa --bin bench_tooling_compare -- \
             --corsa .cache/corsa \
             "${benchmark_args[@]}" \

--- a/bench/src/publish_workflows.test.ts
+++ b/bench/src/publish_workflows.test.ts
@@ -48,12 +48,12 @@ describe("publish workflows", () => {
     expect(workflow).toContain('cross_arg="--cross-compile"');
   });
 
-  it("benchmarks PR base and head against TypeScript 6 and next", () => {
+  it("benchmarks PR base and head against TypeScript 7 and next", () => {
     const workflow = readWorkflow(".github/workflows/pr-performance.yml");
     expect(workflow).toContain('BENCH_ITERATIONS: "5"');
     expect(workflow).toContain("ref-role:");
     expect(workflow).toContain("typescript:");
-    expect(workflow).toContain('package: "typescript@^6"');
+    expect(workflow).toContain('package: "typescript@7.0.2"');
     expect(workflow).toContain('package: "typescript@next"');
     expect(workflow).toContain("Build corsa-oxlint package");
     expect(workflow).toContain("Normalize benchmark paths");

--- a/corsa_ref.lock.toml
+++ b/corsa_ref.lock.toml
@@ -3,8 +3,8 @@ version = 1
 [corsa_upstream]
 path = "ref/corsa-upstream"
 repository = "https://github.com/microsoft/typescript-go.git"
-commit = "73868c8588924d4d972782c9ea102b322d7f3212"
-tree = "81355a169abb605dec5355169fb30ab15677b357"
-committer_date = "2026-05-30T19:52:40Z"
-author = "Anders Hejlsberg"
-subject = "Fix grammar checking for `in` and `out` modifiers in `@template` tags (#4100)"
+commit = "2bd066d87f5bafd315be9f40889d0a60b9e58e0b"
+tree = "ed2c2c12c401b84bd5888d0b889737495aa93a20"
+committer_date = "2026-07-07T21:22:40-07:00"
+author = "Jake Bailey"
+subject = "Merge branch 'main' into ts7-release"

--- a/docs/ci_guide.md
+++ b/docs/ci_guide.md
@@ -47,7 +47,7 @@ The PR performance workflow lives in
 On PR open, reopen, ready-for-review, and synchronize events it benchmarks:
 
 - PR base branch versus PR head branch
-- TypeScript `6` versus the npm `next` TypeScript channel
+- TypeScript `7` versus the npm `next` TypeScript channel
 - five measured samples per row, reported by mean milliseconds
 
 The workflow uploads the four benchmark reports as artifacts, then updates one

--- a/src/bindings/rust/corsa/src/bin/bench_tooling_compare/runner.rs
+++ b/src/bindings/rust/corsa/src/bin/bench_tooling_compare/runner.rs
@@ -345,7 +345,17 @@ async fn open_workflow_session(cli: &Cli, dataset: &DatasetCase) -> Result<Workf
             overlay_changes: None,
         })
         .await?;
-    let project = snapshot.projects[0].id.clone();
+    let project = snapshot
+        .projects
+        .first()
+        .ok_or_else(|| {
+            CorsaError::Protocol(CompactString::from(format!(
+                "benchmark snapshot did not open a project for {}",
+                dataset.config_wire
+            )))
+        })?
+        .id
+        .clone();
     let target =
         discover_bench_target(&client, &snapshot, &project, dataset.primary_file.as_str()).await?;
     Ok(WorkflowSession {


### PR DESCRIPTION
## Summary

- Pin the managed `microsoft/typescript-go` Corsa ref to the TypeScript 7.0.2 release commit.
- Update the PR performance stable benchmark channel from TypeScript 6 to the exact `typescript@7.0.2` package.
- Allow PR performance benchmark rows to be skipped when TypeScript 7/next exposes tooling incompatibilities, while still reporting the rows that complete.
- Convert an empty-project benchmark snapshot from a panic into a normal protocol error so partial benchmark mode can skip that editor workflow row.
- Refresh the workflow assertion and CI guide wording for the TypeScript 7 stable channel.

## Validation

- `cargo run -p corsa_ref -- verify`
- `corepack pnpm peers check`
- `corepack pnpm exec vitest run bench/src/publish_workflows.test.ts`
- `corepack pnpm exec vp fmt --check`
- `cargo fmt --all --check`
- `cargo check -p corsa --bin bench_tooling_compare`

## Notes

- `corepack pnpm exec vp run -w build_corsa` synced and verified the pinned ref, then stopped locally because the upstream `go.mod` requests Go 1.26 and this local toolchain could not download `go1.26` (`toolchain not available`). The PR CI uses `actions/setup-go` with `go-version-file`, and the first CI run confirmed the build job passes there.
