### PR TITLE
fix: enable issue agent auto-merge by default

### DIFF
--- a/docs/ai_agent_issue_workflow.md
+++ b/docs/ai_agent_issue_workflow.md
@@ -14,7 +14,8 @@ The script uses the local `gh` and `codex` CLIs to:
 - create a local `codex/issue-<number>-...` branch
 - run `codex exec` with the issue context
 - commit generated changes with a Conventional Commits title
-- push the branch and open a draft pull request
+- push the branch and open a ready-for-review pull request
+- enable squash auto-merge
 - wait for pull request checks unless disabled
 
 Processed issues are recorded in `.cache/issue-agent/state.json`, which is
@@ -47,7 +48,8 @@ Useful options:
 ```bash
 vp exec node --strip-types ./scripts/issue_agent.ts run --issue 328 --model gpt-5
 vp exec node --strip-types ./scripts/issue_agent.ts run --issue 328 --no-wait-ci
-vp exec node --strip-types ./scripts/issue_agent.ts run --issue 328 --no-draft
+vp exec node --strip-types ./scripts/issue_agent.ts run --issue 328 --draft
+vp exec node --strip-types ./scripts/issue_agent.ts run --issue 328 --no-auto-merge
 ```
 
 ## Watch Issues
@@ -74,7 +76,8 @@ The script enforces these local conventions:
 - PR titles use Conventional Commits format.
 - PR titles do not include `[codex]`.
 - PR bodies include `Closes #<issue-number>`.
-- PRs are draft by default.
+- PRs are ready for review and use squash auto-merge by default.
+- `--draft` keeps work in progress, while `--no-auto-merge` leaves merging manual.
 - PR checks are watched by default after creation.
 
 Codex is asked to write proposed PR metadata under

--- a/scripts/issue_agent.ts
+++ b/scripts/issue_agent.ts
@@ -6,12 +6,13 @@ import { fail, rootDir } from "./shared.ts";
 type Mode = "run" | "watch";
 
 interface Options {
+  readonly autoMerge: boolean;
   readonly baseBranch?: string;
+  readonly draft: boolean;
   readonly issueNumber?: number;
   readonly limit: number;
   readonly mode: Mode;
   readonly model?: string;
-  readonly noDraft: boolean;
   readonly noWaitCi: boolean;
   readonly once: boolean;
   readonly pollSeconds: number;
@@ -56,10 +57,11 @@ function usage(): never {
   node --strip-types ./scripts/issue_agent.ts watch [--repo owner/name] [--poll-seconds 60] [--once]
 
 Options:
+  --draft                 Open a draft PR and skip auto-merge.
   --base <branch>          Base branch. Defaults to the repository default branch.
   --limit <n>              Max open issues to inspect per poll. Default: 50.
   --model <model>          Model passed to codex exec.
-  --no-draft              Open ready-for-review PRs instead of draft PRs.
+  --no-auto-merge         Do not enable squash auto-merge on ready PRs.
   --no-wait-ci            Do not wait for pull request checks after creating a PR.
   --state-file <path>     Processed issue state. Default: .cache/issue-agent/state.json.
 `);
@@ -73,10 +75,11 @@ function parseArgs(args: readonly string[]): Options {
   }
 
   let issueNumber: number | undefined;
+  let autoMerge = true;
   let baseBranch: string | undefined;
+  let draft = false;
   let limit = 50;
   let model: string | undefined;
-  let noDraft = false;
   let noWaitCi = false;
   let once = false;
   let pollSeconds = 60;
@@ -95,6 +98,9 @@ function parseArgs(args: readonly string[]): Options {
     };
 
     switch (arg) {
+      case "--draft":
+        draft = true;
+        break;
       case "--base":
         baseBranch = readValue();
         break;
@@ -113,8 +119,11 @@ function parseArgs(args: readonly string[]): Options {
       case "--model":
         model = readValue();
         break;
+      case "--no-auto-merge":
+        autoMerge = false;
+        break;
       case "--no-draft":
-        noDraft = true;
+        draft = false;
         break;
       case "--no-wait-ci":
         noWaitCi = true;
@@ -144,12 +153,13 @@ function parseArgs(args: readonly string[]): Options {
   }
 
   return {
+    autoMerge,
     baseBranch,
+    draft,
     issueNumber,
     limit,
     mode: modeArg,
     model,
-    noDraft,
     noWaitCi,
     once,
     pollSeconds,
@@ -457,10 +467,14 @@ function processIssue(
     "--body-file",
     prBodyFile,
   ];
-  if (!options.noDraft) {
+  if (options.draft) {
     prArgs.push("--draft");
   }
   const prUrl = checked("gh", prArgs).trim();
+
+  if (options.autoMerge && !options.draft) {
+    checked("gh", ["pr", "merge", prUrl, "--repo", repo, "--auto", "--squash"]);
+  }
 
   if (!options.noWaitCi) {
     const result = runCommand(


### PR DESCRIPTION
## Summary

- make local issue-agent pull requests ready for review by default
- enable squash auto-merge immediately after creating a ready pull request
- retain `--draft` and `--no-auto-merge` escape hatches
- document the new defaults

## Why

The issue agent previously opened every pull request as a draft, so required checks and auto-merge could not carry the work through without a manual ready-for-review step.

The repository ruleset was also aligned separately with the checks emitted by the current pull-request workflows. Obsolete TypeScript 6, cross-platform PR, Real Corsa smoke, and legacy Ubuntu check requirements no longer leave pull requests waiting for statuses that will never be reported.

## Impact

Issue-agent pull requests now enter the normal review and CI flow immediately and request squash auto-merge by default. Work-in-progress and manual-merge workflows remain available explicitly.

## Validation

- `vp check`
- `vp run -w docs_build`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->