### PR TITLE
fix: preserve terminal base type symbols

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
@@ -855,6 +855,77 @@ describe("corsa oxlint implemented types", () => {
     });
   });
 
+  stableTypeScript7Case("preserves terminal base symbols for namespace-scoped leaves", () => {
+    const seen: { text: string; symbol: string | null }[] = [];
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "namespace-terminal-base-symbol",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise terminal base symbols reached from a namespace-scoped class",
+          requiresTypeChecking: true,
+        },
+        messages: { unexpected: "unexpected" },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        const walk = (type: any) => {
+          seen.push({
+            text: checker.typeToString(type),
+            symbol: checker.getSymbolOfType(type)?.name ?? null,
+          });
+          for (const base of checker.getBaseTypes(type)) {
+            walk(base);
+          }
+        };
+        return {
+          TSPropertySignature(node: any) {
+            if (node.key?.name === "leaf") {
+              walk(services.getTypeAtLocation(node));
+            }
+          },
+        };
+      },
+    });
+
+    new RuleTester({ languageOptions: { sourceType: "module" } }).run(
+      "namespace-terminal-base-symbol",
+      rule as any,
+      {
+        valid: [
+          {
+            code: [
+              "class Root {}",
+              "class Mid extends Root {}",
+              "namespace ns { export class Leaf extends Mid {} }",
+              "interface Props { leaf: ns.Leaf; }",
+            ].join("\n"),
+            settings: {
+              corsaOxlint: {
+                parserOptions: {
+                  corsa: {
+                    executable: stableTypeScript7Binary,
+                  },
+                },
+              },
+            },
+          },
+        ],
+        invalid: [],
+      },
+    );
+
+    expect(seen).toEqual([
+      { text: "Leaf", symbol: "Leaf" },
+      { text: "Mid", symbol: "Mid" },
+      { text: "Root", symbol: "Root" },
+    ]);
+  });
+
   stableTypeScript7Case("does not confuse base types that share a simple name", () => {
     const seen: Record<
       string,

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -501,7 +501,8 @@ export class CorsaProjectSession {
     if (!isUsableSymbol(typeSymbol) || typeSymbol.name !== typeSymbolName) {
       return undefined;
     }
-    const classStart = classDeclarationStartAtIdentifier(sourceText, position);
+    const uniqueDeclaration = uniqueClassDeclarationPosition(sourceText, typeSymbolName);
+    const classStart = classDeclarationStartAtIdentifier(sourceText, position) ?? uniqueDeclaration;
     if (classStart !== undefined) {
       this.#classDeclarationByTypeId.set(type.id, {
         fileName: lookup.fileName,
@@ -511,10 +512,22 @@ export class CorsaProjectSession {
       });
     }
     const symbolSearchRange =
-      containingNamespaceRange(sourceText, position) ??
-      qualifiedNamespaceRangeAtIdentifier(sourceText, position);
+      uniqueDeclaration === undefined
+        ? (qualifiedNamespaceRangeAtIdentifier(sourceText, position) ??
+          containingNamespaceRange(sourceText, position))
+        : containingNamespaceRange(sourceText, uniqueDeclaration);
     if (symbolSearchRange) {
       this.#symbolSearchRangeByTypeId.set(type.id, symbolSearchRange);
+      if (uniqueDeclaration !== undefined) {
+        this.#typeLookupById.set(type.id, { ...lookup, symbolSearchRange });
+      }
+    } else if (uniqueDeclaration !== undefined) {
+      // A reference can live inside a namespace while resolving to a
+      // top-level declaration. Do not let the reference scope leak into the
+      // next base-type lookup.
+      this.#symbolSearchRangeByTypeId.delete(type.id);
+      const { symbolSearchRange: _symbolSearchRange, ...unscopedLookup } = lookup;
+      this.#typeLookupById.set(type.id, unscopedLookup);
     }
     return typeSymbol;
   }


### PR DESCRIPTION
## Summary

- clear a propagated namespace search range when a recovered base symbol has a unique top-level declaration
- keep the namespace range when the declaration itself is namespace-scoped
- add the exact three-level namespace-scoped inheritance regression for TypeScript 7

## Root cause

A base symbol reference found inside a namespace was treated as though its declaration also lived in that namespace. That search range was propagated to the next base type, so a top-level terminal base such as Root was no longer discoverable.

## Validation

- vp check
- session unit tests (15 passed)
- TypeScript 7 symbol/base regressions (3 passed)
- vp run -w build
- git diff --check

Closes #413

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symbol lookup for class declarations nested within namespaces.
  * Resolved cases where type navigation could select an incorrect declaration or fail to determine the appropriate search scope.
  * Improved handling of inherited type chains, including reliable traversal from derived types to their root types.

* **Tests**
  * Added coverage for namespace-based type resolution and terminal base-symbol chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->