### PR TITLE
fix: restore implemented types for same-file class declarations

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -55,13 +55,15 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
         return typeOfNewExpression(node as Node, this);
       }
       const lookupNode = nodeForTypeLookup(node);
-      return sessionForContext(context).session.getTypeAtSourceRange(
+      const type = sessionForContext(context).session.getTypeAtSourceRange(
         filenameFor(context, lookupNode),
         toPosition(lookupNode),
         endPosition(lookupNode),
         sourceTextFor(context, lookupNode),
         nodeKind(lookupNode),
       );
+      primeImplementedTypesCacheFromNode(context, node, type, this);
+      return type;
     },
     getContextualType(node) {
       return this.getTypeAtLocation(node);
@@ -206,6 +208,26 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
       return (type.flags & typeFlags.intersection) !== 0;
     },
   };
+}
+
+function primeImplementedTypesCacheFromNode(
+  context: ContextWithParserOptions,
+  node: Node | CorsaNode,
+  type: CorsaType | undefined,
+  checker: CorsaTypeCheckerShape,
+): void {
+  if (!type || "pos" in node) {
+    return;
+  }
+  const kind = (node as { readonly type?: string }).type;
+  if (kind !== "ClassDeclaration" && kind !== "ClassExpression") {
+    return;
+  }
+  const session = sessionForContext(context).session;
+  if (session.getCachedOwnImplementedTypes(type.id)) {
+    return;
+  }
+  session.cacheOwnImplementedTypes(type.id, checker.getImplementedTypes(node));
 }
 
 const typeFlags = {
@@ -412,15 +434,19 @@ function implementedTypesFromTypeDeclaration(
   }
   const symbol = type.symbol ? session.getSymbol(type.symbol) : undefined;
   const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
-  const declarationNode = declaration
-    ? session.getNode(declaration)
-    : implementingClassDeclaration(context, type);
-  const sourceText = declarationNode
-    ? sourceTextForPath(context, declarationNode.fileName)
+  const declarationNode = declaration ? session.getNode(declaration) : undefined;
+  const localImplementingDeclaration =
+    declarationNode && pathsReferToSameFile(declarationNode.fileName, context.filename)
+      ? implementingClassDeclaration(context, type, symbol)
+      : undefined;
+  const resolvedDeclarationNode =
+    localImplementingDeclaration ?? declarationNode ?? implementingClassDeclaration(context, type, symbol);
+  const sourceText = resolvedDeclarationNode
+    ? sourceTextForPath(context, resolvedDeclarationNode.fileName)
     : undefined;
   const implemented =
-    declarationNode && sourceText
-      ? implementedTypesFromSourceText(context, declarationNode, sourceText, checker)
+    resolvedDeclarationNode && sourceText
+      ? implementedTypesFromSourceText(context, resolvedDeclarationNode, sourceText, checker)
       : [];
   return session.cacheOwnImplementedTypes(type.id, implemented);
 }
@@ -428,8 +454,9 @@ function implementedTypesFromTypeDeclaration(
 function implementingClassDeclaration(
   context: ContextWithParserOptions,
   type: CorsaType,
+  symbol?: CorsaSymbol,
 ): CorsaNode | undefined {
-  const name = typeSymbolName(type.texts ?? []);
+  const name = implementingClassName(type, symbol);
   if (!name) {
     return undefined;
   }
@@ -442,6 +469,10 @@ function implementingClassDeclaration(
         range,
       }
     : undefined;
+}
+
+function implementingClassName(type: CorsaType, symbol?: CorsaSymbol): string | undefined {
+  return symbol?.name || typeSymbolName(type.texts ?? []);
 }
 
 function typeSymbolName(texts: readonly string[]): string | undefined {

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -440,7 +440,9 @@ function implementedTypesFromTypeDeclaration(
       ? implementingClassDeclaration(context, type, symbol)
       : undefined;
   const resolvedDeclarationNode =
-    localImplementingDeclaration ?? declarationNode ?? implementingClassDeclaration(context, type, symbol);
+    localImplementingDeclaration ??
+    declarationNode ??
+    implementingClassDeclaration(context, type, symbol);
   const sourceText = resolvedDeclarationNode
     ? sourceTextForPath(context, resolvedDeclarationNode.fileName)
     : undefined;

--- a/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
@@ -157,6 +157,79 @@ describe("corsa oxlint implemented types", () => {
     expect(seen.byType).toEqual(["IChild"]);
   });
 
+  integrationCase("returns implemented interfaces from same-file class declaration types", () => {
+    const seen: Record<string, readonly string[] | undefined> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "implemented-types-of-same-file-class-declarations",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise implemented types resolved from same-file class declaration types",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          ClassDeclaration(node: any) {
+            const className = node.id?.name;
+            const type = checker.getTypeAtLocation(node);
+            if (!className || !type) {
+              return;
+            }
+            seen[className] = checker
+              .getImplementedTypesOfType(type)
+              .map((implemented) => checker.typeToString(implemented));
+          },
+        };
+      },
+    });
+
+    new RuleTester({ languageOptions: { sourceType: "module" } }).run(
+      "implemented-types-of-same-file-class-declarations",
+      rule as any,
+      {
+        valid: [
+          {
+            code: [
+              "interface IContainer { name: string; }",
+              "class Plain implements IContainer {",
+              '  name = "x";',
+              "}",
+              "abstract class ContainerBase implements IContainer {",
+              "  abstract readonly name: string;",
+              "}",
+              "class Container extends ContainerBase {",
+              '  readonly name: string = "x";',
+              "}",
+            ].join("\n"),
+            settings: {
+              corsaOxlint: {
+                parserOptions: {
+                  corsa: {
+                    executable: realCorsaBinary,
+                  },
+                },
+              },
+            },
+          },
+        ],
+        invalid: [],
+      },
+    );
+
+    expect(seen.Plain).toEqual(["IContainer"]);
+    expect(seen.ContainerBase).toEqual(["IContainer"]);
+    expect(seen.Container).toEqual(["IContainer"]);
+  });
+
   integrationCase("resolves namespace-qualified implemented interfaces from class types", () => {
     const seen: Record<string, readonly string[] | undefined> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);


### PR DESCRIPTION
## Summary
- restore `getImplementedTypesOfType` for same-file class declarations when TypeScript 7 returns class types with empty `texts`
- seed the implemented-types cache from the original class AST node so later type-based lookups can reuse the direct `implements` resolution
- add a regression test covering `Plain`, `ContainerBase`, and inherited `Container` resolution

## Root cause
The type-based implementation trusted same-file declaration handles that only identified a narrow symbol span, and the fallback name recovery still depended on synthetic source lookups. Under TypeScript 7, class types from `ClassDeclaration` can arrive with empty `texts`, so `getImplementedTypesOfType` lost the direct `implements` information and returned `[]`.

## Validation
- `vp run -w build_corsa_oxlint`
- exact `#395` probe against the locally built package with a temporary `typescript@7.0.2` runtime; observed `Plain`, `ContainerBase`, and `Container` all resolving to `IContainer`

Closes #395

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->