### PR TITLE
fix: restore oxlint type relations for TypeScript 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 
+- `corsa-oxlint` now resolves nominal type symbols for interface and class property annotations.
+- `corsa-oxlint` now returns direct and inherited implemented interfaces after symbol, base-type, and generic-argument traversal while accepting compact TypeScript 7 declaration handles.
 - `corsa-oxlint` now discovers the native Corsa runtime shipped with TypeScript 7 or newer before falling back to `@typescript/native-preview`.
 - `corsa-oxlint` now reports a dependency-focused error when no default Corsa runtime executable can be found.
 - constructor signature parameter symbol fallback now preserves non-ASCII parameter names.

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -16,7 +16,7 @@ import type {
 
 type ImplementingClassCache = {
   readonly sourceText: string;
-  readonly names: ReadonlySet<string>;
+  readonly declarations: ReadonlyMap<string, readonly [start: number, end: number]>;
 };
 
 const implementingClassNamesBySession = new WeakMap<
@@ -410,13 +410,11 @@ function implementedTypesFromTypeDeclaration(
   if (cached) {
     return cached;
   }
-  const symbol = type.symbol
-    ? session.getSymbol(type.symbol)
-    : shouldRecoverImplementationSymbol(context, type)
-      ? checker.getSymbolOfType(type)
-      : undefined;
+  const symbol = type.symbol ? session.getSymbol(type.symbol) : undefined;
   const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
-  const declarationNode = declaration ? session.getNode(declaration) : undefined;
+  const declarationNode = declaration
+    ? session.getNode(declaration)
+    : implementingClassDeclaration(context, type);
   const sourceText = declarationNode
     ? sourceTextForPath(context, declarationNode.fileName)
     : undefined;
@@ -427,12 +425,23 @@ function implementedTypesFromTypeDeclaration(
   return session.cacheOwnImplementedTypes(type.id, implemented);
 }
 
-function shouldRecoverImplementationSymbol(
+function implementingClassDeclaration(
   context: ContextWithParserOptions,
   type: CorsaType,
-): boolean {
+): CorsaNode | undefined {
   const name = typeSymbolName(type.texts ?? []);
-  return name !== undefined && implementingClassNames(context).has(name);
+  if (!name) {
+    return undefined;
+  }
+  const range = implementingClassDeclarations(context).get(name);
+  return range
+    ? {
+        fileName: context.filename,
+        pos: range[0],
+        end: range[1],
+        range,
+      }
+    : undefined;
 }
 
 function typeSymbolName(texts: readonly string[]): string | undefined {
@@ -448,7 +457,9 @@ function typeSymbolName(texts: readonly string[]): string | undefined {
   return undefined;
 }
 
-function implementingClassNames(context: ContextWithParserOptions): ReadonlySet<string> {
+function implementingClassDeclarations(
+  context: ContextWithParserOptions,
+): ReadonlyMap<string, readonly [start: number, end: number]> {
   const session = sessionForContext(context).session;
   let byFile = implementingClassNamesBySession.get(session);
   if (!byFile) {
@@ -458,15 +469,17 @@ function implementingClassNames(context: ContextWithParserOptions): ReadonlySet<
   const sourceText = context.sourceCode.text;
   const cached = byFile.get(context.filename);
   if (cached?.sourceText === sourceText) {
-    return cached.names;
+    return cached.declarations;
   }
-  const names = collectImplementingClassNames(sourceText);
-  byFile.set(context.filename, { sourceText, names });
-  return names;
+  const declarations = collectImplementingClassDeclarations(sourceText);
+  byFile.set(context.filename, { sourceText, declarations });
+  return declarations;
 }
 
-function collectImplementingClassNames(sourceText: string): ReadonlySet<string> {
-  const names = new Set<string>();
+function collectImplementingClassDeclarations(
+  sourceText: string,
+): ReadonlyMap<string, readonly [start: number, end: number]> {
+  const declarations = new Map<string, readonly [start: number, end: number]>();
   let offset = 0;
   while (offset < sourceText.length) {
     const classOffset = findKeywordOutsideTrivia(sourceText.slice(offset), "class");
@@ -480,12 +493,12 @@ function collectImplementingClassNames(sourceText: string): ReadonlySet<string> 
       const bodyOpen = findClassBodyOpen(rest, 0);
       const header = rest.slice(0, bodyOpen >= 0 ? bodyOpen : rest.length);
       if (findKeywordOutsideTrivia(header, "implements") >= 0) {
-        names.add(match[1]);
+        declarations.set(match[1], [offset + classOffset, sourceText.length]);
       }
     }
     offset = declarationStart;
   }
-  return names;
+  return declarations;
 }
 
 function implementedTypesFromSourceText(

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -213,13 +213,19 @@ function sourceTextForPath(
   context: ContextWithParserOptions,
   fileName: string,
 ): string | undefined {
-  const normalizedFileName = fileName.toLowerCase();
-  const normalizedContextFilename = context.filename.toLowerCase();
-  return normalizedFileName === normalizedContextFilename ||
-    normalizedFileName.endsWith(normalizedContextFilename) ||
-    normalizedContextFilename.endsWith(normalizedFileName)
+  return pathsReferToSameFile(fileName, context.filename)
     ? context.sourceCode.text
     : sessionForContext(context).session.getSourceTextForPath(fileName);
+}
+
+function pathsReferToSameFile(left: string, right: string): boolean {
+  const normalizedLeft = left.replaceAll("\\", "/").toLowerCase();
+  const normalizedRight = right.replaceAll("\\", "/").toLowerCase();
+  return (
+    normalizedLeft === normalizedRight ||
+    normalizedLeft.endsWith(`/${normalizedRight}`) ||
+    normalizedRight.endsWith(`/${normalizedLeft}`)
+  );
 }
 
 function typeOfNewExpression(node: Node, checker: CorsaTypeCheckerShape): CorsaType | undefined {
@@ -384,7 +390,7 @@ function implementedTypesFromTypeDeclaration(
   checker: CorsaTypeCheckerShape,
 ): readonly CorsaType[] {
   const session = sessionForContext(context).session;
-  const symbol = type.symbol ? session.getSymbol(type.symbol) : undefined;
+  const symbol = checker.getSymbolOfType(type);
   const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
   const declarationNode = declaration ? session.getNode(declaration) : undefined;
   const sourceText = declarationNode

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -399,7 +399,7 @@ function implementedTypesFromTypeDeclaration(
   if (cached) {
     return cached;
   }
-  const symbol = checker.getSymbolOfType(type);
+  const symbol = session.getSymbolOfTypeFromSource(type);
   const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
   const declarationNode = declaration ? session.getNode(declaration) : undefined;
   const sourceText = declarationNode

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -420,11 +420,8 @@ function shouldRecoverImplementationSymbol(
   context: ContextWithParserOptions,
   type: CorsaType,
 ): boolean {
-  if (((type.objectFlags ?? 0) & 1) !== 0) {
-    return true;
-  }
   const name = typeSymbolName(type.texts ?? []);
-  return name !== undefined && sourceDeclaresClass(context.sourceCode.text, name);
+  return name !== undefined && sourceDeclaresImplementingClass(context.sourceCode.text, name);
 }
 
 function typeSymbolName(texts: readonly string[]): string | undefined {
@@ -440,7 +437,7 @@ function typeSymbolName(texts: readonly string[]): string | undefined {
   return undefined;
 }
 
-function sourceDeclaresClass(sourceText: string, name: string): boolean {
+function sourceDeclaresImplementingClass(sourceText: string, name: string): boolean {
   let offset = 0;
   while (offset < sourceText.length) {
     const classOffset = findKeywordOutsideTrivia(sourceText.slice(offset), "class");
@@ -451,7 +448,9 @@ function sourceDeclaresClass(sourceText: string, name: string): boolean {
     const rest = sourceText.slice(declarationStart);
     const match = /^\s*([$_\p{ID_Start}][$_\u200c\u200d\p{ID_Continue}]*)/u.exec(rest);
     if (match?.[1] === name) {
-      return true;
+      const bodyOpen = findClassBodyOpen(rest, 0);
+      const header = rest.slice(0, bodyOpen >= 0 ? bodyOpen : rest.length);
+      return findKeywordOutsideTrivia(header, "implements") >= 0;
     }
     offset = declarationStart;
   }

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -346,6 +346,11 @@ function implementedTypesFromTypeAndBases(
   type: CorsaType,
   checker: CorsaTypeCheckerShape,
 ): readonly CorsaType[] {
+  const session = sessionForContext(context).session;
+  const cached = session.getCachedImplementedTypes(type.id);
+  if (cached) {
+    return cached;
+  }
   // Iterative DFS over the base chain so we don't pay for one closure call
   // and one `push(...subResult)` spread per base (each spread used to copy
   // the entire growing accumulator). Visit order doesn't matter because we
@@ -381,7 +386,7 @@ function implementedTypesFromTypeAndBases(
       stack.push(baseType);
     }
   }
-  return implemented;
+  return session.cacheImplementedTypes(type.id, implemented);
 }
 
 function implementedTypesFromTypeDeclaration(
@@ -390,15 +395,21 @@ function implementedTypesFromTypeDeclaration(
   checker: CorsaTypeCheckerShape,
 ): readonly CorsaType[] {
   const session = sessionForContext(context).session;
+  const cached = session.getCachedOwnImplementedTypes(type.id);
+  if (cached) {
+    return cached;
+  }
   const symbol = checker.getSymbolOfType(type);
   const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
   const declarationNode = declaration ? session.getNode(declaration) : undefined;
   const sourceText = declarationNode
     ? sourceTextForPath(context, declarationNode.fileName)
     : undefined;
-  return declarationNode && sourceText
-    ? implementedTypesFromSourceText(context, declarationNode, sourceText, checker)
-    : [];
+  const implemented =
+    declarationNode && sourceText
+      ? implementedTypesFromSourceText(context, declarationNode, sourceText, checker)
+      : [];
+  return session.cacheOwnImplementedTypes(type.id, implemented);
 }
 
 function implementedTypesFromSourceText(

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -2,6 +2,7 @@ import type { Node } from "@oxlint/plugins";
 
 import { createNodeMaps, toPosition } from "./node_map";
 import { sessionForContext } from "./registry";
+import type { CorsaProjectSession } from "./session";
 import { SignatureKind } from "./types";
 import type {
   ContextWithParserOptions,
@@ -12,6 +13,16 @@ import type {
   CorsaType,
   CorsaTypeCheckerShape,
 } from "./types";
+
+type ImplementingClassCache = {
+  readonly sourceText: string;
+  readonly names: ReadonlySet<string>;
+};
+
+const implementingClassNamesBySession = new WeakMap<
+  CorsaProjectSession,
+  Map<string, ImplementingClassCache>
+>();
 
 export function createProgram(
   context: ContextWithParserOptions,
@@ -421,7 +432,7 @@ function shouldRecoverImplementationSymbol(
   type: CorsaType,
 ): boolean {
   const name = typeSymbolName(type.texts ?? []);
-  return name !== undefined && sourceDeclaresImplementingClass(context.sourceCode.text, name);
+  return name !== undefined && implementingClassNames(context).has(name);
 }
 
 function typeSymbolName(texts: readonly string[]): string | undefined {
@@ -437,24 +448,44 @@ function typeSymbolName(texts: readonly string[]): string | undefined {
   return undefined;
 }
 
-function sourceDeclaresImplementingClass(sourceText: string, name: string): boolean {
+function implementingClassNames(context: ContextWithParserOptions): ReadonlySet<string> {
+  const session = sessionForContext(context).session;
+  let byFile = implementingClassNamesBySession.get(session);
+  if (!byFile) {
+    byFile = new Map();
+    implementingClassNamesBySession.set(session, byFile);
+  }
+  const sourceText = context.sourceCode.text;
+  const cached = byFile.get(context.filename);
+  if (cached?.sourceText === sourceText) {
+    return cached.names;
+  }
+  const names = collectImplementingClassNames(sourceText);
+  byFile.set(context.filename, { sourceText, names });
+  return names;
+}
+
+function collectImplementingClassNames(sourceText: string): ReadonlySet<string> {
+  const names = new Set<string>();
   let offset = 0;
   while (offset < sourceText.length) {
     const classOffset = findKeywordOutsideTrivia(sourceText.slice(offset), "class");
     if (classOffset < 0) {
-      return false;
+      break;
     }
     const declarationStart = offset + classOffset + "class".length;
     const rest = sourceText.slice(declarationStart);
     const match = /^\s*([$_\p{ID_Start}][$_\u200c\u200d\p{ID_Continue}]*)/u.exec(rest);
-    if (match?.[1] === name) {
+    if (match?.[1]) {
       const bodyOpen = findClassBodyOpen(rest, 0);
       const header = rest.slice(0, bodyOpen >= 0 ? bodyOpen : rest.length);
-      return findKeywordOutsideTrivia(header, "implements") >= 0;
+      if (findKeywordOutsideTrivia(header, "implements") >= 0) {
+        names.add(match[1]);
+      }
     }
     offset = declarationStart;
   }
-  return false;
+  return names;
 }
 
 function implementedTypesFromSourceText(

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -399,7 +399,11 @@ function implementedTypesFromTypeDeclaration(
   if (cached) {
     return cached;
   }
-  const symbol = session.getSymbolOfTypeFromSource(type);
+  const symbol = type.symbol
+    ? session.getSymbol(type.symbol)
+    : shouldRecoverImplementationSymbol(context, type)
+      ? checker.getSymbolOfType(type)
+      : undefined;
   const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
   const declarationNode = declaration ? session.getNode(declaration) : undefined;
   const sourceText = declarationNode
@@ -410,6 +414,48 @@ function implementedTypesFromTypeDeclaration(
       ? implementedTypesFromSourceText(context, declarationNode, sourceText, checker)
       : [];
   return session.cacheOwnImplementedTypes(type.id, implemented);
+}
+
+function shouldRecoverImplementationSymbol(
+  context: ContextWithParserOptions,
+  type: CorsaType,
+): boolean {
+  if (((type.objectFlags ?? 0) & 1) !== 0) {
+    return true;
+  }
+  const name = typeSymbolName(type.texts ?? []);
+  return name !== undefined && sourceDeclaresClass(context.sourceCode.text, name);
+}
+
+function typeSymbolName(texts: readonly string[]): string | undefined {
+  for (const text of texts) {
+    const match =
+      /^(?:typeof\s+)?(?:[$_\p{ID_Start}][$_\u200c\u200d\p{ID_Continue}]*\.)*([$_\p{ID_Start}][$_\u200c\u200d\p{ID_Continue}]*)(?:\s*<|$)/u.exec(
+        text.trim(),
+      );
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return undefined;
+}
+
+function sourceDeclaresClass(sourceText: string, name: string): boolean {
+  let offset = 0;
+  while (offset < sourceText.length) {
+    const classOffset = findKeywordOutsideTrivia(sourceText.slice(offset), "class");
+    if (classOffset < 0) {
+      return false;
+    }
+    const declarationStart = offset + classOffset + "class".length;
+    const rest = sourceText.slice(declarationStart);
+    const match = /^\s*([$_\p{ID_Start}][$_\u200c\u200d\p{ID_Continue}]*)/u.exec(rest);
+    if (match?.[1] === name) {
+      return true;
+    }
+    offset = declarationStart;
+  }
+  return false;
 }
 
 function implementedTypesFromSourceText(

--- a/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
@@ -325,6 +325,104 @@ describe("corsa oxlint implemented types", () => {
     },
   );
 
+  integrationCase(
+    "resolves implemented interfaces for generic property arguments after a hierarchy walk",
+    () => {
+      const seen: Record<string, readonly string[] | undefined> = {};
+      const errors: string[] = [];
+      const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+      const rule = createRule({
+        name: "implemented-types-after-hierarchy-walk",
+        meta: {
+          type: "problem",
+          docs: {
+            description: "exercise property type arguments after symbol and base traversal",
+            requiresTypeChecking: true,
+          },
+          messages: { unexpected: "unexpected" },
+          schema: [],
+        },
+        defaultOptions: [],
+        create(context: any) {
+          const services = OxlintUtils.getParserServices(context);
+          const checker = services.program.getTypeChecker();
+          const walk = (type: any, depth = 0) => {
+            if (!type || depth > 8) {
+              return;
+            }
+            checker.getSymbolOfType(type);
+            for (const base of checker.getBaseTypes(type)) {
+              walk(base, depth + 1);
+            }
+          };
+          return {
+            ClassDeclaration(node: any) {
+              const type = services.getTypeAtLocation(node);
+              walk(type);
+              if (node.id?.name && type) {
+                seen[node.id.name] = checker
+                  .getImplementedTypesOfType(type)
+                  .map((implemented) => checker.typeToString(implemented));
+              }
+            },
+            PropertyDefinition(node: any) {
+              try {
+                const type = services.getTypeAtLocation(node);
+                if (type) {
+                  checker.getImplementedTypesOfType(type);
+                  for (const argument of checker.getTypeArguments(type)) {
+                    seen.argument = checker
+                      .getImplementedTypesOfType(argument)
+                      .map((implemented) => checker.typeToString(implemented));
+                  }
+                }
+              } catch (error) {
+                errors.push(error instanceof Error ? error.message : String(error));
+              }
+            },
+          };
+        },
+      });
+
+      new RuleTester({ languageOptions: { sourceType: "module" } }).run(
+        "implemented-types-after-hierarchy-walk",
+        rule as any,
+        {
+          valid: [
+            {
+              code: [
+                "interface IContainer { name: string; }",
+                "abstract class ContainerBase implements IContainer {",
+                "  abstract readonly name: string;",
+                "}",
+                "class Container extends ContainerBase {",
+                '  readonly name: string = "x";',
+                "}",
+                "interface Wrapper<T> { value: T; }",
+                "class Holder {",
+                "  public field: Wrapper<Container>;",
+                "}",
+              ].join("\n"),
+              settings: {
+                corsaOxlint: {
+                  parserOptions: {
+                    corsa: { executable: realCorsaBinary },
+                  },
+                },
+              },
+            },
+          ],
+          invalid: [],
+        },
+      );
+
+      expect(errors).toEqual([]);
+      expect(seen.ContainerBase).toEqual(["IContainer"]);
+      expect(seen.Container).toEqual(["IContainer"]);
+      expect(seen.argument).toEqual(["IContainer"]);
+    },
+  );
+
   integrationCase("returns inherited implemented interfaces from class types", () => {
     const seen: Record<string, readonly string[] | undefined> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
@@ -415,6 +415,78 @@ describe("CorsaProjectSession", () => {
     );
   });
 
+  it("resolves a nominal type symbol from a property type annotation", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+    const sourceText = "interface Props { p: Derived; }";
+    const propertyPosition = sourceText.indexOf("p:");
+    const typePosition = sourceText.indexOf("Derived");
+
+    const type = session.getTypeAtPosition("/tmp/one.ts", propertyPosition, sourceText);
+    const client = clients[0];
+    if (!client) {
+      throw new Error("expected a fake client");
+    }
+    client.getSymbolOfType.mockReturnValueOnce(null as never);
+    client.getSymbolAtPosition
+      .mockReturnValueOnce({ id: "symbol-property", name: "p" })
+      .mockReturnValueOnce({ id: "symbol-derived", name: "Derived" });
+    client.typeToString.mockReturnValueOnce("Derived");
+    (type as { texts: string[] }).texts = [];
+
+    expect(session.getSymbolOfType(type as never)?.name).toBe("Derived");
+    expect(client.getSymbolAtPosition).toHaveBeenLastCalledWith(
+      expect.any(String),
+      "project-1",
+      "/tmp/one.ts",
+      typePosition,
+    );
+  });
+
+  it("parses declaration handles that omit an end position", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+    const sourceText = "class Container {}";
+    session.getTypeAtPosition("/tmp/one.ts", 0, sourceText);
+
+    expect(session.getNode("0.264./tmp/one.ts")).toEqual({
+      id: "0.264./tmp/one.ts",
+      fileName: "/tmp/one.ts",
+      pos: 0,
+      end: sourceText.length,
+      range: [0, sourceText.length],
+    });
+    expect(session.getNode("0.18.264./tmp/one.ts")?.range).toEqual([0, 18]);
+  });
+
   it("returns undefined when getSymbolOfType hits an empty type handle", () => {
     clients.length = 0;
     const runtime = {

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -810,12 +810,6 @@ export class CorsaProjectSession {
     normalizeSymbol(symbol);
     this.#snapshotHasIssuedHandles = true;
     this.#symbolsById.set(symbol.id, symbol);
-    for (const declaration of symbol.declarations ?? []) {
-      this.rememberNode(declaration);
-    }
-    if (symbol.valueDeclaration) {
-      this.rememberNode(symbol.valueDeclaration);
-    }
     return symbol;
   }
 

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -256,18 +256,42 @@ export class CorsaProjectSession {
       return undefined;
     }
     const symbol = this.getSymbolAtPosition(lookup.fileName, lookup.position, lookup.sourceText);
-    if (!isUsableSymbol(symbol)) {
-      return undefined;
-    }
-    const texts = this.typeTexts(type);
-    if (texts.some((text) => text.trim() === symbol.name)) {
+    const texts = [...this.typeTexts(type)];
+    if (isUsableSymbol(symbol) && texts.some((text) => text.trim() === symbol.name)) {
       return symbol;
     }
     try {
-      return this.typeToString(type).trim() === symbol.name ? symbol : undefined;
+      const rendered = this.typeToString(type);
+      if (!texts.includes(rendered)) {
+        texts.unshift(rendered);
+      }
     } catch {
-      return undefined;
+      // A stale handle may still have cached texts or a usable lookup symbol.
     }
+    if (isUsableSymbol(symbol) && texts.some((text) => text.trim() === symbol.name)) {
+      return symbol;
+    }
+    const sourceText = lookup.sourceText ?? this.sourceTextForPath(lookup.fileName);
+    const typeSymbolName = typeSymbolNameFromTexts(texts);
+    if (sourceText && typeSymbolName) {
+      const typePosition = findIdentifierPosition(
+        sourceText,
+        typeSymbolName,
+        lookup.position,
+        lookup.position + 512,
+      );
+      if (typePosition !== undefined && typePosition !== lookup.position) {
+        const typeSymbol = this.getSymbolAtPosition(
+          lookup.fileName,
+          typePosition,
+          lookup.sourceText,
+        );
+        if (isUsableSymbol(typeSymbol) && typeSymbol.name === typeSymbolName) {
+          return typeSymbol;
+        }
+      }
+    }
+    return undefined;
   }
 
   private getSymbolOfTypeById(typeId: string): CorsaSymbol | undefined {
@@ -773,7 +797,7 @@ export class CorsaProjectSession {
   }
 
   private rememberNode(handle: string): CorsaNode | undefined {
-    const parsed = parseNodeHandle(handle);
+    const parsed = parseNodeHandle(handle, (fileName) => this.sourceTextForPath(fileName)?.length);
     if (!parsed) {
       return undefined;
     }
@@ -807,7 +831,7 @@ export class CorsaProjectSession {
 
   private sourceTextForPath(path: string): string | undefined {
     for (const [fileName, cached] of this.#files) {
-      if (fileName === path || fileName.endsWith(path)) {
+      if (pathsReferToSameFile(fileName, path)) {
         return cached.lintSourceText ?? cached.sourceText ?? readFileOrUndefined(fileName);
       }
     }
@@ -1051,6 +1075,52 @@ function isSyntheticTypeHandle(handle: string): boolean {
   return handle.startsWith("synthetic-");
 }
 
+function typeSymbolNameFromTexts(texts: readonly string[]): string | undefined {
+  for (const text of texts) {
+    const match =
+      /^(?:typeof\s+)?(?:[$_\p{ID_Start}][$_\u200c\u200d\p{ID_Continue}]*\.)*([$_\p{ID_Start}][$_\u200c\u200d\p{ID_Continue}]*)(?:\s*<|$)/u.exec(
+        text.trim(),
+      );
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return undefined;
+}
+
+function findIdentifierPosition(
+  sourceText: string,
+  identifier: string,
+  start: number,
+  end: number,
+): number | undefined {
+  const boundedEnd = Math.min(sourceText.length, end);
+  let position = sourceText.indexOf(identifier, Math.max(0, start));
+  while (position >= 0 && position < boundedEnd) {
+    const before = position > 0 ? sourceText[position - 1] : undefined;
+    const after = sourceText[position + identifier.length];
+    if (!isIdentifierPart(before) && !isIdentifierPart(after)) {
+      return position;
+    }
+    position = sourceText.indexOf(identifier, position + identifier.length);
+  }
+  return undefined;
+}
+
+function isIdentifierPart(char: string | undefined): boolean {
+  return char !== undefined && /[$_\u200c\u200d\p{ID_Continue}]/u.test(char);
+}
+
+function pathsReferToSameFile(left: string, right: string): boolean {
+  const normalizedLeft = left.replaceAll("\\", "/").toLowerCase();
+  const normalizedRight = right.replaceAll("\\", "/").toLowerCase();
+  return (
+    normalizedLeft === normalizedRight ||
+    normalizedLeft.endsWith(`/${normalizedRight}`) ||
+    normalizedRight.endsWith(`/${normalizedLeft}`)
+  );
+}
+
 function normalizeType(type: CorsaType): void {
   const mutable = type as {
     id: string;
@@ -1148,12 +1218,24 @@ function languageIdFor(fileName: string): string {
   return "typescript";
 }
 
-function parseNodeHandle(value: string): CorsaNode | undefined {
-  const [posText, endText, _kindText, ...pathParts] = value.split(".");
+function parseNodeHandle(
+  value: string,
+  sourceLengthForPath: (fileName: string) => number | undefined,
+): CorsaNode | undefined {
+  const [posText, secondText, thirdText, ...remainingParts] = value.split(".");
   const pos = Number(posText);
-  const end = Number(endText);
-  const fileName = pathParts.join(".");
-  if (!Number.isFinite(pos) || !Number.isFinite(end) || !fileName) {
+  const second = Number(secondText);
+  const third = Number(thirdText);
+  if (!Number.isFinite(pos) || !Number.isFinite(second)) {
+    return undefined;
+  }
+  const hasEndPosition = Number.isFinite(third);
+  const fileName = (hasEndPosition ? remainingParts : [thirdText, ...remainingParts]).join(".");
+  if (!fileName) {
+    return undefined;
+  }
+  const end = hasEndPosition ? second : (sourceLengthForPath(fileName) ?? pos + 1);
+  if (end < pos) {
     return undefined;
   }
   return { id: value, fileName, pos, end, range: [pos, end] };

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -252,15 +252,15 @@ export class CorsaProjectSession {
         return symbol;
       }
     }
-    const lookupSymbol = this.getSymbolOfTypeAtLookup(type);
-    if (lookupSymbol) {
-      this.#symbolsByTypeId.set(type.id, lookupSymbol);
-      return lookupSymbol;
-    }
     const symbol = this.getSymbolOfTypeById(type.id);
     if (symbol) {
       this.#symbolsByTypeId.set(type.id, symbol);
       return symbol;
+    }
+    const lookupSymbol = this.getSymbolOfTypeAtLookup(type);
+    if (lookupSymbol) {
+      this.#symbolsByTypeId.set(type.id, lookupSymbol);
+      return lookupSymbol;
     }
     this.#symbolsByTypeId.set(type.id, null);
     return undefined;

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -257,23 +257,25 @@ export class CorsaProjectSession {
     }
     const symbol = this.getSymbolAtPosition(lookup.fileName, lookup.position, lookup.sourceText);
     const texts = [...this.typeTexts(type)];
-    if (isUsableSymbol(symbol) && texts.some((text) => text.trim() === symbol.name)) {
-      return symbol;
-    }
-    try {
-      const rendered = this.typeToString(type);
-      if (!texts.includes(rendered)) {
-        texts.unshift(rendered);
+    if (isUsableSymbol(symbol)) {
+      if (texts.some((text) => text.trim() === symbol.name)) {
+        return symbol;
       }
-    } catch {
-      // A stale handle may still have cached texts or a usable lookup symbol.
-    }
-    if (isUsableSymbol(symbol) && texts.some((text) => text.trim() === symbol.name)) {
-      return symbol;
+      try {
+        const rendered = this.typeToString(type);
+        if (!texts.includes(rendered)) {
+          texts.unshift(rendered);
+        }
+      } catch {
+        // A stale handle may still have cached texts or a usable lookup symbol.
+      }
+      if (texts.some((text) => text.trim() === symbol.name)) {
+        return symbol;
+      }
     }
     const sourceText = lookup.sourceText ?? this.sourceTextForPath(lookup.fileName);
     const typeSymbolName = typeSymbolNameFromTexts(texts);
-    if (sourceText && typeSymbolName) {
+    if (isUsableSymbol(symbol) && sourceText && typeSymbolName) {
       const typePosition = findIdentifierPosition(
         sourceText,
         typeSymbolName,

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -30,7 +30,6 @@ type PreparedFileState = {
 
 type SourceSlice = {
   node: CorsaNode;
-  text: string;
 };
 
 type TypeLookup = {
@@ -765,7 +764,6 @@ export class CorsaProjectSession {
     };
     this.#typeSourceById.set(type.id, {
       node,
-      text: sourceText.slice(start, end),
     });
   }
 
@@ -899,7 +897,6 @@ export class CorsaProjectSession {
     }
     return {
       node,
-      text: sourceText.slice(node.pos, node.end),
     };
   }
 

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -240,6 +240,27 @@ export class CorsaProjectSession {
     );
   }
 
+  getSymbolOfTypeFromSource(type: CorsaType): CorsaSymbol | undefined {
+    return this.withTransportRecovery(() => {
+      const cached = this.#symbolsByTypeId.get(type.id);
+      if (cached) {
+        return cached;
+      }
+      if (type.symbol) {
+        const symbol = this.getSymbol(type.symbol);
+        if (isUsableSymbol(symbol)) {
+          this.#symbolsByTypeId.set(type.id, symbol);
+          return symbol;
+        }
+      }
+      const symbol = this.getSymbolOfTypeAtLookup(type);
+      if (symbol) {
+        this.#symbolsByTypeId.set(type.id, symbol);
+      }
+      return symbol;
+    }, "looking up a symbol from source");
+  }
+
   private getSymbolOfTypeUnchecked(type: CorsaType): CorsaSymbol | undefined {
     const cached = this.#symbolsByTypeId.get(type.id);
     if (cached !== undefined) {
@@ -277,6 +298,16 @@ export class CorsaProjectSession {
       if (texts.some((text) => text.trim() === symbol.name)) {
         return symbol;
       }
+    }
+    const sourceText = lookup.sourceText ?? this.sourceTextForPath(lookup.fileName);
+    let typeSymbolName = typeSymbolNameFromTexts(texts);
+    if (isUsableSymbol(symbol) && sourceText && typeSymbolName) {
+      const typeSymbol = this.getNearbyTypeSymbol(lookup, sourceText, typeSymbolName);
+      if (typeSymbol) {
+        return typeSymbol;
+      }
+    }
+    if (isUsableSymbol(symbol)) {
       try {
         const rendered = this.typeToString(type);
         if (!texts.includes(rendered)) {
@@ -288,28 +319,32 @@ export class CorsaProjectSession {
       if (texts.some((text) => text.trim() === symbol.name)) {
         return symbol;
       }
+      typeSymbolName = typeSymbolNameFromTexts(texts);
     }
-    const sourceText = lookup.sourceText ?? this.sourceTextForPath(lookup.fileName);
-    const typeSymbolName = typeSymbolNameFromTexts(texts);
     if (isUsableSymbol(symbol) && sourceText && typeSymbolName) {
-      const typePosition = findIdentifierPosition(
-        sourceText,
-        typeSymbolName,
-        lookup.position,
-        lookup.position + 512,
-      );
-      if (typePosition !== undefined && typePosition !== lookup.position) {
-        const typeSymbol = this.getSymbolAtPosition(
-          lookup.fileName,
-          typePosition,
-          lookup.sourceText,
-        );
-        if (isUsableSymbol(typeSymbol) && typeSymbol.name === typeSymbolName) {
-          return typeSymbol;
-        }
-      }
+      return this.getNearbyTypeSymbol(lookup, sourceText, typeSymbolName);
     }
     return undefined;
+  }
+
+  private getNearbyTypeSymbol(
+    lookup: TypeLookup,
+    sourceText: string,
+    typeSymbolName: string,
+  ): CorsaSymbol | undefined {
+    const typePosition = findIdentifierPosition(
+      sourceText,
+      typeSymbolName,
+      lookup.position,
+      lookup.position + 512,
+    );
+    if (typePosition === undefined || typePosition === lookup.position) {
+      return undefined;
+    }
+    const typeSymbol = this.getSymbolAtPosition(lookup.fileName, typePosition, lookup.sourceText);
+    return isUsableSymbol(typeSymbol) && typeSymbol.name === typeSymbolName
+      ? typeSymbol
+      : undefined;
   }
 
   private getSymbolOfTypeById(typeId: string): CorsaSymbol | undefined {

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -240,27 +240,6 @@ export class CorsaProjectSession {
     );
   }
 
-  getSymbolOfTypeFromSource(type: CorsaType): CorsaSymbol | undefined {
-    return this.withTransportRecovery(() => {
-      const cached = this.#symbolsByTypeId.get(type.id);
-      if (cached) {
-        return cached;
-      }
-      if (type.symbol) {
-        const symbol = this.getSymbol(type.symbol);
-        if (isUsableSymbol(symbol)) {
-          this.#symbolsByTypeId.set(type.id, symbol);
-          return symbol;
-        }
-      }
-      const symbol = this.getSymbolOfTypeAtLookup(type);
-      if (symbol) {
-        this.#symbolsByTypeId.set(type.id, symbol);
-      }
-      return symbol;
-    }, "looking up a symbol from source");
-  }
-
   private getSymbolOfTypeUnchecked(type: CorsaType): CorsaSymbol | undefined {
     const cached = this.#symbolsByTypeId.get(type.id);
     if (cached !== undefined) {

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -901,6 +901,10 @@ export class CorsaProjectSession {
   }
 
   private sourceTextForPath(path: string): string | undefined {
+    const direct = this.#files.get(path);
+    if (direct) {
+      return direct.lintSourceText ?? direct.sourceText ?? readFileOrUndefined(path);
+    }
     for (const [fileName, cached] of this.#files) {
       if (pathsReferToSameFile(fileName, path)) {
         return cached.lintSourceText ?? cached.sourceText ?? readFileOrUndefined(fileName);

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -64,8 +64,12 @@ export class CorsaProjectSession {
   #projects: ProjectResponse[] = [];
   #files = new Map<string, FileCache>();
   #symbolsById = new Map<string, CorsaSymbol>();
+  #symbolsByTypeId = new Map<string, CorsaSymbol | null>();
   #symbolTypeById = new Map<string, string>();
   #nodesById = new Map<string, CorsaNode>();
+  #baseTypesById = new Map<string, readonly CorsaType[]>();
+  #implementedTypesById = new Map<string, readonly CorsaType[]>();
+  #ownImplementedTypesById = new Map<string, readonly CorsaType[]>();
   #typeLookupById = new Map<string, TypeLookup>();
   #typeSourceById = new Map<string, SourceSlice>();
   #typeTextById = new Map<string, string>();
@@ -237,17 +241,29 @@ export class CorsaProjectSession {
   }
 
   private getSymbolOfTypeUnchecked(type: CorsaType): CorsaSymbol | undefined {
+    const cached = this.#symbolsByTypeId.get(type.id);
+    if (cached !== undefined) {
+      return cached ?? undefined;
+    }
     if (type.symbol) {
       const symbol = this.getSymbol(type.symbol);
       if (isUsableSymbol(symbol)) {
+        this.#symbolsByTypeId.set(type.id, symbol);
         return symbol;
       }
     }
+    const lookupSymbol = this.getSymbolOfTypeAtLookup(type);
+    if (lookupSymbol) {
+      this.#symbolsByTypeId.set(type.id, lookupSymbol);
+      return lookupSymbol;
+    }
     const symbol = this.getSymbolOfTypeById(type.id);
     if (symbol) {
+      this.#symbolsByTypeId.set(type.id, symbol);
       return symbol;
     }
-    return this.getSymbolOfTypeAtLookup(type);
+    this.#symbolsByTypeId.set(type.id, null);
+    return undefined;
   }
 
   private getSymbolOfTypeAtLookup(type: CorsaType): CorsaSymbol | undefined {
@@ -472,15 +488,39 @@ export class CorsaProjectSession {
       if (isSyntheticTypeHandle(type.id) || isArrayOrTupleLikeType(this, type)) {
         return [];
       }
-      return this.rememberTypes(
-        this.client().callJson("getBaseTypes", {
+      const cached = this.#baseTypesById.get(type.id);
+      if (cached) {
+        return cached;
+      }
+      const baseTypes = this.rememberTypes(
+        this.client().callJson<readonly CorsaType[]>("getBaseTypes", {
           snapshot: this.#snapshot,
           project: this.projectId(),
           type: type.id,
           texts: this.typeTexts(type),
         }) ?? [],
       );
+      this.#baseTypesById.set(type.id, baseTypes);
+      return baseTypes;
     });
+  }
+
+  getCachedImplementedTypes(typeId: string): readonly CorsaType[] | undefined {
+    return this.#implementedTypesById.get(typeId);
+  }
+
+  cacheImplementedTypes(typeId: string, types: readonly CorsaType[]): readonly CorsaType[] {
+    this.#implementedTypesById.set(typeId, types);
+    return types;
+  }
+
+  getCachedOwnImplementedTypes(typeId: string): readonly CorsaType[] | undefined {
+    return this.#ownImplementedTypesById.get(typeId);
+  }
+
+  cacheOwnImplementedTypes(typeId: string, types: readonly CorsaType[]): readonly CorsaType[] {
+    this.#ownImplementedTypesById.set(typeId, types);
+    return types;
   }
 
   getTypeArguments(type: CorsaType): readonly CorsaType[] {
@@ -809,8 +849,12 @@ export class CorsaProjectSession {
 
   private clearHandleCaches(): void {
     this.#symbolsById.clear();
+    this.#symbolsByTypeId.clear();
     this.#symbolTypeById.clear();
     this.#nodesById.clear();
+    this.#baseTypesById.clear();
+    this.#implementedTypesById.clear();
+    this.#ownImplementedTypesById.clear();
     this.#typeLookupById.clear();
     this.#typeSourceById.clear();
     this.#snapshotHasIssuedHandles = false;

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -72,6 +72,7 @@ export class CorsaProjectSession {
   #ownImplementedTypesById = new Map<string, readonly CorsaType[]>();
   #typeLookupById = new Map<string, TypeLookup>();
   #typeSourceById = new Map<string, SourceSlice>();
+  #sourceLengthByPath = new Map<string, number>();
   #typeTextById = new Map<string, string>();
   #lastRefreshMs = 0;
   #snapshotHasIssuedHandles = false;
@@ -853,7 +854,7 @@ export class CorsaProjectSession {
   }
 
   private rememberNode(handle: string): CorsaNode | undefined {
-    const parsed = parseNodeHandle(handle, (fileName) => this.sourceTextForPath(fileName)?.length);
+    const parsed = parseNodeHandle(handle, (fileName) => this.sourceLengthForPath(fileName));
     if (!parsed) {
       return undefined;
     }
@@ -871,7 +872,20 @@ export class CorsaProjectSession {
     this.#ownImplementedTypesById.clear();
     this.#typeLookupById.clear();
     this.#typeSourceById.clear();
+    this.#sourceLengthByPath.clear();
     this.#snapshotHasIssuedHandles = false;
+  }
+
+  private sourceLengthForPath(path: string): number | undefined {
+    const cached = this.#sourceLengthByPath.get(path);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const length = this.sourceTextForPath(path)?.length;
+    if (length !== undefined) {
+      this.#sourceLengthByPath.set(path, length);
+    }
+    return length;
   }
 
   private sourceSliceForHandle(handle: string): SourceSlice | undefined {

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -1428,7 +1428,7 @@ describe("corsa oxlint type locations", () => {
   });
 
   integrationCase("exposes symbols from type handles", () => {
-    const seen: Record<string, string | undefined> = {};
+    const seen: Record<string, string | null | undefined> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
     const rule = createRule({
       name: "type-symbol-accessor",
@@ -1453,7 +1453,14 @@ describe("corsa oxlint type locations", () => {
               return;
             }
             const type = checker.getTypeAtLocation(node);
-            seen.animal = type ? checker.getSymbolOfType(type)?.name : undefined;
+            seen.animal = type ? (checker.getSymbolOfType(type)?.name ?? null) : undefined;
+          },
+          PropertyDefinition(node: any) {
+            if (node.key?.name !== "resident") {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node);
+            seen.resident = type ? (checker.getSymbolOfType(type)?.name ?? null) : undefined;
           },
         };
       },
@@ -1463,7 +1470,15 @@ describe("corsa oxlint type locations", () => {
     tester.run("type-symbol-accessor", rule as any, {
       valid: [
         {
-          code: ["class Animal {}", "interface Bag {", "  animal: Animal;", "}"].join("\n"),
+          code: [
+            "class Animal {}",
+            "interface Bag {",
+            "  animal: Animal;",
+            "}",
+            "class Habitat {",
+            "  resident: Animal;",
+            "}",
+          ].join("\n"),
           settings: {
             corsaOxlint: {
               parserOptions: {
@@ -1480,6 +1495,7 @@ describe("corsa oxlint type locations", () => {
     });
 
     expect(seen.animal).toBe("Animal");
+    expect(seen.resident).toBe("Animal");
   });
 
   integrationCase("exposes symbols for type references with the default corsa executable", () => {


### PR DESCRIPTION
## Summary

- accept compact TypeScript 7 declaration handles and recover their source ranges
- resolve nominal symbols from property type annotations when runtime handles are stale
- restore direct and inherited `getImplementedTypesOfType` results across hierarchy and generic-argument traversal

## Root cause

TypeScript 7 emits declaration handles without the legacy end-position segment. The client parsed those handles as the older four-part format, reducing a path such as `case.ts` to `ts`. That prevented declaration-source recovery and could turn a fallback lookup into `source file not found: ts`. The implemented-type helper also bypassed the existing symbol fallback.

## Validation

- `pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/session.test.ts` (15 passed)
- `vp check --no-fmt` (0 errors; 4 pre-existing warnings)
- `vp run -w fmt_check_rust`
- exact Issue #392/#393 probe against `typescript@7.0.2` using a packed local `corsa-oxlint`: property symbols resolved to `Container`; direct, inherited, and generic-argument implemented types resolved to `IContainer`; no protocol error

Closes #392
Closes #393

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->