### PR TITLE
fix: format first-touch type symbol lookup sources

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
@@ -855,7 +855,7 @@ describe("corsa oxlint implemented types", () => {
     });
   });
 
-  stableTypeScript7Case("resolves symbols for first-touch class field and new expression types", () => {
+  stableTypeScript7Case("resolves first-touch class field and new expression type symbols", () => {
     const seen: Record<string, string | null> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
     const runSelector = (label: string, selectorName: string) => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -563,7 +563,10 @@ export class CorsaProjectSession {
     return this.#classDeclarationByTypeId.get(type.id);
   }
 
-  rememberTypeLookupFromType(type: CorsaType | undefined, relatedType: CorsaType | undefined): void {
+  rememberTypeLookupFromType(
+    type: CorsaType | undefined,
+    relatedType: CorsaType | undefined,
+  ): void {
     if (!type || !relatedType || type.id === relatedType.id) {
       return;
     }


### PR DESCRIPTION
#419 merged with two lines that exceed the formatter's print width, so `vp fmt --check` (the `JS/TS Format` CI job) now fails on `main`. This wraps the `rememberTypeLookupFromType` signature the way the formatter wants it:

```ts
  rememberTypeLookupFromType(
    type: CorsaType | undefined,
    relatedType: CorsaType | undefined,
  ): void {
```

and shortens the new regression test's title so the hugged `stableTypeScript7Case("…", () => {` call fits in one line instead of being split across four. No behavior changes; `pnpm exec vp fmt --check` passes on this branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->