### PR TITLE
fix: preserve class body type symbols

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -292,6 +292,17 @@ function nodeForTypeLookup(node: Node | CorsaNode): Node | CorsaNode {
     return node;
   }
   switch ((node as { readonly type?: string }).type) {
+    case "ClassBody": {
+      const parent = childNode(node, "parent");
+      if (
+        parent &&
+        ((parent as { readonly type?: string }).type === "ClassDeclaration" ||
+          (parent as { readonly type?: string }).type === "ClassExpression")
+      ) {
+        return childNode(parent, "id") ?? parent;
+      }
+      return node;
+    }
     case "ClassDeclaration":
     case "ClassExpression":
       return childNode(node, "id") ?? node;

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -125,6 +125,65 @@ describe("corsa oxlint type locations", () => {
     expect(seen).toEqual({ Base: "Base", Derived: "Derived" });
   });
 
+  integrationCase("exposes symbols for class body types and their bases", () => {
+    const seen: Record<
+      string,
+      {
+        readonly text: string;
+        readonly symbol: string | null;
+        readonly bases: readonly { readonly text: string; readonly symbol: string | null }[];
+      }
+    > = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "class-body-type-symbols",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise class body type and base symbol lookup",
+          requiresTypeChecking: true,
+        },
+        messages: { unexpected: "unexpected" },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          ClassBody(node: any) {
+            const name = node.parent?.id?.name;
+            const type = services.getTypeAtLocation(node);
+            if (name && type) {
+              seen[name] = {
+                text: checker.typeToString(type),
+                symbol: checker.getSymbolOfType(type)?.name ?? null,
+                bases: checker.getBaseTypes(type).map((base: any) => ({
+                  text: checker.typeToString(base),
+                  symbol: checker.getSymbolOfType(base)?.name ?? null,
+                })),
+              };
+            }
+          },
+        };
+      },
+    });
+
+    new RuleTester().run("class-body-type-symbols", rule as any, {
+      valid: [{ code: "class Base {}\nclass Derived extends Base {}\n" }],
+      invalid: [],
+    });
+
+    expect(seen).toEqual({
+      Base: { text: "Base", symbol: "Base", bases: [] },
+      Derived: {
+        text: "Derived",
+        symbol: "Derived",
+        bases: [{ text: "Base", symbol: "Base" }],
+      },
+    });
+  });
+
   integrationCase("resolves declared types for type reference nodes", () => {
     const seen: {
       readonly name: string;


### PR DESCRIPTION
## Summary

- resolve `ClassBody` type lookups through the enclosing class identifier
- preserve class symbols on `getTypeAtLocation(ClassBody)` results
- cover symbols on both class body types and their base-type chain

## Root cause

`ClassBody` type resolution already fell back to the enclosing class name in the native bridge, but the TypeScript session remembered the body opening brace as the lookup origin. When the returned type handle did not expose a symbol directly, the lookup fallback could not recover the enclosing class symbol or propagate a useful origin to base types.

## Validation

- `vp check`
- `cargo fmt --all --check`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/session.test.ts --reporter=dot`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts --reporter=dot` (mock-backed test passed; real-Corsa cases require the CI Go 1.26 toolchain)
- `vp run -w build_node_debug`

Closes #416

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type information for class bodies, including class names and inherited base types.
  * Class inheritance details are now correctly exposed for inspection and analysis.

* **Tests**
  * Added coverage verifying symbols and base types for classes with and without inheritance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->