### PR TITLE
fix: report LSP editor capabilities

### DIFF
--- a/src/bindings/nodejs/corsa_node/ts/types.ts
+++ b/src/bindings/nodejs/corsa_node/ts/types.ts
@@ -108,11 +108,19 @@ export interface EditorCapabilities {
   completion: boolean;
 }
 
+export interface LspCapabilities {
+  available: boolean;
+  editor: EditorCapabilities;
+}
+
 export interface CapabilitiesResponse {
   runtime: RuntimeCapabilities;
   overlay: OverlayCapabilities;
   diagnostics: DiagnosticsCapabilities;
+  /** Editor features available through the active API transport. */
   editor: EditorCapabilities;
+  /** Features available by starting the executable as a separate LSP server. */
+  lsp: LspCapabilities;
 }
 
 export interface FileDiagnosticsResponse {

--- a/src/bindings/rust/corsa/tests/api_async.rs
+++ b/src/bindings/rust/corsa/tests/api_async.rs
@@ -624,6 +624,8 @@ fn async_api_supports_capabilities_overlay_diagnostics_and_editor_surface() {
         assert!(capabilities.overlay.update_snapshot_overlay_changes);
         assert!(capabilities.diagnostics.file);
         assert!(capabilities.editor.hover);
+        assert!(capabilities.lsp.available);
+        assert!(!capabilities.lsp.editor.hover);
 
         let snapshot = client
             .update_snapshot(UpdateSnapshotParams {

--- a/src/bindings/rust/corsa/tests/api_msgpack.rs
+++ b/src/bindings/rust/corsa/tests/api_msgpack.rs
@@ -82,6 +82,8 @@ fn msgpack_api_supports_capabilities_and_overlay_updates() {
             .unwrap();
         let capabilities = client.describe_capabilities().await.unwrap();
         assert!(capabilities.overlay.update_snapshot_overlay_changes);
+        assert!(capabilities.lsp.available);
+        assert!(!capabilities.lsp.editor.hover);
         let snapshot = client
             .update_snapshot(UpdateSnapshotParams {
                 open_project: Some("/workspace/tsconfig.json".into()),

--- a/src/bindings/rust/corsa/tests/project_session.rs
+++ b/src/bindings/rust/corsa/tests/project_session.rs
@@ -106,6 +106,8 @@ fn project_session_supports_capabilities_diagnostics_and_editor_helpers() {
 
         let capabilities = session.describe_capabilities().await.unwrap();
         assert!(capabilities.editor.completion);
+        assert!(capabilities.lsp.available);
+        assert!(!capabilities.lsp.editor.completion);
 
         session
             .refresh_with_overlay_changes(

--- a/src/core/corsa_client/src/api/capabilities.rs
+++ b/src/core/corsa_client/src/api/capabilities.rs
@@ -14,9 +14,14 @@ pub struct CapabilitiesResponse {
     /// Diagnostics API availability by scope.
     #[serde(default)]
     pub diagnostics: DiagnosticsCapabilities,
-    /// Editor-style API availability by feature.
+    /// Editor-style availability on the active API transport.
     #[serde(default)]
     pub editor: EditorCapabilities,
+    /// Editor-style availability when the executable is started as an LSP server.
+    ///
+    /// LSP is a separate process and transport from the active API session.
+    #[serde(default)]
+    pub lsp: LspCapabilities,
 }
 
 /// Runtime identity details for the active worker.
@@ -82,14 +87,71 @@ pub struct EditorCapabilities {
     pub completion: bool,
 }
 
+/// Capability summary for the executable's separate LSP transport.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LspCapabilities {
+    /// Whether the executable can be started as an LSP server.
+    #[serde(default)]
+    pub available: bool,
+    /// Editor features advertised by that LSP server.
+    #[serde(default)]
+    pub editor: EditorCapabilities,
+}
+
 impl CapabilitiesResponse {
     pub(crate) fn fallback(runtime: RuntimeCapabilities) -> Self {
+        let lsp = LspCapabilities::from_runtime(&runtime);
         Self {
             runtime,
             overlay: OverlayCapabilities::default(),
             diagnostics: DiagnosticsCapabilities::default(),
             editor: EditorCapabilities::default(),
+            lsp,
         }
+    }
+}
+
+impl EditorCapabilities {
+    fn all() -> Self {
+        Self {
+            hover: true,
+            definition: true,
+            references: true,
+            rename: true,
+            completion: true,
+        }
+    }
+
+    fn merge_with_local(mut self, local: Self) -> Self {
+        self.hover |= local.hover;
+        self.definition |= local.definition;
+        self.references |= local.references;
+        self.rename |= local.rename;
+        self.completion |= local.completion;
+        self
+    }
+}
+
+impl LspCapabilities {
+    pub(crate) fn from_runtime(runtime: &RuntimeCapabilities) -> Self {
+        match runtime.kind.as_deref() {
+            Some("corsa" | "native-preview" | "typescript") => Self {
+                available: true,
+                editor: EditorCapabilities::all(),
+            },
+            Some("mock-corsa") => Self {
+                available: true,
+                editor: EditorCapabilities::default(),
+            },
+            _ => Self::default(),
+        }
+    }
+
+    pub(crate) fn merge_with_local(mut self, local: Self) -> Self {
+        self.available |= local.available;
+        self.editor = self.editor.merge_with_local(local.editor);
+        self
     }
 }
 
@@ -111,7 +173,7 @@ impl RuntimeCapabilities {
 
 #[cfg(test)]
 mod tests {
-    use super::{CapabilitiesResponse, RuntimeCapabilities};
+    use super::{CapabilitiesResponse, LspCapabilities, RuntimeCapabilities};
     use corsa_core::fast::CompactString;
 
     #[test]
@@ -127,5 +189,39 @@ mod tests {
         assert!(!response.overlay.update_snapshot_overlay_changes);
         assert!(!response.diagnostics.snapshot);
         assert!(!response.editor.hover);
+        assert!(response.lsp.available);
+        assert!(response.lsp.editor.hover);
+    }
+
+    #[test]
+    fn mock_runtime_reports_lsp_transport_without_unadvertised_editor_features() {
+        let lsp = LspCapabilities::from_runtime(&RuntimeCapabilities {
+            kind: Some(CompactString::from("mock-corsa")),
+            ..RuntimeCapabilities::default()
+        });
+
+        assert!(lsp.available);
+        assert!(!lsp.editor.hover);
+        assert!(!lsp.editor.definition);
+    }
+
+    #[test]
+    fn custom_runtime_keeps_server_advertised_lsp_features() {
+        let advertised = LspCapabilities {
+            available: true,
+            editor: super::EditorCapabilities {
+                hover: true,
+                ..super::EditorCapabilities::default()
+            },
+        };
+        let local = LspCapabilities::from_runtime(&RuntimeCapabilities {
+            kind: Some(CompactString::from("custom")),
+            ..RuntimeCapabilities::default()
+        });
+
+        let merged = advertised.merge_with_local(local);
+        assert!(merged.available);
+        assert!(merged.editor.hover);
+        assert!(!merged.editor.definition);
     }
 }

--- a/src/core/corsa_client/src/api/client.rs
+++ b/src/core/corsa_client/src/api/client.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use super::{
-    capabilities::{CapabilitiesResponse, RuntimeCapabilities},
+    capabilities::{CapabilitiesResponse, LspCapabilities, RuntimeCapabilities},
     changes::{UpdateSnapshotParams, UpdateSnapshotResponse},
     config::{ApiMode, ApiSpawnConfig},
     document::DocumentIdentifier,
@@ -310,6 +310,9 @@ impl ApiClient {
                                 .runtime
                                 .merge_with_local(self.runtime_capabilities.clone());
                             parsed.runtime.capability_endpoint = true;
+                            parsed.lsp = parsed
+                                .lsp
+                                .merge_with_local(LspCapabilities::from_runtime(&parsed.runtime));
                             parsed
                         }
                         Err(CorsaError::Rpc(error))
@@ -652,10 +655,15 @@ impl RuntimeCapabilities {
 
 fn infer_runtime_kind(path: &Path) -> Option<CompactString> {
     let normalized = path.to_string_lossy().to_ascii_lowercase();
+    let file_name = normalized
+        .rsplit(|character| ['/', '\\'].contains(&character))
+        .next();
     let kind = if normalized.contains("mock_corsa") {
         "mock-corsa"
     } else if normalized.contains("native-preview") {
         "native-preview"
+    } else if matches!(file_name, Some("tsc" | "tsc.exe" | "tsgo" | "tsgo.exe")) {
+        "typescript"
     } else if normalized.ends_with("/corsa")
         || normalized.ends_with("\\corsa.exe")
         || normalized.ends_with("\\corsa")
@@ -682,7 +690,9 @@ fn is_protocol_panic_message(message: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{ApiClient, is_unknown_api_method_message};
+    use std::path::Path;
+
+    use super::{ApiClient, infer_runtime_kind, is_unknown_api_method_message};
     use crate::CorsaError;
     use corsa_core::{RpcResponseError, fast::CompactString};
 
@@ -691,6 +701,30 @@ mod tests {
         assert!(is_unknown_api_method_message(
             "api: invalid request: unknown API method \"describeCapabilities\""
         ));
+    }
+
+    #[test]
+    fn infers_typescript_runtime_from_standard_executable_names() {
+        for path in [
+            "/tmp/typescript/lib/tsc",
+            "/tmp/typescript/lib/tsgo",
+            r"C:\typescript\lib\tsc.exe",
+            r"C:\typescript\lib\tsgo.exe",
+        ] {
+            assert_eq!(
+                infer_runtime_kind(Path::new(path)).as_deref(),
+                Some("typescript"),
+                "{path}"
+            );
+        }
+    }
+
+    #[test]
+    fn does_not_infer_typescript_runtime_from_wrapper_names() {
+        assert_eq!(
+            infer_runtime_kind(Path::new("/tmp/my-tsc-wrapper")).as_deref(),
+            Some("custom")
+        );
     }
 
     #[test]

--- a/src/core/corsa_client/src/api/mod.rs
+++ b/src/core/corsa_client/src/api/mod.rs
@@ -50,8 +50,8 @@ pub use callbacks::{
 };
 /// Runtime capability descriptors exposed by `describeCapabilities`.
 pub use capabilities::{
-    CapabilitiesResponse, DiagnosticsCapabilities, EditorCapabilities, OverlayCapabilities,
-    RuntimeCapabilities,
+    CapabilitiesResponse, DiagnosticsCapabilities, EditorCapabilities, LspCapabilities,
+    OverlayCapabilities, RuntimeCapabilities,
 };
 /// Snapshot update inputs and change summaries.
 pub use changes::{


### PR DESCRIPTION
## Summary

- distinguish editor features exposed by the active project-session API from features available through a separate LSP process
- infer the TypeScript runtime from `tsc` and `tsgo` executable names and report its LSP editor capabilities
- preserve server-advertised LSP capabilities while supplying metadata for older runtimes that do not return the new field
- cover JSON-RPC, msgpack, project-session, fallback, mock-LSP, and cross-platform executable inference behavior

## Validation

- `vp check`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p corsa_client`
- targeted `corsa` API JSON-RPC, msgpack, and project-session integration tests
- `vp run -w build_wrapper_ci`

Closes #409

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->