### PR TITLE
fix: resolve lint warnings

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/rule_tester_cleanup.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rule_tester_cleanup.test.ts
@@ -36,8 +36,8 @@ vi.mock("./context", () => ({
   defaultCorsaExecutable: vi.fn(() => "/tmp/corsa"),
   mergeTypeAwareParserOptions: vi.fn(
     (left: Record<string, unknown> | undefined, right: Record<string, unknown> | undefined) => ({
-      ...(left ?? {}),
-      ...(right ?? {}),
+      ...left,
+      ...right,
     }),
   ),
 }));

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
@@ -9,7 +9,7 @@ import type {
 
 import { createNativeRule } from "./rule_creator";
 import { checkerFor, propertyNamesOfNode, typeAtNode, typeTextsAtNode } from "./type_utils";
-import type { ContextWithParserOptions, CorsaCallSignatureFacts, CorsaType } from "../types";
+import type { ContextWithParserOptions, CorsaCallSignatureFacts } from "../types";
 
 type RangedNode = {
   readonly type: string;
@@ -583,17 +583,6 @@ function typeParameterName(node: any): string | undefined {
     return node.name.name;
   }
   return undefined;
-}
-
-function renderTypeTexts(context: ContextWithParserOptions, type: CorsaType): readonly string[] {
-  const texts = new Set<string>();
-  const checker = checkerFor(context);
-  for (const text of [...(type.texts ?? []), checker.typeToString(type)]) {
-    if (text) {
-      texts.add(text);
-    }
-  }
-  return [...texts];
 }
 
 function nearestFunctionAncestor(context: ContextWithParserOptions, node: any): any {

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -1594,7 +1594,9 @@ describe("corsa oxlint type locations", () => {
             const symbol = type ? checker.getSymbolOfType(type) : undefined;
             seen[keyName] = {
               name: symbol?.name,
-              codepoints: symbol ? [...symbol.name].map((char) => char.codePointAt(0) ?? 0) : null,
+              codepoints: symbol
+                ? Array.from(symbol.name, (char) => char.codePointAt(0) ?? 0)
+                : null,
             };
           },
         };


### PR DESCRIPTION
## Summary

- remove unnecessary empty-object fallbacks from parser option test mocks
- remove an unused native bridge type-rendering helper and import
- use `Array.from` when collecting symbol code points

## Why

Recent lint rules identified four warnings: two unnecessary spread fallbacks, one unused helper, and one string spread that could mishandle complex Unicode characters.

## Impact

The workspace lint and type check now completes without warnings. Runtime behavior is unchanged; the code-point assertion continues to iterate Unicode code points safely.

## Validation

- `vp check`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/rule_tester_cleanup.test.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test handling for parser options and Unicode symbol names.
  * Preserved existing fallback behavior when type information is unavailable.

* **Refactor**
  * Simplified internal type-processing logic without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->