### PR TITLE
fix: preserve base type identity in corsa-oxlint

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -14,9 +14,20 @@ import type {
   CorsaTypeCheckerShape,
 } from "./types";
 
+type ImplementingClassDeclarations = {
+  /** Ranges of the classes that carry an `implements` clause, keyed by name. */
+  readonly byName: ReadonlyMap<string, readonly (readonly [start: number, end: number])[]>;
+  /**
+   * Names declared by more than one class in the file. A lookup by simple name
+   * cannot tell those declarations apart, so it needs a declaration position to
+   * pick the right one.
+   */
+  readonly ambiguousNames: ReadonlySet<string>;
+};
+
 type ImplementingClassCache = {
   readonly sourceText: string;
-  readonly declarations: ReadonlyMap<string, readonly [start: number, end: number]>;
+  readonly declarations: ImplementingClassDeclarations;
 };
 
 const implementingClassNamesBySession = new WeakMap<
@@ -438,7 +449,7 @@ function implementedTypesFromTypeDeclaration(
   const declarationNode = declaration ? session.getNode(declaration) : undefined;
   const localImplementingDeclaration =
     declarationNode && pathsReferToSameFile(declarationNode.fileName, context.filename)
-      ? implementingClassDeclaration(context, type, symbol)
+      ? implementingClassDeclaration(context, type, symbol, declarationNode)
       : undefined;
   const resolvedDeclarationNode =
     localImplementingDeclaration ??
@@ -458,12 +469,20 @@ function implementingClassDeclaration(
   context: ContextWithParserOptions,
   type: CorsaType,
   symbol?: CorsaSymbol,
+  declarationNode?: CorsaNode,
 ): CorsaNode | undefined {
   const name = implementingClassName(type, symbol);
   if (!name) {
     return undefined;
   }
-  const range = implementingClassDeclarations(context).get(name);
+  const { byName, ambiguousNames } = implementingClassDeclarations(context);
+  const ranges = byName.get(name);
+  if (!ranges || ranges.length === 0) {
+    return undefined;
+  }
+  const range = ambiguousNames.has(name)
+    ? declaredRange(ranges, declarationNode, context.filename)
+    : ranges[0];
   return range
     ? {
         fileName: context.filename,
@@ -472,6 +491,23 @@ function implementingClassDeclaration(
         range,
       }
     : undefined;
+}
+
+/**
+ * Picks the candidate whose `class` keyword sits inside `declarationNode`, which
+ * is the declaration the symbol actually points at. Without a usable declaration
+ * range there is nothing to disambiguate with, so the lookup gives up rather
+ * than returning a same-named class from another scope.
+ */
+function declaredRange(
+  ranges: readonly (readonly [start: number, end: number])[],
+  declarationNode: CorsaNode | undefined,
+  filename: string,
+): (readonly [start: number, end: number]) | undefined {
+  if (!declarationNode || !pathsReferToSameFile(declarationNode.fileName, filename)) {
+    return undefined;
+  }
+  return ranges.find(([start]) => start >= declarationNode.pos && start < declarationNode.end);
 }
 
 function implementingClassName(type: CorsaType, symbol?: CorsaSymbol): string | undefined {
@@ -493,7 +529,7 @@ function typeSymbolName(texts: readonly string[]): string | undefined {
 
 function implementingClassDeclarations(
   context: ContextWithParserOptions,
-): ReadonlyMap<string, readonly [start: number, end: number]> {
+): ImplementingClassDeclarations {
   const session = sessionForContext(context).session;
   let byFile = implementingClassNamesBySession.get(session);
   if (!byFile) {
@@ -510,10 +546,10 @@ function implementingClassDeclarations(
   return declarations;
 }
 
-function collectImplementingClassDeclarations(
-  sourceText: string,
-): ReadonlyMap<string, readonly [start: number, end: number]> {
-  const declarations = new Map<string, readonly [start: number, end: number]>();
+function collectImplementingClassDeclarations(sourceText: string): ImplementingClassDeclarations {
+  const byName = new Map<string, (readonly [start: number, end: number])[]>();
+  const declaredNames = new Set<string>();
+  const ambiguousNames = new Set<string>();
   let offset = 0;
   while (offset < sourceText.length) {
     const classOffset = findKeywordOutsideTrivia(sourceText.slice(offset), "class");
@@ -524,15 +560,26 @@ function collectImplementingClassDeclarations(
     const rest = sourceText.slice(declarationStart);
     const match = /^\s*([$_\p{ID_Start}][$_\u200c\u200d\p{ID_Continue}]*)/u.exec(rest);
     if (match?.[1]) {
+      const name = match[1];
+      if (declaredNames.has(name)) {
+        ambiguousNames.add(name);
+      }
+      declaredNames.add(name);
       const bodyOpen = findClassBodyOpen(rest, 0);
       const header = rest.slice(0, bodyOpen >= 0 ? bodyOpen : rest.length);
       if (findKeywordOutsideTrivia(header, "implements") >= 0) {
-        declarations.set(match[1], [offset + classOffset, sourceText.length]);
+        const range = [offset + classOffset, sourceText.length] as const;
+        const ranges = byName.get(name);
+        if (ranges) {
+          ranges.push(range);
+        } else {
+          byName.set(name, [range]);
+        }
       }
     }
     offset = declarationStart;
   }
-  return declarations;
+  return { byName, ambiguousNames };
 }
 
 function implementedTypesFromSourceText(

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -432,7 +432,8 @@ function implementedTypesFromTypeDeclaration(
   if (cached) {
     return cached;
   }
-  const symbol = type.symbol ? session.getSymbol(type.symbol) : undefined;
+  const symbol =
+    (type.symbol ? session.getSymbol(type.symbol) : undefined) ?? checker.getSymbolOfType(type);
   const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
   const declarationNode = declaration ? session.getNode(declaration) : undefined;
   const localImplementingDeclaration =

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -503,7 +503,7 @@ function declaredRange(
   ranges: readonly (readonly [start: number, end: number])[],
   declarationNode: CorsaNode | undefined,
   filename: string,
-): (readonly [start: number, end: number]) | undefined {
+): readonly [start: number, end: number] | undefined {
   if (!declarationNode || !pathsReferToSameFile(declarationNode.fileName, filename)) {
     return undefined;
   }

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -447,11 +447,13 @@ function implementedTypesFromTypeDeclaration(
     (type.symbol ? session.getSymbol(type.symbol) : undefined) ?? checker.getSymbolOfType(type);
   const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
   const declarationNode = declaration ? session.getNode(declaration) : undefined;
+  const matchedDeclarationNode = session.getClassDeclarationForType(type);
   const localImplementingDeclaration =
     declarationNode && pathsReferToSameFile(declarationNode.fileName, context.filename)
       ? implementingClassDeclaration(context, type, symbol, declarationNode)
       : undefined;
   const resolvedDeclarationNode =
+    matchedDeclarationNode ??
     localImplementingDeclaration ??
     declarationNode ??
     implementingClassDeclaration(context, type, symbol);

--- a/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -10,7 +11,32 @@ import { RuleTester } from "./rule_tester";
 import { resolvedRealCorsaBinary } from "./test_support";
 
 const realCorsaBinary = resolvedRealCorsaBinary() ?? "";
+const stableTypeScript7Binary = optionalStableTypeScript7Executable() ?? "";
 const integrationCase = existsSync(realCorsaBinary) ? it : it.skip;
+const stableTypeScript7Case = existsSync(stableTypeScript7Binary) ? it : it.skip;
+
+/**
+ * Resolves the `tsc` shipped by the installed stable `typescript` package, so
+ * the regression test below runs against a released TypeScript 7 runtime rather
+ * than the Corsa build this repository pins.
+ */
+function optionalStableTypeScript7Executable(): string | undefined {
+  try {
+    const require = createRequire(import.meta.url);
+    const typeScriptPackage = require.resolve("typescript/package.json");
+    const requireFromTypeScript = createRequire(typeScriptPackage);
+    const platformPackage = requireFromTypeScript.resolve(
+      `@typescript/typescript-${process.platform}-${process.arch}/package.json`,
+    );
+    return resolve(
+      dirname(platformPackage),
+      "lib",
+      process.platform === "win32" ? "tsc.exe" : "tsc",
+    );
+  } catch {
+    return undefined;
+  }
+}
 
 describe("corsa oxlint implemented types", () => {
   integrationCase("exposes class implements clause types", () => {
@@ -703,6 +729,107 @@ describe("corsa oxlint implemented types", () => {
       expect(seen.foo).toEqual(["IFoo"]);
     },
   );
+
+  stableTypeScript7Case("preserves symbols and implemented types on immediate base types", () => {
+    const seen: Record<
+      string,
+      {
+        readonly symbol: string | null;
+        readonly implemented: readonly string[];
+        readonly bases: readonly {
+          readonly text: string;
+          readonly symbol: string | null;
+          readonly implemented: readonly string[];
+        }[];
+      }
+    > = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "base-type-identity",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise symbol and implements lookups on base type handles",
+          requiresTypeChecking: true,
+        },
+        messages: { unexpected: "unexpected" },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          TSPropertySignature(node: any) {
+            const name = node.key?.name;
+            if (!name) {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node);
+            if (!type || checker.typeToString(type) === "string") {
+              return;
+            }
+            seen[name] = {
+              symbol: checker.getSymbolOfType(type)?.name ?? null,
+              implemented: checker
+                .getImplementedTypesOfType(type)
+                .map((implemented: any) => checker.typeToString(implemented)),
+              bases: checker.getBaseTypes(type).map((base: any) => ({
+                text: checker.typeToString(base),
+                symbol: checker.getSymbolOfType(base)?.name ?? null,
+                implemented: checker
+                  .getImplementedTypesOfType(base)
+                  .map((implemented: any) => checker.typeToString(implemented)),
+              })),
+            };
+          },
+        };
+      },
+    });
+
+    new RuleTester({ languageOptions: { sourceType: "module" } }).run(
+      "base-type-identity",
+      rule as any,
+      {
+        valid: [
+          {
+            code: [
+              "interface I { name: string; }",
+              'class A_Base implements I { name = "x"; }',
+              "class A_Leaf extends A_Base {}",
+              "class B_Root {}",
+              'class B_Base extends B_Root implements I { name = "x"; }',
+              "class B_Leaf extends B_Base {}",
+              "interface Props { a: A_Leaf; b: B_Leaf; }",
+            ].join("\n"),
+            settings: {
+              corsaOxlint: {
+                parserOptions: {
+                  corsa: {
+                    executable: stableTypeScript7Binary,
+                  },
+                },
+              },
+            },
+          },
+        ],
+        invalid: [],
+      },
+    );
+
+    expect(seen).toEqual({
+      a: {
+        symbol: "A_Leaf",
+        implemented: ["I"],
+        bases: [{ text: "A_Base", symbol: "A_Base", implemented: ["I"] }],
+      },
+      b: {
+        symbol: "B_Leaf",
+        implemented: ["I"],
+        bases: [{ text: "B_Base", symbol: "B_Base", implemented: ["I"] }],
+      },
+    });
+  });
 
   integrationCase("returns implemented interfaces from external declaration class types", () => {
     const workspace = mkdtempSync(resolve(tmpdir(), "corsa-oxlint-external-implements-"));

--- a/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
@@ -801,6 +801,20 @@ describe("corsa oxlint implemented types", () => {
               'class B_Base extends B_Root implements I { name = "x"; }',
               "class B_Leaf extends B_Base {}",
               "interface Props { a: A_Leaf; b: B_Leaf; }",
+              "namespace First {",
+              "  export interface IFirst { first: string; }",
+              '  export class Base implements IFirst { first = "x"; }',
+              "  export class Leaf extends Base {}",
+              "}",
+              "namespace Second {",
+              "  export interface ISecond { second: string; }",
+              '  export class Base implements ISecond { second = "x"; }',
+              "  export class Leaf extends Base {}",
+              "}",
+              "interface NamespacedProps {",
+              "  firstLeaf: First.Leaf;",
+              "  secondLeaf: Second.Leaf;",
+              "}",
             ].join("\n"),
             settings: {
               corsaOxlint: {
@@ -827,6 +841,16 @@ describe("corsa oxlint implemented types", () => {
         symbol: "B_Leaf",
         implemented: ["I"],
         bases: [{ text: "B_Base", symbol: "B_Base", implemented: ["I"] }],
+      },
+      firstLeaf: {
+        symbol: "Leaf",
+        implemented: ["IFirst"],
+        bases: [{ text: "Base", symbol: "Base", implemented: ["IFirst"] }],
+      },
+      secondLeaf: {
+        symbol: "Leaf",
+        implemented: ["ISecond"],
+        bases: [{ text: "Base", symbol: "Base", implemented: ["ISecond"] }],
       },
     });
   });

--- a/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
@@ -831,6 +831,87 @@ describe("corsa oxlint implemented types", () => {
     });
   });
 
+  stableTypeScript7Case("does not confuse base types that share a simple name", () => {
+    const seen: Record<
+      string,
+      readonly {
+        readonly symbol: string | null;
+        readonly implemented: readonly string[];
+      }[]
+    > = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "duplicate-base-names",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise base type recovery when two declarations share a simple name",
+          requiresTypeChecking: true,
+        },
+        messages: { unexpected: "unexpected" },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          TSPropertySignature(node: any) {
+            const name = node.key?.name;
+            if (!name) {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node);
+            if (!type) {
+              return;
+            }
+            seen[name] = checker.getBaseTypes(type).map((base: any) => ({
+              symbol: checker.getSymbolOfType(base)?.name ?? null,
+              implemented: checker
+                .getImplementedTypesOfType(base)
+                .map((implemented: any) => checker.typeToString(implemented)),
+            }));
+          },
+        };
+      },
+    });
+
+    new RuleTester({ languageOptions: { sourceType: "module" } }).run(
+      "duplicate-base-names",
+      rule as any,
+      {
+        valid: [
+          {
+            code: [
+              "interface I { name: string; }",
+              'namespace First { export class Base implements I { name = "x"; } }',
+              "namespace Second { export class Base { size = 1; } }",
+              "class FirstLeaf extends First.Base {}",
+              "class SecondLeaf extends Second.Base {}",
+              "interface Props { a: FirstLeaf; b: SecondLeaf; }",
+            ].join("\n"),
+            settings: {
+              corsaOxlint: {
+                parserOptions: {
+                  corsa: {
+                    executable: stableTypeScript7Binary,
+                  },
+                },
+              },
+            },
+          },
+        ],
+        invalid: [],
+      },
+    );
+
+    // `Second.Base` must never inherit `First.Base`'s implemented interfaces,
+    // even though both declarations are named `Base`. Recovery is allowed to
+    // report no symbol for an ambiguous name, but never the wrong one.
+    expect(seen.a?.map((base) => base.implemented)).toEqual([["I"]]);
+    expect(seen.b?.map((base) => base.implemented)).toEqual([[]]);
+  });
+
   integrationCase("returns implemented interfaces from external declaration class types", () => {
     const workspace = mkdtempSync(resolve(tmpdir(), "corsa-oxlint-external-implements-"));
     const depDir = resolve(workspace, "node_modules", "external-dep");

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -311,16 +311,51 @@ export class CorsaProjectSession {
     sourceText: string,
     typeSymbolName: string,
   ): CorsaSymbol | undefined {
-    const typePosition = findIdentifierPosition(
+    const nearbySymbol = this.findMatchingTypeSymbol(
+      lookup,
       sourceText,
       typeSymbolName,
       lookup.position,
       lookup.position + 512,
     );
-    if (typePosition === undefined || typePosition === lookup.position) {
+    if (nearbySymbol) {
+      return nearbySymbol;
+    }
+    return this.findMatchingTypeSymbol(lookup, sourceText, typeSymbolName, 0, sourceText.length);
+  }
+
+  private findMatchingTypeSymbol(
+    lookup: TypeLookup,
+    sourceText: string,
+    typeSymbolName: string,
+    start: number,
+    end: number,
+  ): CorsaSymbol | undefined {
+    let offset = Math.max(0, start);
+    const boundary = Math.min(sourceText.length, end);
+    while (offset < boundary) {
+      const position = findIdentifierPosition(sourceText, typeSymbolName, offset, boundary);
+      if (position === undefined) {
+        return undefined;
+      }
+      const symbol = this.getMatchingSymbolAtPosition(lookup, typeSymbolName, position);
+      if (symbol) {
+        return symbol;
+      }
+      offset = position + typeSymbolName.length;
+    }
+    return undefined;
+  }
+
+  private getMatchingSymbolAtPosition(
+    lookup: TypeLookup,
+    typeSymbolName: string,
+    position: number | undefined,
+  ): CorsaSymbol | undefined {
+    if (position === undefined || position === lookup.position) {
       return undefined;
     }
-    const typeSymbol = this.getSymbolAtPosition(lookup.fileName, typePosition, lookup.sourceText);
+    const typeSymbol = this.getSymbolAtPosition(lookup.fileName, position, lookup.sourceText);
     return isUsableSymbol(typeSymbol) && typeSymbol.name === typeSymbolName
       ? typeSymbol
       : undefined;
@@ -514,6 +549,13 @@ export class CorsaProjectSession {
           texts: this.typeTexts(type),
         }) ?? [],
       );
+      const lookup = this.#typeLookupById.get(type.id);
+      for (const baseType of baseTypes) {
+        this.cacheTypeText(baseType);
+        if (lookup && !this.#typeLookupById.has(baseType.id)) {
+          this.#typeLookupById.set(baseType.id, lookup);
+        }
+      }
       this.#baseTypesById.set(type.id, baseTypes);
       return baseTypes;
     });

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -32,10 +32,16 @@ type SourceSlice = {
   node: CorsaNode;
 };
 
+type SourceRange = {
+  start: number;
+  end: number;
+};
+
 type TypeLookup = {
   fileName: string;
   position: number;
   sourceText?: string;
+  symbolSearchRange?: SourceRange;
 };
 
 const typeFlags = {
@@ -71,6 +77,8 @@ export class CorsaProjectSession {
   #ownImplementedTypesById = new Map<string, readonly CorsaType[]>();
   #typeLookupById = new Map<string, TypeLookup>();
   #typeSourceById = new Map<string, SourceSlice>();
+  #classDeclarationByTypeId = new Map<string, CorsaNode>();
+  #symbolSearchRangeByTypeId = new Map<string, SourceRange>();
   #sourceLengthByPath = new Map<string, number>();
   #typeTextById = new Map<string, string>();
   #lastRefreshMs = 0;
@@ -281,7 +289,7 @@ export class CorsaProjectSession {
     const sourceText = lookup.sourceText ?? this.sourceTextForPath(lookup.fileName);
     let typeSymbolName = typeSymbolNameFromTexts(texts);
     if (isUsableSymbol(symbol) && sourceText && typeSymbolName) {
-      const typeSymbol = this.getNearbyTypeSymbol(lookup, sourceText, typeSymbolName, texts);
+      const typeSymbol = this.getNearbyTypeSymbol(type, lookup, sourceText, typeSymbolName, texts);
       if (typeSymbol) {
         return typeSymbol;
       }
@@ -301,18 +309,30 @@ export class CorsaProjectSession {
       typeSymbolName = typeSymbolNameFromTexts(texts);
     }
     if (isUsableSymbol(symbol) && sourceText && typeSymbolName) {
-      return this.getNearbyTypeSymbol(lookup, sourceText, typeSymbolName, texts);
+      return this.getNearbyTypeSymbol(type, lookup, sourceText, typeSymbolName, texts);
     }
     return undefined;
   }
 
   private getNearbyTypeSymbol(
+    type: CorsaType,
     lookup: TypeLookup,
     sourceText: string,
     typeSymbolName: string,
     texts: readonly string[],
   ): CorsaSymbol | undefined {
+    if (lookup.symbolSearchRange) {
+      return this.findMatchingTypeSymbol(
+        type,
+        lookup,
+        sourceText,
+        typeSymbolName,
+        lookup.symbolSearchRange.start,
+        lookup.symbolSearchRange.end,
+      );
+    }
     const nearbySymbol = this.findMatchingTypeSymbol(
+      type,
       lookup,
       sourceText,
       typeSymbolName,
@@ -324,6 +344,7 @@ export class CorsaProjectSession {
     }
     for (const qualifiedName of qualifiedTypeNamesFromTexts(texts, typeSymbolName)) {
       const qualifiedSymbol = this.findQualifiedTypeSymbol(
+        type,
         lookup,
         sourceText,
         qualifiedName,
@@ -333,7 +354,7 @@ export class CorsaProjectSession {
         return qualifiedSymbol;
       }
     }
-    return this.findUniqueTypeSymbol(lookup, sourceText, typeSymbolName);
+    return this.findUniqueTypeSymbol(type, lookup, sourceText, typeSymbolName);
   }
 
   /**
@@ -341,11 +362,28 @@ export class CorsaProjectSession {
    * same-named declaration under a different container cannot win the lookup.
    */
   private findQualifiedTypeSymbol(
+    type: CorsaType,
     lookup: TypeLookup,
     sourceText: string,
     qualifiedName: string,
     typeSymbolName: string,
   ): CorsaSymbol | undefined {
+    const qualifiers = qualifiedName.slice(0, -(typeSymbolName.length + 1)).split(".");
+    const qualifier = qualifiers[qualifiers.length - 1];
+    const containerRange = qualifier ? namespaceRangeByName(sourceText, qualifier) : undefined;
+    if (containerRange) {
+      const declarationSymbol = this.findMatchingTypeSymbol(
+        type,
+        lookup,
+        sourceText,
+        typeSymbolName,
+        containerRange.start,
+        containerRange.end,
+      );
+      if (declarationSymbol) {
+        return declarationSymbol;
+      }
+    }
     let offset = 0;
     while (offset < sourceText.length) {
       const start = sourceText.indexOf(qualifiedName, offset);
@@ -358,7 +396,9 @@ export class CorsaProjectSession {
       // container, so this occurrence names a different type.
       if (before !== "." && !isIdentifierPart(before) && !isIdentifierPart(after)) {
         const symbol = this.getMatchingSymbolAtPosition(
+          type,
           lookup,
+          sourceText,
           typeSymbolName,
           start + qualifiedName.length - typeSymbolName.length,
         );
@@ -379,6 +419,7 @@ export class CorsaProjectSession {
    * simple name in different scopes.
    */
   private findUniqueTypeSymbol(
+    type: CorsaType,
     lookup: TypeLookup,
     sourceText: string,
     typeSymbolName: string,
@@ -396,7 +437,13 @@ export class CorsaProjectSession {
       if (position === undefined) {
         break;
       }
-      const symbol = this.getMatchingSymbolAtPosition(lookup, typeSymbolName, position);
+      const symbol = this.getMatchingSymbolAtPosition(
+        type,
+        lookup,
+        sourceText,
+        typeSymbolName,
+        position,
+      );
       if (symbol) {
         const key = symbolDeclarationKey(symbol);
         if (uniqueKey !== undefined && uniqueKey !== key) {
@@ -411,6 +458,7 @@ export class CorsaProjectSession {
   }
 
   private findMatchingTypeSymbol(
+    type: CorsaType,
     lookup: TypeLookup,
     sourceText: string,
     typeSymbolName: string,
@@ -424,7 +472,13 @@ export class CorsaProjectSession {
       if (position === undefined) {
         return undefined;
       }
-      const symbol = this.getMatchingSymbolAtPosition(lookup, typeSymbolName, position);
+      const symbol = this.getMatchingSymbolAtPosition(
+        type,
+        lookup,
+        sourceText,
+        typeSymbolName,
+        position,
+      );
       if (symbol) {
         return symbol;
       }
@@ -434,7 +488,9 @@ export class CorsaProjectSession {
   }
 
   private getMatchingSymbolAtPosition(
+    type: CorsaType,
     lookup: TypeLookup,
+    sourceText: string,
     typeSymbolName: string,
     position: number | undefined,
   ): CorsaSymbol | undefined {
@@ -442,9 +498,25 @@ export class CorsaProjectSession {
       return undefined;
     }
     const typeSymbol = this.getSymbolAtPosition(lookup.fileName, position, lookup.sourceText);
-    return isUsableSymbol(typeSymbol) && typeSymbol.name === typeSymbolName
-      ? typeSymbol
-      : undefined;
+    if (!isUsableSymbol(typeSymbol) || typeSymbol.name !== typeSymbolName) {
+      return undefined;
+    }
+    const classStart = classDeclarationStartAtIdentifier(sourceText, position);
+    if (classStart !== undefined) {
+      this.#classDeclarationByTypeId.set(type.id, {
+        fileName: lookup.fileName,
+        pos: classStart,
+        end: sourceText.length,
+        range: [classStart, sourceText.length],
+      });
+    }
+    const symbolSearchRange =
+      containingNamespaceRange(sourceText, position) ??
+      qualifiedNamespaceRangeAtIdentifier(sourceText, position);
+    if (symbolSearchRange) {
+      this.#symbolSearchRangeByTypeId.set(type.id, symbolSearchRange);
+    }
+    return typeSymbol;
   }
 
   private getSymbolOfTypeById(typeId: string): CorsaSymbol | undefined {
@@ -472,6 +544,10 @@ export class CorsaProjectSession {
 
   getSourceTextForPath(path: string): string | undefined {
     return this.sourceTextForPath(path);
+  }
+
+  getClassDeclarationForType(type: CorsaType): CorsaNode | undefined {
+    return this.#classDeclarationByTypeId.get(type.id);
   }
 
   getTypeOfSymbol(symbol: CorsaSymbol): CorsaType | undefined {
@@ -627,6 +703,8 @@ export class CorsaProjectSession {
       if (cached) {
         return cached;
       }
+      const lookup = this.#typeLookupById.get(type.id);
+      const relatedTypeLookup = lookup ? this.relatedTypeLookup(type, lookup) : undefined;
       const baseTypes = this.rememberTypes(
         this.client().callJson<readonly CorsaType[]>("getBaseTypes", {
           snapshot: this.#snapshot,
@@ -635,16 +713,57 @@ export class CorsaProjectSession {
           texts: this.typeTexts(type),
         }) ?? [],
       );
-      const lookup = this.#typeLookupById.get(type.id);
       for (const baseType of baseTypes) {
         this.cacheTypeText(baseType);
-        if (lookup && !this.#typeLookupById.has(baseType.id)) {
-          this.#typeLookupById.set(baseType.id, lookup);
+        if (relatedTypeLookup && !this.#typeLookupById.has(baseType.id)) {
+          this.#typeLookupById.set(baseType.id, relatedTypeLookup);
         }
       }
       this.#baseTypesById.set(type.id, baseTypes);
       return baseTypes;
     });
+  }
+
+  private relatedTypeLookup(type: CorsaType, lookup: TypeLookup): TypeLookup {
+    if (lookup.symbolSearchRange) {
+      return lookup;
+    }
+    const rememberedRange = this.#symbolSearchRangeByTypeId.get(type.id);
+    if (rememberedRange) {
+      return { ...lookup, symbolSearchRange: rememberedRange };
+    }
+    const cachedSymbol = this.#symbolsByTypeId.get(type.id);
+    const symbol =
+      cachedSymbol === null ? undefined : (cachedSymbol ?? this.getSymbolOfTypeUnchecked(type));
+    const sourceText = lookup.sourceText ?? this.sourceTextForPath(lookup.fileName);
+    if (!symbol || !sourceText) {
+      return lookup;
+    }
+    const recoveredDeclaration = uniqueClassDeclarationPosition(sourceText, symbol.name);
+    if (recoveredDeclaration !== undefined) {
+      const recoveredRange =
+        qualifiedBaseNamespaceRangeAtDeclaration(sourceText, recoveredDeclaration) ??
+        containingNamespaceRange(sourceText, recoveredDeclaration);
+      if (recoveredRange) {
+        return { ...lookup, symbolSearchRange: recoveredRange };
+      }
+    }
+    const declarationHandles = [symbol.valueDeclaration, ...(symbol.declarations ?? [])].filter(
+      (handle): handle is string => handle !== undefined,
+    );
+    for (const handle of declarationHandles) {
+      const declaration = this.getNode(handle);
+      if (!declaration || !pathsReferToSameFile(declaration.fileName, lookup.fileName)) {
+        continue;
+      }
+      const symbolSearchRange =
+        qualifiedBaseNamespaceRangeAtDeclaration(sourceText, declaration.pos) ??
+        containingNamespaceRange(sourceText, declaration.pos);
+      if (symbolSearchRange) {
+        return { ...lookup, symbolSearchRange };
+      }
+    }
+    return lookup;
   }
 
   getCachedImplementedTypes(typeId: string): readonly CorsaType[] | undefined {
@@ -992,6 +1111,8 @@ export class CorsaProjectSession {
     this.#ownImplementedTypesById.clear();
     this.#typeLookupById.clear();
     this.#typeSourceById.clear();
+    this.#classDeclarationByTypeId.clear();
+    this.#symbolSearchRangeByTypeId.clear();
     this.#sourceLengthByPath.clear();
     this.#snapshotHasIssuedHandles = false;
   }
@@ -1315,6 +1436,189 @@ function qualifiedTypeNamesFromTexts(
  */
 function symbolDeclarationKey(symbol: CorsaSymbol): string {
   return symbol.valueDeclaration ?? symbol.declarations[0] ?? symbol.id;
+}
+
+function classDeclarationStartAtIdentifier(
+  sourceText: string,
+  identifierPosition: number,
+): number | undefined {
+  const prefixStart = Math.max(0, identifierPosition - 128);
+  const prefix = sourceText.slice(prefixStart, identifierPosition);
+  const match = /\bclass\s*$/u.exec(prefix);
+  return match ? prefixStart + match.index : undefined;
+}
+
+function uniqueClassDeclarationPosition(sourceText: string, className: string): number | undefined {
+  const escapedName = className.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const declarationPattern = new RegExp(`\\bclass\\s+${escapedName}\\b`, "gu");
+  const declaration = declarationPattern.exec(sourceText);
+  if (!declaration || declarationPattern.exec(sourceText)) {
+    return undefined;
+  }
+  return declaration.index;
+}
+
+function qualifiedNamespaceRangeAtIdentifier(
+  sourceText: string,
+  identifierPosition: number,
+): SourceRange | undefined {
+  const prefixStart = Math.max(0, identifierPosition - 256);
+  const prefix = sourceText.slice(prefixStart, identifierPosition);
+  const match = /([$_\p{ID_Start}][$_\u200c\u200d\p{ID_Continue}]*)\s*\.\s*$/u.exec(prefix);
+  return match?.[1] ? namespaceRangeByName(sourceText, match[1]) : undefined;
+}
+
+function qualifiedBaseNamespaceRangeAtDeclaration(
+  sourceText: string,
+  declarationPosition: number,
+): SourceRange | undefined {
+  const headerEnd = sourceText.indexOf("{", declarationPosition);
+  const header = sourceText.slice(
+    declarationPosition,
+    headerEnd < 0 ? declarationPosition + 512 : headerEnd,
+  );
+  const match =
+    /\bextends\s+(?:[$_\p{ID_Start}][$_\u200c\u200d\p{ID_Continue}]*\.)+([$_\p{ID_Start}][$_\u200c\u200d\p{ID_Continue}]*)/u.exec(
+      header,
+    );
+  if (!match) {
+    return undefined;
+  }
+  const qualifiedBase = match[0].slice("extends".length).trim();
+  const qualifiers = qualifiedBase.split(".");
+  const qualifier = qualifiers[qualifiers.length - 2];
+  return qualifier ? namespaceRangeByName(sourceText, qualifier) : undefined;
+}
+
+function namespaceRangeByName(sourceText: string, name: string): SourceRange | undefined {
+  const escapedName = name.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const declarationPattern = new RegExp(`\\b(?:namespace|module)\\s+${escapedName}\\s*\\{`, "gu");
+  const declaration = declarationPattern.exec(sourceText);
+  if (!declaration) {
+    return undefined;
+  }
+  const open = declaration.index + declaration[0].lastIndexOf("{");
+  const scanner = createSourceScanner();
+  let depth = 1;
+  for (let index = open + 1; index < sourceText.length; index += 1) {
+    const nextIndex = scanner.skip(sourceText, index);
+    if (nextIndex > index) {
+      index = nextIndex - 1;
+      continue;
+    }
+    if (sourceText[index] === "{") {
+      depth += 1;
+    } else if (sourceText[index] === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return { start: open + 1, end: index };
+      }
+    }
+  }
+  return undefined;
+}
+
+function containingNamespaceRange(sourceText: string, position: number): SourceRange | undefined {
+  const scanner = createSourceScanner();
+  const blocks: { start: number; namespace: boolean }[] = [];
+  let pendingNamespace = false;
+  let innermost: SourceRange | undefined;
+  for (let index = 0; index < sourceText.length; index += 1) {
+    const nextIndex = scanner.skip(sourceText, index);
+    if (nextIndex > index) {
+      index = nextIndex - 1;
+      continue;
+    }
+    const char = sourceText[index];
+    if (isIdentifierStart(char)) {
+      let end = index + 1;
+      while (isIdentifierPart(sourceText[end])) {
+        end += 1;
+      }
+      const identifier = sourceText.slice(index, end);
+      if (identifier === "namespace" || identifier === "module") {
+        pendingNamespace = true;
+      }
+      index = end - 1;
+      continue;
+    }
+    if (char === "{") {
+      blocks.push({ start: index + 1, namespace: pendingNamespace });
+      pendingNamespace = false;
+      continue;
+    }
+    if (char === "}") {
+      const block = blocks.pop();
+      if (
+        block?.namespace &&
+        block.start <= position &&
+        position < index &&
+        (!innermost || block.start >= innermost.start)
+      ) {
+        innermost = { start: block.start, end: index };
+      }
+      continue;
+    }
+    if (pendingNamespace && (char === ";" || char === "=")) {
+      pendingNamespace = false;
+    }
+  }
+  return innermost;
+}
+
+function createSourceScanner(): {
+  skip(text: string, index: number): number;
+} {
+  let quote: string | undefined;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+  return {
+    skip(text, index) {
+      const char = text[index];
+      const next = text[index + 1];
+      if (inLineComment) {
+        if (char === "\n" || char === "\r") {
+          inLineComment = false;
+        }
+        return index + 1;
+      }
+      if (inBlockComment) {
+        if (char === "*" && next === "/") {
+          inBlockComment = false;
+          return index + 2;
+        }
+        return index + 1;
+      }
+      if (quote) {
+        if (escaped) {
+          escaped = false;
+        } else if (char === "\\") {
+          escaped = true;
+        } else if (char === quote) {
+          quote = undefined;
+        }
+        return index + 1;
+      }
+      if (char === "/" && next === "/") {
+        inLineComment = true;
+        return index + 2;
+      }
+      if (char === "/" && next === "*") {
+        inBlockComment = true;
+        return index + 2;
+      }
+      if (char === '"' || char === "'" || char === "`") {
+        quote = char;
+        return index + 1;
+      }
+      return index;
+    },
+  };
+}
+
+function isIdentifierStart(char: string | undefined): boolean {
+  return char !== undefined && /[$_\p{ID_Start}]/u.test(char);
 }
 
 function findIdentifierPosition(

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -281,7 +281,7 @@ export class CorsaProjectSession {
     const sourceText = lookup.sourceText ?? this.sourceTextForPath(lookup.fileName);
     let typeSymbolName = typeSymbolNameFromTexts(texts);
     if (isUsableSymbol(symbol) && sourceText && typeSymbolName) {
-      const typeSymbol = this.getNearbyTypeSymbol(lookup, sourceText, typeSymbolName);
+      const typeSymbol = this.getNearbyTypeSymbol(lookup, sourceText, typeSymbolName, texts);
       if (typeSymbol) {
         return typeSymbol;
       }
@@ -301,7 +301,7 @@ export class CorsaProjectSession {
       typeSymbolName = typeSymbolNameFromTexts(texts);
     }
     if (isUsableSymbol(symbol) && sourceText && typeSymbolName) {
-      return this.getNearbyTypeSymbol(lookup, sourceText, typeSymbolName);
+      return this.getNearbyTypeSymbol(lookup, sourceText, typeSymbolName, texts);
     }
     return undefined;
   }
@@ -310,6 +310,7 @@ export class CorsaProjectSession {
     lookup: TypeLookup,
     sourceText: string,
     typeSymbolName: string,
+    texts: readonly string[],
   ): CorsaSymbol | undefined {
     const nearbySymbol = this.findMatchingTypeSymbol(
       lookup,
@@ -321,7 +322,92 @@ export class CorsaProjectSession {
     if (nearbySymbol) {
       return nearbySymbol;
     }
-    return this.findMatchingTypeSymbol(lookup, sourceText, typeSymbolName, 0, sourceText.length);
+    for (const qualifiedName of qualifiedTypeNamesFromTexts(texts, typeSymbolName)) {
+      const qualifiedSymbol = this.findQualifiedTypeSymbol(
+        lookup,
+        sourceText,
+        qualifiedName,
+        typeSymbolName,
+      );
+      if (qualifiedSymbol) {
+        return qualifiedSymbol;
+      }
+    }
+    return this.findUniqueTypeSymbol(lookup, sourceText, typeSymbolName);
+  }
+
+  /**
+   * Anchors a qualified type text such as `Second.Base` on its qualifier, so a
+   * same-named declaration under a different container cannot win the lookup.
+   */
+  private findQualifiedTypeSymbol(
+    lookup: TypeLookup,
+    sourceText: string,
+    qualifiedName: string,
+    typeSymbolName: string,
+  ): CorsaSymbol | undefined {
+    let offset = 0;
+    while (offset < sourceText.length) {
+      const start = sourceText.indexOf(qualifiedName, offset);
+      if (start < 0) {
+        return undefined;
+      }
+      const before = start > 0 ? sourceText[start - 1] : undefined;
+      const after = sourceText[start + qualifiedName.length];
+      // A leading `.` means the qualifier itself is nested under another
+      // container, so this occurrence names a different type.
+      if (before !== "." && !isIdentifierPart(before) && !isIdentifierPart(after)) {
+        const symbol = this.getMatchingSymbolAtPosition(
+          lookup,
+          typeSymbolName,
+          start + qualifiedName.length - typeSymbolName.length,
+        );
+        if (symbol) {
+          return symbol;
+        }
+      }
+      offset = start + qualifiedName.length;
+    }
+    return undefined;
+  }
+
+  /**
+   * Scans the whole file, but only accepts a match when every occurrence of the
+   * name resolves to the same declaration. Returning the first same-named
+   * symbol would otherwise cache the wrong nominal symbol, and the wrong
+   * implemented interfaces, for any file that declares two types with the same
+   * simple name in different scopes.
+   */
+  private findUniqueTypeSymbol(
+    lookup: TypeLookup,
+    sourceText: string,
+    typeSymbolName: string,
+  ): CorsaSymbol | undefined {
+    let uniqueSymbol: CorsaSymbol | undefined;
+    let uniqueKey: string | undefined;
+    let offset = 0;
+    while (offset < sourceText.length) {
+      const position = findIdentifierPosition(
+        sourceText,
+        typeSymbolName,
+        offset,
+        sourceText.length,
+      );
+      if (position === undefined) {
+        break;
+      }
+      const symbol = this.getMatchingSymbolAtPosition(lookup, typeSymbolName, position);
+      if (symbol) {
+        const key = symbolDeclarationKey(symbol);
+        if (uniqueKey !== undefined && uniqueKey !== key) {
+          return undefined;
+        }
+        uniqueSymbol ??= symbol;
+        uniqueKey = key;
+      }
+      offset = position + typeSymbolName.length;
+    }
+    return uniqueSymbol;
   }
 
   private findMatchingTypeSymbol(
@@ -1197,6 +1283,38 @@ function typeSymbolNameFromTexts(texts: readonly string[]): string | undefined {
     }
   }
   return undefined;
+}
+
+/**
+ * Collects the qualified spellings of `typeSymbolName` (such as `Second.Base`)
+ * carried by a type's rendered texts. These keep the container context that
+ * `typeSymbolNameFromTexts` drops.
+ */
+function qualifiedTypeNamesFromTexts(
+  texts: readonly string[],
+  typeSymbolName: string,
+): readonly string[] {
+  const qualifiedNames: string[] = [];
+  for (const text of texts) {
+    const rendered = text.trim().replace(/^typeof\s+/u, "");
+    const typeArgumentStart = rendered.indexOf("<");
+    const withoutTypeArguments =
+      typeArgumentStart < 0 ? rendered : rendered.slice(0, typeArgumentStart);
+    const name = withoutTypeArguments.trimEnd();
+    if (name.endsWith(`.${typeSymbolName}`) && !qualifiedNames.includes(name)) {
+      qualifiedNames.push(name);
+    }
+  }
+  return qualifiedNames;
+}
+
+/**
+ * Identifies a symbol by its declaration handle, which encodes a source range
+ * and therefore stays comparable across separate lookups, unlike the opaque
+ * symbol handle.
+ */
+function symbolDeclarationKey(symbol: CorsaSymbol): string {
+  return symbol.valueDeclaration ?? symbol.declarations[0] ?? symbol.id;
 }
 
 function findIdentifierPosition(


### PR DESCRIPTION
## Summary

- propagate source lookup context from derived types to handles returned by `getBaseTypes`
- recover nominal symbols across the source file when TypeScript 7 returns base handles without symbol metadata
- reuse recovered symbols when resolving implemented interfaces
- add a TypeScript 7.0.2 regression test for both two-level and three-level inheritance

## Root cause

TypeScript 7 can return base type handles that remain renderable but no longer include enough symbol/declaration metadata for follow-up queries. The JS bridge did not associate those handles with the originating source lookup, so both `getSymbolOfType` and implemented-interface traversal lost nominal identity.

## Validation

- `vp check`
- `vp run -w fmt_check_rust`
- `pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts -t "preserves symbols and implemented types on immediate base types"`
- `pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/session.test.ts`
- packed local `corsa-oxlint` installed beside `typescript@7.0.2`; the exact issue probe returns `A_Base` / `B_Base` symbols and `I` implemented types

Closes #410

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript type and symbol resolution, especially for types without directly associated symbols.
  - Improved detection of nearby type declarations across source files.
  - Preserved type identity and implemented-interface information when examining base types.

- **Compatibility**
  - Added validation for stable TypeScript 7 behavior in the Node.js integration test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->