### PR TITLE
fix: discover TypeScript 7 runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- `corsa-oxlint` now discovers the native Corsa runtime shipped with TypeScript 7 or newer before falling back to `@typescript/native-preview`.
 - `corsa-oxlint` now reports a dependency-focused error when no default Corsa runtime executable can be found.
 - constructor signature parameter symbol fallback now preserves non-ASCII parameter names.
 - imported inherited constructor signatures with non-ASCII JSDoc retain resolvable parameter symbols.

--- a/src/bindings/nodejs/corsa_oxlint/README.md
+++ b/src/bindings/nodejs/corsa_oxlint/README.md
@@ -26,9 +26,11 @@ custom rules in plain JS/TS.
 
 ## Plugin-Owned Runtime Resolution
 
-If a plugin ships its own `@typescript/native-preview` dependency, pass a
-module anchor to `definePlugin()` so `corsa-oxlint` can resolve that runtime
-even when package managers like pnpm do not hoist it to the consumer root.
+By default, `corsa-oxlint` first uses the native runtime shipped with
+`typescript` 7 or newer, then falls back to `@typescript/native-preview` and
+finally `.cache/corsa`. If a plugin ships either runtime dependency, pass a
+module anchor to `definePlugin()` so `corsa-oxlint` can resolve it even when
+package managers like pnpm do not hoist it to the consumer root.
 
 ```ts
 import { definePlugin } from "corsa-oxlint";

--- a/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
@@ -149,6 +149,31 @@ describe("context", () => {
     expect(defaultCorsaExecutable(workspace, "linux")).toBe(realpathSync(stableBin));
   });
 
+  it("resolves the stable TypeScript 7 platform executable on Windows", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
+    cleanupDirs.add(workspace);
+    const typescriptDir = resolve(workspace, "node_modules/typescript");
+    const platformDir = resolve(
+      workspace,
+      `node_modules/@typescript/typescript-win32-${process.arch}`,
+    );
+    const stableBin = resolve(platformDir, "lib/tsc.exe");
+
+    mkdirSync(typescriptDir, { recursive: true });
+    mkdirSync(dirname(stableBin), { recursive: true });
+    writeFileSync(
+      resolve(typescriptDir, "package.json"),
+      JSON.stringify({ name: "typescript", version: "7.0.2" }),
+    );
+    writeFileSync(
+      resolve(platformDir, "package.json"),
+      JSON.stringify({ name: `@typescript/typescript-win32-${process.arch}`, version: "7.0.2" }),
+    );
+    writeFileSync(stableBin, "");
+
+    expect(defaultCorsaExecutable(workspace, "win32")).toBe(realpathSync(stableBin));
+  });
+
   it("ignores TypeScript versions before 7", () => {
     const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
     cleanupDirs.add(workspace);

--- a/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
@@ -112,8 +112,69 @@ describe("context", () => {
     cleanupDirs.add(workspace);
 
     expect(() => defaultCorsaExecutable(workspace, "linux")).toThrow(
-      "Install `@typescript/native-preview`",
+      "Install `typescript` 7 or `@typescript/native-preview`",
     );
+  });
+
+  it("prefers the stable TypeScript 7 platform executable when available", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
+    cleanupDirs.add(workspace);
+    const typescriptDir = resolve(workspace, "node_modules/typescript");
+    const platformDir = resolve(
+      workspace,
+      `node_modules/@typescript/typescript-linux-${process.arch}`,
+    );
+    const stableBin = resolve(platformDir, "lib/tsc");
+    const previewDir = resolve(workspace, "node_modules/@typescript/native-preview");
+    const previewBin = resolve(previewDir, "bin/tsgo.js");
+
+    mkdirSync(typescriptDir, { recursive: true });
+    mkdirSync(dirname(stableBin), { recursive: true });
+    mkdirSync(dirname(previewBin), { recursive: true });
+    writeFileSync(
+      resolve(typescriptDir, "package.json"),
+      JSON.stringify({ name: "typescript", version: "7.0.2" }),
+    );
+    writeFileSync(
+      resolve(platformDir, "package.json"),
+      JSON.stringify({ name: `@typescript/typescript-linux-${process.arch}`, version: "7.0.2" }),
+    );
+    writeFileSync(stableBin, "");
+    writeFileSync(
+      resolve(previewDir, "package.json"),
+      JSON.stringify({ name: "@typescript/native-preview", bin: { tsgo: "bin/tsgo.js" } }),
+    );
+    writeFileSync(previewBin, "#!/usr/bin/env node\n");
+
+    expect(defaultCorsaExecutable(workspace, "linux")).toBe(realpathSync(stableBin));
+  });
+
+  it("ignores TypeScript versions before 7", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
+    cleanupDirs.add(workspace);
+    const typescriptDir = resolve(workspace, "node_modules/typescript");
+    const platformDir = resolve(
+      workspace,
+      `node_modules/@typescript/typescript-linux-${process.arch}`,
+    );
+    const stableBin = resolve(platformDir, "lib/tsc");
+    const fallback = resolve(workspace, ".cache/corsa");
+
+    mkdirSync(typescriptDir, { recursive: true });
+    mkdirSync(dirname(stableBin), { recursive: true });
+    mkdirSync(dirname(fallback), { recursive: true });
+    writeFileSync(
+      resolve(typescriptDir, "package.json"),
+      JSON.stringify({ name: "typescript", version: "6.0.3" }),
+    );
+    writeFileSync(
+      resolve(platformDir, "package.json"),
+      JSON.stringify({ name: `@typescript/typescript-linux-${process.arch}`, version: "6.0.3" }),
+    );
+    writeFileSync(stableBin, "");
+    writeFileSync(fallback, "");
+
+    expect(defaultCorsaExecutable(workspace, "linux")).toBe(fallback);
   });
 
   it("prefers the installed native-preview tsgo binary when available", () => {
@@ -155,6 +216,39 @@ describe("context", () => {
       }),
     );
     writeFileSync(binPath, "#!/usr/bin/env node\n");
+
+    const pluginEntry = resolve(pluginRoot, "dist/plugin.js");
+    mkdirSync(dirname(pluginEntry), { recursive: true });
+    writeFileSync(pluginEntry, "export default {};\n");
+
+    expect(defaultCorsaExecutable(consumerRoot, "linux", pathToFileURL(pluginEntry).href)).toBe(
+      realpathSync(binPath),
+    );
+  });
+
+  it("resolves stable TypeScript 7 from a plugin anchor", () => {
+    const consumerRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-consumer-"));
+    const pluginRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-plugin-"));
+    cleanupDirs.add(consumerRoot);
+    cleanupDirs.add(pluginRoot);
+
+    const typescriptDir = resolve(pluginRoot, "node_modules/typescript");
+    const platformDir = resolve(
+      pluginRoot,
+      `node_modules/@typescript/typescript-linux-${process.arch}`,
+    );
+    const binPath = resolve(platformDir, "lib/tsc");
+    mkdirSync(typescriptDir, { recursive: true });
+    mkdirSync(dirname(binPath), { recursive: true });
+    writeFileSync(
+      resolve(typescriptDir, "package.json"),
+      JSON.stringify({ name: "typescript", version: "7.0.2" }),
+    );
+    writeFileSync(
+      resolve(platformDir, "package.json"),
+      JSON.stringify({ name: `@typescript/typescript-linux-${process.arch}`, version: "7.0.2" }),
+    );
+    writeFileSync(binPath, "");
 
     const pluginEntry = resolve(pluginRoot, "dist/plugin.js");
     mkdirSync(dirname(pluginEntry), { recursive: true });

--- a/src/bindings/nodejs/corsa_oxlint/ts/context.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.ts
@@ -26,6 +26,12 @@ export function defaultCorsaExecutable(
   platform = process.platform,
   resolveFrom?: string,
 ): string {
+  const stableTypeScript =
+    resolveStableTypeScriptExecutableFrom(resolve(rootDir, "package.json"), platform) ??
+    (resolveFrom ? resolveStableTypeScriptExecutableFrom(resolveFrom, platform) : undefined);
+  if (stableTypeScript) {
+    return stableTypeScript;
+  }
   const nativePreview =
     resolveNativePreviewExecutableFrom(resolve(rootDir, "package.json")) ??
     (resolveFrom ? resolveNativePreviewExecutableFrom(resolveFrom) : undefined);
@@ -39,7 +45,7 @@ export function defaultCorsaExecutable(
   throw new Error(
     [
       "corsa-oxlint could not locate a Corsa runtime executable.",
-      "Install `@typescript/native-preview`, set `CORSA_EXECUTABLE`, configure `parserOptions.corsa.executable`, or pass `resolveFrom` to `definePlugin`.",
+      "Install `typescript` 7 or `@typescript/native-preview`, set `CORSA_EXECUTABLE`, configure `parserOptions.corsa.executable`, or pass `resolveFrom` to `definePlugin`.",
     ].join(" "),
   );
 }
@@ -184,6 +190,46 @@ function globMatch(value: string, pattern: string): boolean {
 
 function asArray(value: string | string[] | undefined): string[] {
   return value ? (Array.isArray(value) ? value : [value]) : [];
+}
+
+function resolveStableTypeScriptExecutableFrom(
+  anchor: string,
+  platform: NodeJS.Platform,
+): string | undefined {
+  const requireFromAnchor = createRequire(anchor);
+  const packageJsonPath = resolveOptional(requireFromAnchor, "typescript/package.json");
+  if (!packageJsonPath || !isTypeScriptVersionSevenOrNewer(packageJsonPath)) {
+    return undefined;
+  }
+
+  const platformPackage = `@typescript/typescript-${platform}-${process.arch}`;
+  const requireFromTypeScript = createRequire(packageJsonPath);
+  const platformPackageJsonPath = resolveOptional(
+    requireFromTypeScript,
+    `${platformPackage}/package.json`,
+  );
+  if (!platformPackageJsonPath) {
+    return undefined;
+  }
+
+  const executable = resolve(
+    dirname(platformPackageJsonPath),
+    "lib",
+    platform === "win32" ? "tsc.exe" : "tsc",
+  );
+  return existsSync(executable) ? executable : undefined;
+}
+
+function isTypeScriptVersionSevenOrNewer(packageJsonPath: string): boolean {
+  try {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      readonly version?: string;
+    };
+    const major = Number.parseInt(packageJson.version?.split(".")[0] ?? "", 10);
+    return Number.isFinite(major) && major >= 7;
+  } catch {
+    return false;
+  }
 }
 
 function resolveNativePreviewExecutableFrom(anchor: string): string | undefined {

--- a/src/core/corsa_core/src/lint/rules/no_unnecessary_boolean_literal_compare.rs
+++ b/src/core/corsa_core/src/lint/rules/no_unnecessary_boolean_literal_compare.rs
@@ -171,10 +171,7 @@ fn boolean_comparison(node: &LintNode) -> Option<BooleanComparison<'_>> {
     let (expression, literal_boolean_in_comparison) =
         match boolean_literal_kind(strip_parens(right)) {
             Some(is_true) => (left, is_true),
-            None => match boolean_literal_kind(strip_parens(left)) {
-                Some(is_true) => (right, is_true),
-                None => return None,
-            },
+            None => (right, boolean_literal_kind(strip_parens(left))?),
         };
 
     // Inspect the constraint type of the compared expression.

--- a/src/core/corsa_orchestrator/src/orchestrator/state_tests.rs
+++ b/src/core/corsa_orchestrator/src/orchestrator/state_tests.rs
@@ -57,7 +57,7 @@ fn malformed_results_surface_decode_errors() {
     let mut state = ReplicatedState::default();
     state.results.insert(
         "broken".into(),
-        ReplicatedCacheEntry::new([b'{'].into_iter().collect(), Some(Duration::from_secs(60))),
+        ReplicatedCacheEntry::new((*b"{").into_iter().collect(), Some(Duration::from_secs(60))),
     );
     assert!(matches!(
         state.result::<String>("broken"),


### PR DESCRIPTION
## Summary

- discover the native platform executable shipped with TypeScript 7 and newer
- prefer stable TypeScript over `@typescript/native-preview` while preserving explicit overrides
- document the resolution order and cover stable, legacy, and plugin-anchor cases

## Root cause

Runtime discovery only resolved `@typescript/native-preview`, even though the pinned TypeScript 7 stable package ships the compatible native `tsc` executable in its platform package.

## Validation

- `vp test src/bindings/nodejs/corsa_oxlint/ts/context.test.ts`
- `vp fmt --check`
- `vp check --no-fmt` (passes with 4 pre-existing warnings)
- resolved a real temporary `typescript@7.0.2` installation to `@typescript/typescript-darwin-arm64/lib/tsc`

Closes #377

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786543088&installation_id=136613492&pr_number=378&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F378&signature=fd48a4412d2b6ec5e74fceb77d0106af5fbfdcb59acc1e865dde38f27e9fc222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime discovery to prefer the locally shipped TypeScript 7+ `tsc` before using `@typescript/native-preview`, then cached Corsa.
  * Updated “no runtime found” guidance to recommend installing TypeScript 7 or using an executable override.
* **Documentation / Tests**
  * Refined plugin runtime resolution documentation to reflect the default selection order and override precedence.
  * Expanded resolution test coverage for platform-specific `tsc` binaries and older TypeScript versions.
* **Chores**
  * Minor test data adjustment to keep malformed-cache decode error coverage accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->