### PR TITLE
fix: normalize empty type handles

### DIFF
--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -1943,7 +1943,7 @@ fn is_stale_handle_error(error: &CorsaError) -> bool {
 }
 
 fn is_stale_handle_message(message: &str) -> bool {
-    message.contains("not found in snapshot registry")
+    message.contains("not found in snapshot registry") || message.contains("empty type handle")
 }
 
 async fn get_signatures_of_type_with_parameter_texts(

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
@@ -233,6 +233,42 @@ describe("CorsaProjectSession", () => {
     ).toThrow(/unexpected failure/);
   });
 
+  it("returns an empty list when getBaseTypes hits an empty type handle", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    session.getTypeAtPosition("/tmp/one.ts", 0);
+    const client = clients[0];
+    if (!client) {
+      throw new Error("expected a fake client");
+    }
+    client.callJson.mockImplementationOnce(() => {
+      throw new Error("protocol error: api: client error: empty type handle");
+    });
+
+    expect(
+      session.getBaseTypes({
+        id: "type-1",
+        flags: 0,
+        texts: ["Base"],
+      } as never),
+    ).toEqual([]);
+  });
+
   it("returns a server-rendered cached type text when typeToString later hits a stale handle", () => {
     clients.length = 0;
     const runtime = {
@@ -304,6 +340,42 @@ describe("CorsaProjectSession", () => {
         id: "synthetic-type-argument:1:0:T",
         flags: 0,
         texts: ["T"],
+      } as never),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when getSymbolOfType hits an empty type handle", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    session.getTypeAtPosition("/tmp/one.ts", 0);
+    const client = clients[0];
+    if (!client) {
+      throw new Error("expected a fake client");
+    }
+    client.getSymbolOfType.mockImplementationOnce(() => {
+      throw new Error("protocol error: api: client error: empty type handle");
+    });
+
+    expect(
+      session.getSymbolOfType({
+        id: "type-1",
+        flags: 0,
+        texts: ["Base"],
       } as never),
     ).toBeUndefined();
   });

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -247,7 +247,7 @@ export class CorsaProjectSession {
   }
 
   private getSymbolOfTypeById(typeId: string): CorsaSymbol | undefined {
-    if (!this.#snapshot) {
+    if (!this.#snapshot || typeId.trim().length === 0) {
       return undefined;
     }
     try {
@@ -255,7 +255,7 @@ export class CorsaProjectSession {
         this.client().getSymbolOfType(this.#snapshot, typeId) as CorsaSymbol | null,
       );
     } catch (error) {
-      if (isStaleHandleError(error)) {
+      if (isMissingTypeHandleError(error)) {
         return undefined;
       }
       throw error;
@@ -316,36 +316,56 @@ export class CorsaProjectSession {
   }
 
   getBaseTypeOfLiteralType(type: CorsaType): CorsaType | undefined {
-    return this.rememberType(
-      this.client().callJson("getBaseTypeOfLiteralType", {
-        snapshot: this.#snapshot,
-        project: this.projectId(),
-        type: type.id,
-      }),
+    return this.withMissingTypeHandleFallback<CorsaType | undefined>(type, undefined, () =>
+      this.rememberType(
+        this.client().callJson("getBaseTypeOfLiteralType", {
+          snapshot: this.#snapshot,
+          project: this.projectId(),
+          type: type.id,
+        }),
+      ),
     );
   }
 
   getPropertiesOfType(type: CorsaType): readonly CorsaSymbol[] {
-    return this.rememberSymbols(
-      this.client().callJson("getPropertiesOfType", {
-        snapshot: this.#snapshot,
-        project: this.projectId(),
-        type: type.id,
-      }) ?? [],
+    return this.withMissingTypeHandleFallback<readonly CorsaSymbol[]>(type, [], () =>
+      this.rememberSymbols(
+        this.client().callJson("getPropertiesOfType", {
+          snapshot: this.#snapshot,
+          project: this.projectId(),
+          type: type.id,
+        }) ?? [],
+      ),
     );
   }
 
   getSignaturesOfType(type: CorsaType, kind: number): readonly CorsaSignature[] {
-    const source = this.sourceContextForType(type);
-    return this.rememberSignatures(
-      this.client().callJson("getSignaturesOfType", {
-        snapshot: this.#snapshot,
-        project: this.projectId(),
-        type: type.id,
-        kind,
-        ...source,
-      }) ?? [],
-    );
+    return this.withMissingTypeHandleFallback<readonly CorsaSignature[]>(type, [], () => {
+      const source = this.sourceContextForType(type);
+      return this.rememberSignatures(
+        this.client().callJson("getSignaturesOfType", {
+          snapshot: this.#snapshot,
+          project: this.projectId(),
+          type: type.id,
+          kind,
+          ...source,
+        }) ?? [],
+      );
+    });
+  }
+
+  private withMissingTypeHandleFallback<T>(type: CorsaType, fallback: T, operation: () => T): T {
+    if (type.id.trim().length === 0) {
+      return fallback;
+    }
+    try {
+      return operation();
+    } catch (error) {
+      if (isMissingTypeHandleError(error)) {
+        return fallback;
+      }
+      throw error;
+    }
   }
 
   getCallSignatureFacts(
@@ -354,20 +374,22 @@ export class CorsaProjectSession {
     argumentTypeTexts: readonly (readonly string[])[],
     explicitTypeArgumentTexts: readonly string[],
   ): CorsaCallSignatureFacts {
-    const source = this.sourceContextForType(type);
-    const facts = this.client().callJson<CorsaCallSignatureFacts>("getCallSignatureFacts", {
-      snapshot: this.#snapshot,
-      project: this.projectId(),
-      type: type.id,
-      kind,
-      ...source,
-      argumentTypeTexts,
-      explicitTypeArgumentTexts,
+    return this.withMissingTypeHandleFallback<CorsaCallSignatureFacts>(type, {}, () => {
+      const source = this.sourceContextForType(type);
+      const facts = this.client().callJson<CorsaCallSignatureFacts>("getCallSignatureFacts", {
+        snapshot: this.#snapshot,
+        project: this.projectId(),
+        type: type.id,
+        kind,
+        ...source,
+        argumentTypeTexts,
+        explicitTypeArgumentTexts,
+      });
+      if (facts?.signature) {
+        this.rememberSignature(facts.signature);
+      }
+      return facts ?? {};
     });
-    if (facts?.signature) {
-      this.rememberSignature(facts.signature);
-    }
-    return facts ?? {};
   }
 
   getReturnTypeOfSignature(signature: CorsaSignature): CorsaType | undefined {
@@ -396,40 +418,44 @@ export class CorsaProjectSession {
   }
 
   getBaseTypes(type: CorsaType): readonly CorsaType[] {
-    if (isArrayOrTupleLikeType(this, type)) {
-      return [];
-    }
-    return this.rememberTypes(
-      this.client().callJson("getBaseTypes", {
-        snapshot: this.#snapshot,
-        project: this.projectId(),
-        type: type.id,
-        texts: this.typeTexts(type),
-      }) ?? [],
-    );
+    return this.withMissingTypeHandleFallback<readonly CorsaType[]>(type, [], () => {
+      if (isArrayOrTupleLikeType(this, type)) {
+        return [];
+      }
+      return this.rememberTypes(
+        this.client().callJson("getBaseTypes", {
+          snapshot: this.#snapshot,
+          project: this.projectId(),
+          type: type.id,
+          texts: this.typeTexts(type),
+        }) ?? [],
+      );
+    });
   }
 
   getTypeArguments(type: CorsaType): readonly CorsaType[] {
-    const source = this.sourceSliceForType(type);
-    return this.rememberTypes(
-      source
-        ? (this.client().getTypeArgumentsAtSourceRange(
-            this.#snapshot!,
-            this.projectId(),
-            type.id,
-            type.objectFlags,
-            source.node.fileName,
-            source.node.pos,
-            source.node.end,
-            this.sourceTextForPath(source.node.fileName) ?? "",
-          ) as unknown as readonly CorsaType[])
-        : (this.client().getTypeArguments(
-            this.#snapshot!,
-            this.projectId(),
-            type.id,
-            type.objectFlags,
-          ) as unknown as readonly CorsaType[]),
-    );
+    return this.withMissingTypeHandleFallback<readonly CorsaType[]>(type, [], () => {
+      const source = this.sourceSliceForType(type);
+      return this.rememberTypes(
+        source
+          ? (this.client().getTypeArgumentsAtSourceRange(
+              this.#snapshot!,
+              this.projectId(),
+              type.id,
+              type.objectFlags,
+              source.node.fileName,
+              source.node.pos,
+              source.node.end,
+              this.sourceTextForPath(source.node.fileName) ?? "",
+            ) as unknown as readonly CorsaType[])
+          : (this.client().getTypeArguments(
+              this.#snapshot!,
+              this.projectId(),
+              type.id,
+              type.objectFlags,
+            ) as unknown as readonly CorsaType[]),
+      );
+    });
   }
 
   getTypesOfType(type: CorsaType): readonly CorsaType[] {
@@ -509,28 +535,34 @@ export class CorsaProjectSession {
   }
 
   getConstraintOfType(type: CorsaType): CorsaType | undefined {
-    return this.rememberType(
-      this.client().getConstraintOfType(this.#snapshot!, this.projectId(), type.id) as
-        | CorsaType
-        | undefined,
+    return this.withMissingTypeHandleFallback<CorsaType | undefined>(type, undefined, () =>
+      this.rememberType(
+        this.client().getConstraintOfType(this.#snapshot!, this.projectId(), type.id) as
+          | CorsaType
+          | undefined,
+      ),
     );
   }
 
   private callType(method: string, type: CorsaType): CorsaType | undefined {
-    return this.rememberType(
-      this.client().callJson<CorsaType | null>(method, {
-        snapshot: this.#snapshot,
-        type: type.id,
-      }) ?? undefined,
+    return this.withMissingTypeHandleFallback<CorsaType | undefined>(type, undefined, () =>
+      this.rememberType(
+        this.client().callJson<CorsaType | null>(method, {
+          snapshot: this.#snapshot,
+          type: type.id,
+        }) ?? undefined,
+      ),
     );
   }
 
   private callTypeArray(method: string, type: CorsaType): readonly CorsaType[] {
-    return this.rememberTypes(
-      this.client().callJson<readonly CorsaType[] | null>(method, {
-        snapshot: this.#snapshot,
-        type: type.id,
-      }) ?? [],
+    return this.withMissingTypeHandleFallback<readonly CorsaType[]>(type, [], () =>
+      this.rememberTypes(
+        this.client().callJson<readonly CorsaType[] | null>(method, {
+          snapshot: this.#snapshot,
+          type: type.id,
+        }) ?? [],
+      ),
     );
   }
 
@@ -1115,8 +1147,11 @@ function isRecoverableTransportError(error: unknown): boolean {
   );
 }
 
-function isStaleHandleError(error: unknown): boolean {
-  return errorMessage(error).includes("not found in snapshot registry");
+function isMissingTypeHandleError(error: unknown): boolean {
+  const message = errorMessage(error);
+  return (
+    message.includes("not found in snapshot registry") || message.includes("empty type handle")
+  );
 }
 
 function errorMessage(error: unknown): string {

--- a/src/core/corsa_client/src/api/client.rs
+++ b/src/core/corsa_client/src/api/client.rs
@@ -532,14 +532,14 @@ impl ApiClient {
         }
     }
 
-    /// Reports whether an error means the server dropped a type handle from its
-    /// snapshot registry.
+    /// Reports whether an error means the server could not resolve a type handle.
     ///
     /// Upstream Corsa occasionally evicts a live handle mid-session (for
     /// example after a base-types query on a class with no explicit `extends`
     /// clause). A follow-up relation query on that handle then fails with
-    /// "type handle ... not found in snapshot registry". Relation endpoints
-    /// treat this as missing data so analysis can continue instead of aborting.
+    /// "type handle ... not found in snapshot registry". Some upstream paths
+    /// instead report "empty type handle" for the same missing-data condition.
+    /// Relation endpoints treat both as missing data so analysis can continue.
     /// The message arrives as [`CorsaError::Protocol`] over msgpack and as
     /// [`CorsaError::Rpc`] over JSON-RPC, so both variants are inspected.
     pub(crate) fn is_stale_handle_error(error: &CorsaError) -> bool {
@@ -673,7 +673,7 @@ fn is_unknown_api_method_message(message: &str) -> bool {
 }
 
 fn is_stale_handle_message(message: &str) -> bool {
-    message.contains("not found in snapshot registry")
+    message.contains("not found in snapshot registry") || message.contains("empty type handle")
 }
 
 fn is_protocol_panic_message(message: &str) -> bool {
@@ -746,6 +746,13 @@ mod tests {
                 ),
                 data: None,
             },
+        )));
+    }
+
+    #[test]
+    fn recognizes_empty_type_handle_protocol_error() {
+        assert!(ApiClient::is_stale_handle_error(&CorsaError::Protocol(
+            CompactString::from("api: client error: empty type handle"),
         )));
     }
 


### PR DESCRIPTION
## Summary

- treat `empty type handle` as missing snapshot data alongside evicted handles
- preserve `undefined` / empty collection contracts across type relation queries
- keep unexpected protocol failures observable
- add regressions for `getSymbolOfType` and `getBaseTypes`

## Validation

- `pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/session.test.ts`
- `cargo test -p corsa_client api::client::tests --lib`
- `vp check --no-fmt` (passes with 4 pre-existing warnings)
- `vp fmt`

Closes #384

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786898398&installation_id=136613492&pr_number=385&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F385&signature=4c175561e896ac844f499b67a58ce452c4a39f11b65d44a25f951d47635a78d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->