### PR TITLE
fix: preserve first-touch type symbol lookups

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -63,7 +63,7 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
   return {
     getTypeAtLocation(node) {
       if ((node as { readonly type?: string }).type === "NewExpression") {
-        return typeOfNewExpression(node as Node, this);
+        return typeOfNewExpression(context, node as Node, this);
       }
       const lookupNode = nodeForTypeLookup(node);
       const type = sessionForContext(context).session.getTypeAtSourceRange(
@@ -272,7 +272,11 @@ function pathsReferToSameFile(left: string, right: string): boolean {
   );
 }
 
-function typeOfNewExpression(node: Node, checker: CorsaTypeCheckerShape): CorsaType | undefined {
+function typeOfNewExpression(
+  context: ContextWithParserOptions,
+  node: Node,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
   const callee = childNode(node, "callee");
   if (!callee) {
     return undefined;
@@ -282,9 +286,11 @@ function typeOfNewExpression(node: Node, checker: CorsaTypeCheckerShape): CorsaT
     return undefined;
   }
   const constructSignature = checker.getSignaturesOfType(calleeType, SignatureKind.Construct)[0];
-  return constructSignature
+  const type = constructSignature
     ? (checker.getReturnTypeOfSignature(constructSignature) ?? calleeType)
     : calleeType;
+  sessionForContext(context).session.rememberTypeLookupFromType(type, calleeType);
+  return type;
 }
 
 function nodeForTypeLookup(node: Node | CorsaNode): Node | CorsaNode {
@@ -308,6 +314,9 @@ function nodeForTypeLookup(node: Node | CorsaNode): Node | CorsaNode {
       return childNode(node, "id") ?? node;
     case "TSPropertySignature":
       return childNode(node, "key") ?? node;
+    case "PropertyDefinition":
+    case "TSAbstractPropertyDefinition":
+      return childNode(node, "typeAnnotation") ?? childNode(node, "key") ?? node;
     default:
       return node;
   }

--- a/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
@@ -855,6 +855,81 @@ describe("corsa oxlint implemented types", () => {
     });
   });
 
+  stableTypeScript7Case("resolves symbols for first-touch class field and new expression types", () => {
+    const seen: Record<string, string | null> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const runSelector = (label: string, selectorName: string) => {
+      const rule = createRule({
+        name: `first-touch-type-symbol-${label}`,
+        meta: {
+          type: "problem",
+          docs: {
+            description: "exercise symbol lookup on isolated getTypeAtLocation queries",
+            requiresTypeChecking: true,
+          },
+          messages: { unexpected: "unexpected" },
+          schema: [],
+        },
+        defaultOptions: [],
+        create(context: any) {
+          const services = OxlintUtils.getParserServices(context);
+          const checker = services.program.getTypeChecker();
+          return {
+            [selectorName](node: any) {
+              const type = services.getTypeAtLocation(node);
+              if (!type || checker.typeToString(type) !== "Derived") {
+                return;
+              }
+              seen[label] = checker.getSymbolOfType(type)?.name ?? null;
+            },
+          };
+        },
+      });
+
+      new RuleTester({ languageOptions: { sourceType: "module" } }).run(label, rule as any, {
+        valid: [
+          {
+            code: [
+              "class Base {}",
+              "class Derived extends Base {}",
+              "class Holder { public h: Derived; }",
+              "interface Props { d: Derived; }",
+              "const inst = new Derived();",
+            ].join("\n"),
+            settings: {
+              corsaOxlint: {
+                parserOptions: {
+                  corsa: {
+                    executable: stableTypeScript7Binary,
+                  },
+                },
+              },
+            },
+          },
+        ],
+        invalid: [],
+      });
+    };
+
+    for (const [label, selectorName] of [
+      ["ClassDeclaration", "ClassDeclaration"],
+      ["ClassBody", "ClassBody"],
+      ["TSPropertySignature", "TSPropertySignature"],
+      ["PropertyDefinition", "PropertyDefinition"],
+      ["NewExpression", "NewExpression"],
+    ] as const) {
+      runSelector(label, selectorName);
+    }
+
+    expect(seen).toEqual({
+      ClassDeclaration: "Derived",
+      ClassBody: "Derived",
+      TSPropertySignature: "Derived",
+      PropertyDefinition: "Derived",
+      NewExpression: "Derived",
+    });
+  });
+
   stableTypeScript7Case("preserves terminal base symbols for namespace-scoped leaves", () => {
     const seen: { text: string; symbol: string | null }[] = [];
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -563,6 +563,24 @@ export class CorsaProjectSession {
     return this.#classDeclarationByTypeId.get(type.id);
   }
 
+  rememberTypeLookupFromType(type: CorsaType | undefined, relatedType: CorsaType | undefined): void {
+    if (!type || !relatedType || type.id === relatedType.id) {
+      return;
+    }
+    const lookup = this.#typeLookupById.get(relatedType.id);
+    if (lookup && !this.#typeLookupById.has(type.id)) {
+      this.#typeLookupById.set(type.id, lookup);
+    }
+    const source = this.#typeSourceById.get(relatedType.id);
+    if (source && !this.#typeSourceById.has(type.id)) {
+      this.#typeSourceById.set(type.id, source);
+    }
+    const symbolSearchRange = this.#symbolSearchRangeByTypeId.get(relatedType.id);
+    if (symbolSearchRange && !this.#symbolSearchRangeByTypeId.has(type.id)) {
+      this.#symbolSearchRangeByTypeId.set(type.id, symbolSearchRange);
+    }
+  }
+
   getTypeOfSymbol(symbol: CorsaSymbol): CorsaType | undefined {
     const type = this.rememberType(this.tryGetSymbolType(symbol, "getTypeOfSymbol"));
     this.rememberTypeSource(type, symbol.valueDeclaration);


### PR DESCRIPTION
## Summary
- preserve type lookup hints for first-touch `NewExpression` instance types
- seed `PropertyDefinition` lookups from the field type annotation when available
- add a stable TypeScript 7 regression test for isolated selector queries

## Root Cause
The first `getSymbolOfType()` lookup depended on source-position hints that were never attached to `NewExpression` return types, and class-field lookups started from the whole property node instead of the type annotation. That left the symbol recovery path without a reliable declaration position until another selector primed the same type handle.

## Impact
This restores `checker.getSymbolOfType(services.getTypeAtLocation(node))` for `PropertyDefinition` and `NewExpression` nodes without requiring a prior class-level query.

## Validation
- `pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts --reporter=verbose`

Closes #418

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript type and symbol resolution across class declarations, class bodies, property definitions, property signatures, and `new` expressions.
  * Type queries now provide more consistent results when symbols are accessed for the first time.
  * Property type lookups now prioritize explicit type annotations and property keys for more accurate results.

* **Tests**
  * Added regression coverage for TypeScript 7 type and symbol resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->