### PR TITLE
fix: restore oxlint type traversal

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
@@ -19,6 +19,7 @@ class FakeClient {
     id: "symbol-1",
     name: "value",
   }));
+  readonly getSymbolAtPosition = vi.fn(() => undefined as { id: string; name: string } | undefined);
   readonly typeToString = vi.fn(() => "type:string");
   readonly releaseHandle = vi.fn();
   readonly close = vi.fn();
@@ -144,6 +145,40 @@ describe("CorsaProjectSession", () => {
     } as never);
 
     expect(result).toEqual([]);
+  });
+
+  it("does not send synthetic fallback types back to the runtime", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    session.getTypeAtPosition("/tmp/one.ts", 0);
+    const client = clients[0];
+    if (!client) {
+      throw new Error("expected a fake client");
+    }
+
+    expect(
+      session.getBaseTypes({
+        id: "synthetic-type-argument:14:0:Derived",
+        flags: 0,
+        texts: ["Derived"],
+      } as never),
+    ).toEqual([]);
+    expect(client.callJson).not.toHaveBeenCalledWith("getBaseTypes", expect.anything());
   });
 
   it("normalizes numeric raw type handles before typed client calls", () => {
@@ -342,6 +377,42 @@ describe("CorsaProjectSession", () => {
         texts: ["T"],
       } as never),
     ).toBeUndefined();
+  });
+
+  it("resolves a matching symbol from the original type lookup position", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    const type = session.getTypeAtPosition("/tmp/one.ts", 4);
+    const client = clients[0];
+    if (!client) {
+      throw new Error("expected a fake client");
+    }
+    client.getSymbolOfType.mockReturnValueOnce(null as never);
+    client.getSymbolAtPosition.mockReturnValueOnce({ id: "symbol-base", name: "Base" });
+    client.typeToString.mockReturnValueOnce("Base");
+
+    expect(session.getSymbolOfType(type as never)?.name).toBe("Base");
+    expect(client.getSymbolAtPosition).toHaveBeenCalledWith(
+      expect.any(String),
+      "project-1",
+      "/tmp/one.ts",
+      4,
+    );
   });
 
   it("returns undefined when getSymbolOfType hits an empty type handle", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -243,7 +243,31 @@ export class CorsaProjectSession {
         return symbol;
       }
     }
-    return this.getSymbolOfTypeById(type.id);
+    const symbol = this.getSymbolOfTypeById(type.id);
+    if (symbol) {
+      return symbol;
+    }
+    return this.getSymbolOfTypeAtLookup(type);
+  }
+
+  private getSymbolOfTypeAtLookup(type: CorsaType): CorsaSymbol | undefined {
+    const lookup = this.#typeLookupById.get(type.id);
+    if (!lookup) {
+      return undefined;
+    }
+    const symbol = this.getSymbolAtPosition(lookup.fileName, lookup.position, lookup.sourceText);
+    if (!isUsableSymbol(symbol)) {
+      return undefined;
+    }
+    const texts = this.typeTexts(type);
+    if (texts.some((text) => text.trim() === symbol.name)) {
+      return symbol;
+    }
+    try {
+      return this.typeToString(type).trim() === symbol.name ? symbol : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   private getSymbolOfTypeById(typeId: string): CorsaSymbol | undefined {
@@ -419,7 +443,7 @@ export class CorsaProjectSession {
 
   getBaseTypes(type: CorsaType): readonly CorsaType[] {
     return this.withMissingTypeHandleFallback<readonly CorsaType[]>(type, [], () => {
-      if (isArrayOrTupleLikeType(this, type)) {
+      if (isSyntheticTypeHandle(type.id) || isArrayOrTupleLikeType(this, type)) {
         return [];
       }
       return this.rememberTypes(
@@ -1021,6 +1045,10 @@ function isArrayOrTupleLikeType(session: CorsaProjectSession, type: CorsaType): 
 
 function isUsableSymbol(symbol: CorsaSymbol | null | undefined): symbol is CorsaSymbol {
   return symbol != null && !symbol.name.includes("\ufffd");
+}
+
+function isSyntheticTypeHandle(handle: string): boolean {
+  return handle.startsWith("synthetic-");
 }
 
 function normalizeType(type: CorsaType): void {

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -95,6 +95,44 @@ describe("corsa oxlint type locations", () => {
     expect(seen.classFromNode).toBe(seen.classFromId);
   });
 
+  integrationCase("exposes symbols for class declaration types", () => {
+    const seen: Record<string, string | null> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "class-declaration-type-symbols",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise class declaration type symbol lookup",
+          requiresTypeChecking: true,
+        },
+        messages: { unexpected: "unexpected" },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          ClassDeclaration(node: any) {
+            const name = node.id?.name;
+            const type = services.getTypeAtLocation(node);
+            if (name) {
+              seen[name] = type ? (checker.getSymbolOfType(type)?.name ?? null) : null;
+            }
+          },
+        };
+      },
+    });
+
+    new RuleTester().run("class-declaration-type-symbols", rule as any, {
+      valid: [{ code: "class Base {}\nclass Derived extends Base {}\n" }],
+      invalid: [],
+    });
+
+    expect(seen).toEqual({ Base: "Base", Derived: "Derived" });
+  });
+
   integrationCase("resolves declared types for type reference nodes", () => {
     const seen: {
       readonly name: string;
@@ -1332,6 +1370,61 @@ describe("corsa oxlint type locations", () => {
     expect(seen.intersection.parts).toEqual(expect.arrayContaining(["Foo", "{ x: number; }"]));
     expect(seen.mapped.args).toEqual(["Foo"]);
     expect(seen.mapped.target).toBe("Readonly<T>");
+  });
+
+  integrationCase("walks base types through intersections without protocol errors", () => {
+    const visited: string[] = [];
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "intersection-base-type-walk",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise recursive base type traversal",
+          requiresTypeChecking: true,
+        },
+        messages: { unexpected: "unexpected" },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        const walk = (type: any, depth = 0) => {
+          if (!type || depth > 8) {
+            return;
+          }
+          visited.push(checker.typeToString(type));
+          for (const base of checker.getBaseTypes(type)) {
+            walk(base, depth + 1);
+          }
+        };
+        return {
+          TSPropertySignature(node: any) {
+            if (node.key?.name === "target") {
+              walk(services.getTypeAtLocation(node));
+            }
+          },
+        };
+      },
+    });
+
+    new RuleTester().run("intersection-base-type-walk", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Base {}",
+            "class Derived extends Base {}",
+            "interface Props {",
+            "  target: Derived & { extra: string };",
+            "}",
+          ].join("\n"),
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(visited[0]).toContain("Derived");
   });
 
   integrationCase("exposes symbols from type handles", () => {


### PR DESCRIPTION
## Summary

- resolve class type symbols from their original source lookup when TypeScript 7 omits the symbol on the type handle
- stop synthetic intersection fallback types from being sent back to runtime APIs
- add regression coverage for class declarations and recursive intersection base-type walks

## Root cause

TypeScript 7 can return a class type without a directly attached symbol, while text-derived intersection constituents use synthetic handles that are not valid runtime `TypeID` values. The former silently returned `undefined`; the latter was sent to `getBaseTypes` and failed protocol decoding.

## Validation

- `vp fmt --write ...`
- `pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/session.test.ts` (13 passed)
- exact Issue reproductions against `typescript@7.0.2` (2 passed)
- `vp run build_corsa_oxlint_ci`

Closes #389
Closes #390

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->