### PR TITLE
chore: support prerelease automation

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -63,8 +63,8 @@ jobs:
             sha="$(git rev-list -n 1 "$tag")"
           fi
 
-          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Expected a release tag like v1.2.3, received $tag"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "::error::Expected a release tag like v1.2.3 or v1.0.0-beta.1, received $tag"
             exit 1
           fi
           if [[ -z "$sha" ]]; then
@@ -75,6 +75,11 @@ jobs:
           {
             echo "tag=$tag"
             echo "sha=$sha"
+            if [[ "$tag" == *-* ]]; then
+              echo "prerelease=true"
+            else
+              echo "prerelease=false"
+            fi
           } >> "$GITHUB_OUTPUT"
           echo "RELEASE_TAG=$tag" >> "$GITHUB_ENV"
 
@@ -137,6 +142,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
+          RELEASE_PRERELEASE: ${{ steps.release.outputs.prerelease }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
         shell: bash
@@ -146,8 +152,12 @@ jobs:
             exit 0
           fi
 
-          gh release create "$RELEASE_TAG" \
+          args=(release create "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
             --title "$RELEASE_TAG" \
-            --generate-notes
+            --generate-notes)
+          if [[ "$RELEASE_PRERELEASE" == "true" ]]; then
+            args+=(--prerelease)
+          fi
+          gh "${args[@]}"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -32,6 +32,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  NPM_DIST_TAG: ${{ contains(github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name, '-') && 'beta' || '' }}
 
 jobs:
   release-gates:

--- a/bench/src/release_manifest.test.ts
+++ b/bench/src/release_manifest.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  isPrereleaseTag,
+  isPrereleaseVersion,
+  normalizeReleaseTag,
+  parseReleaseVersion,
   publicRustCrateNames,
   publicRustCrates,
   rustReleaseCrates,
+  versionToTag,
 } from "../../scripts/release_manifest.ts";
 
 describe("release manifest", () => {
@@ -25,5 +30,37 @@ describe("release manifest", () => {
     ).toEqual(["corsa_ref", "corsa_ffi", "corsa_node", "corsa_elixir"]);
 
     expect(publicRustCrates.every((crate) => crate.publish === "public")).toBe(true);
+  });
+
+  it("accepts stable and prerelease versions", () => {
+    expect(parseReleaseVersion("1.0.0")).toEqual({
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: null,
+    });
+    expect(parseReleaseVersion("1.0.0-beta.1")).toEqual({
+      major: 1,
+      minor: 0,
+      patch: 0,
+      prerelease: "beta.1",
+    });
+    expect(versionToTag("1.0.0-beta.1")).toBe("v1.0.0-beta.1");
+  });
+
+  it("normalizes stable and prerelease tags", () => {
+    expect(normalizeReleaseTag("refs/tags/v1.0.0")).toBe("v1.0.0");
+    expect(normalizeReleaseTag("refs/tags/v1.0.0-beta.1")).toBe("v1.0.0-beta.1");
+    expect(isPrereleaseVersion("1.0.0")).toBe(false);
+    expect(isPrereleaseVersion("1.0.0-beta.1")).toBe(true);
+    expect(isPrereleaseTag("v1.0.0")).toBe(false);
+    expect(isPrereleaseTag("v1.0.0-beta.1")).toBe(true);
+  });
+
+  it("rejects invalid release versions and tags", () => {
+    expect(() => parseReleaseVersion("1.0")).toThrow();
+    expect(() => parseReleaseVersion("1.0.0-")).toThrow();
+    expect(() => parseReleaseVersion("1.0.0-beta..1")).toThrow();
+    expect(() => normalizeReleaseTag("1.0.0")).toThrow();
   });
 });

--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -148,6 +148,21 @@ The GitHub publish workflow fan-outs native binding builds per target, downloads
 those `.node` artifacts into the publish job, and only then publishes the root
 package and `corsa-oxlint`.
 
+## Prereleases
+
+Use an explicit semver prerelease when cutting a beta or release candidate:
+
+```bash
+git switch main
+git pull --ff-only
+vp run -w release 1.0.0-beta.1
+```
+
+This creates `release: v1.0.0-beta.1` and the annotated
+`v1.0.0-beta.1` tag. Tag-triggered GitHub Actions run the same release gates as
+stable releases. npm prerelease versions are published with the `beta` dist-tag,
+and the generated GitHub Release is marked as a prerelease.
+
 ## Trusted Publishing
 
 ### crates.io

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -7,6 +7,7 @@ import {
 import {
   assertReleaseTagMatchesWorkspace,
   bumpVersion,
+  parseReleaseVersion,
   publicRustCrateNames,
   readWorkspaceVersion,
   type ReleaseBump,
@@ -26,6 +27,16 @@ const gitNoPromptEnv = {
   GIT_TERMINAL_PROMPT: "0",
 };
 
+type ReleaseTarget =
+  | {
+      kind: "bump";
+      bump: ReleaseBump;
+    }
+  | {
+      kind: "version";
+      version: string;
+    };
+
 function isPresent<T>(value: T | null): value is T {
   return value !== null;
 }
@@ -33,17 +44,17 @@ function isPresent<T>(value: T | null): value is T {
 interface ReleaseOptions {
   allowBootstrapGap: boolean;
   allowAnyBranch: boolean;
-  bump: ReleaseBump;
   push: boolean;
   remote: string;
   requiredBranch: string;
   runFullGates: boolean;
   skipGates: boolean;
+  target: ReleaseTarget;
 }
 
 function printUsage(): void {
   console.log(
-    "Usage: vp run -w release <patch|minor|major> [--no-push] [--full-gates] [--skip-gates] [--allow-bootstrap-gap]",
+    "Usage: vp run -w release <patch|minor|major|version> [--no-push] [--full-gates] [--skip-gates] [--allow-bootstrap-gap]",
   );
 }
 
@@ -57,19 +68,31 @@ function parseArgs(argv: string[]): ReleaseOptions {
   const bump = args.find(
     (arg): arg is ReleaseBump => arg === "patch" || arg === "minor" || arg === "major",
   );
-  if (!bump) {
-    throw new Error("Expected one of: patch, minor, major");
+  const version = args.find((arg) => {
+    try {
+      parseReleaseVersion(arg);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
+  if (bump && version) {
+    throw new Error("Expected either a version or one of: patch, minor, major, not both");
+  }
+  if (!bump && !version) {
+    throw new Error("Expected a version or one of: patch, minor, major");
   }
 
   return {
     allowBootstrapGap: args.includes("--allow-bootstrap-gap"),
     allowAnyBranch: process.env.RELEASE_ALLOW_ANY_BRANCH?.trim() === "1",
-    bump,
     push: !args.includes("--no-push"),
     remote: process.env.RELEASE_REMOTE?.trim() || defaultRemote,
     requiredBranch: process.env.RELEASE_BRANCH?.trim() || defaultBranch,
     runFullGates: args.includes("--full-gates"),
     skipGates: args.includes("--skip-gates"),
+    target: bump ? { kind: "bump", bump } : { kind: "version", version: version as string },
   };
 }
 
@@ -230,7 +253,10 @@ async function main(): Promise<void> {
   }
 
   const currentVersion = readWorkspaceVersion();
-  const nextVersion = bumpVersion(currentVersion, options.bump);
+  const nextVersion =
+    options.target.kind === "bump"
+      ? bumpVersion(currentVersion, options.target.bump)
+      : options.target.version;
   const tag = versionToTag(nextVersion);
 
   assertTagAbsent(options.remote, tag);

--- a/scripts/release_manifest.ts
+++ b/scripts/release_manifest.ts
@@ -6,6 +6,9 @@ import { rootDir, runCommand } from "./shared.ts";
 
 export type ReleaseBump = "major" | "minor" | "patch";
 
+const semverPattern =
+  /^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?$/;
+
 export interface RustReleaseCrate {
   manifestPath: string;
   name: string;
@@ -124,12 +127,22 @@ function escapeRegex(value: string): string {
   return value.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function parseSemver(version: string): [number, number, number] {
-  const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)$/);
-  if (!match) {
-    throw new Error(`Expected a semver version like 0.2.0, received ${version}`);
+export function parseReleaseVersion(version: string): {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string | null;
+} {
+  const match = version.trim().match(semverPattern);
+  if (!match?.groups) {
+    throw new Error(`Expected a semver version like 0.2.0 or 1.0.0-beta.1, received ${version}`);
   }
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
+  return {
+    major: Number(match.groups.major),
+    minor: Number(match.groups.minor),
+    patch: Number(match.groups.patch),
+    prerelease: match.groups.prerelease ?? null,
+  };
 }
 
 function getCargoPackageVersion(manifestPath: string): string {
@@ -301,7 +314,7 @@ export function readWorkspaceVersion(): string {
 }
 
 export function bumpVersion(currentVersion: string, bump: ReleaseBump): string {
-  const [major, minor, patch] = parseSemver(currentVersion);
+  const { major, minor, patch } = parseReleaseVersion(currentVersion);
   if (bump === "major") {
     return `${major + 1}.0.0`;
   }
@@ -312,16 +325,24 @@ export function bumpVersion(currentVersion: string, bump: ReleaseBump): string {
 }
 
 export function versionToTag(version: string): string {
-  parseSemver(version);
+  parseReleaseVersion(version);
   return `v${version}`;
 }
 
 export function normalizeReleaseTag(input: string): string {
   const tag = input.trim().replace(/^refs\/tags\//, "");
-  if (!/^v\d+\.\d+\.\d+$/.test(tag)) {
-    throw new Error(`Expected a release tag like v0.2.0, received ${input}`);
+  if (!semverPattern.test(tag.slice(1)) || !tag.startsWith("v")) {
+    throw new Error(`Expected a release tag like v0.2.0 or v1.0.0-beta.1, received ${input}`);
   }
   return tag;
+}
+
+export function isPrereleaseVersion(version: string): boolean {
+  return parseReleaseVersion(version).prerelease !== null;
+}
+
+export function isPrereleaseTag(input: string): boolean {
+  return isPrereleaseVersion(normalizeReleaseTag(input).slice(1));
 }
 
 export function assertReleaseTagMatchesWorkspace(input: string): string {
@@ -339,7 +360,7 @@ export function assertReleaseTagMatchesWorkspace(input: string): string {
 }
 
 export function updateWorkspaceVersion(nextVersion: string): string[] {
-  parseSemver(nextVersion);
+  parseReleaseVersion(nextVersion);
 
   const changedPaths: string[] = [];
 


### PR DESCRIPTION
## Summary
- allow release automation and tag validation to accept semver prerelease versions like `1.0.0-beta.1`
- publish npm prereleases under the `beta` dist-tag
- mark generated GitHub Releases for prerelease tags as prereleases
- document the beta release command and add release manifest tests

## Validation
- `vp fmt --check`
- `vp exec vitest run bench/src/release_manifest.test.ts`
- `vp check` (passes with existing warnings)
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "blacksmith-32vcpu-ubuntu-2404" is unknown' .github/workflows/publish-npm.yml .github/workflows/github-release.yml .github/workflows/publish-rust.yml`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786128213&installation_id=136613492&pr_number=376&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F376&signature=578e1ae8096ba423eac502e1f11ee19493974bf4164caa7b40d223e87a0f9184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for prerelease releases and tags, including beta/release-candidate versioning.
  * Release publishing now automatically marks prerelease GitHub releases and uses the beta npm dist-tag when appropriate.

* **Bug Fixes**
  * Expanded version and tag validation to accept valid semantic version prereleases.
  * Improved release handling so explicit version releases work alongside standard version bumps.

* **Documentation**
  * Added guidance for creating prerelease releases in the release guide.

* **Tests**
  * Expanded release version tests to cover stable, prerelease, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->