### PR TITLE
style: format first-touch type symbol lookup fix

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
@@ -855,80 +855,83 @@ describe("corsa oxlint implemented types", () => {
     });
   });
 
-  stableTypeScript7Case("resolves symbols for first-touch class field and new expression types", () => {
-    const seen: Record<string, string | null> = {};
-    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
-    const runSelector = (label: string, selectorName: string) => {
-      const rule = createRule({
-        name: `first-touch-type-symbol-${label}`,
-        meta: {
-          type: "problem",
-          docs: {
-            description: "exercise symbol lookup on isolated getTypeAtLocation queries",
-            requiresTypeChecking: true,
-          },
-          messages: { unexpected: "unexpected" },
-          schema: [],
-        },
-        defaultOptions: [],
-        create(context: any) {
-          const services = OxlintUtils.getParserServices(context);
-          const checker = services.program.getTypeChecker();
-          return {
-            [selectorName](node: any) {
-              const type = services.getTypeAtLocation(node);
-              if (!type || checker.typeToString(type) !== "Derived") {
-                return;
-              }
-              seen[label] = checker.getSymbolOfType(type)?.name ?? null;
+  stableTypeScript7Case(
+    "resolves symbols for first-touch class field and new expression types",
+    () => {
+      const seen: Record<string, string | null> = {};
+      const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+      const runSelector = (label: string, selectorName: string) => {
+        const rule = createRule({
+          name: `first-touch-type-symbol-${label}`,
+          meta: {
+            type: "problem",
+            docs: {
+              description: "exercise symbol lookup on isolated getTypeAtLocation queries",
+              requiresTypeChecking: true,
             },
-          };
-        },
-      });
+            messages: { unexpected: "unexpected" },
+            schema: [],
+          },
+          defaultOptions: [],
+          create(context: any) {
+            const services = OxlintUtils.getParserServices(context);
+            const checker = services.program.getTypeChecker();
+            return {
+              [selectorName](node: any) {
+                const type = services.getTypeAtLocation(node);
+                if (!type || checker.typeToString(type) !== "Derived") {
+                  return;
+                }
+                seen[label] = checker.getSymbolOfType(type)?.name ?? null;
+              },
+            };
+          },
+        });
 
-      new RuleTester({ languageOptions: { sourceType: "module" } }).run(label, rule as any, {
-        valid: [
-          {
-            code: [
-              "class Base {}",
-              "class Derived extends Base {}",
-              "class Holder { public h: Derived; }",
-              "interface Props { d: Derived; }",
-              "const inst = new Derived();",
-            ].join("\n"),
-            settings: {
-              corsaOxlint: {
-                parserOptions: {
-                  corsa: {
-                    executable: stableTypeScript7Binary,
+        new RuleTester({ languageOptions: { sourceType: "module" } }).run(label, rule as any, {
+          valid: [
+            {
+              code: [
+                "class Base {}",
+                "class Derived extends Base {}",
+                "class Holder { public h: Derived; }",
+                "interface Props { d: Derived; }",
+                "const inst = new Derived();",
+              ].join("\n"),
+              settings: {
+                corsaOxlint: {
+                  parserOptions: {
+                    corsa: {
+                      executable: stableTypeScript7Binary,
+                    },
                   },
                 },
               },
             },
-          },
-        ],
-        invalid: [],
+          ],
+          invalid: [],
+        });
+      };
+
+      for (const [label, selectorName] of [
+        ["ClassDeclaration", "ClassDeclaration"],
+        ["ClassBody", "ClassBody"],
+        ["TSPropertySignature", "TSPropertySignature"],
+        ["PropertyDefinition", "PropertyDefinition"],
+        ["NewExpression", "NewExpression"],
+      ] as const) {
+        runSelector(label, selectorName);
+      }
+
+      expect(seen).toEqual({
+        ClassDeclaration: "Derived",
+        ClassBody: "Derived",
+        TSPropertySignature: "Derived",
+        PropertyDefinition: "Derived",
+        NewExpression: "Derived",
       });
-    };
-
-    for (const [label, selectorName] of [
-      ["ClassDeclaration", "ClassDeclaration"],
-      ["ClassBody", "ClassBody"],
-      ["TSPropertySignature", "TSPropertySignature"],
-      ["PropertyDefinition", "PropertyDefinition"],
-      ["NewExpression", "NewExpression"],
-    ] as const) {
-      runSelector(label, selectorName);
-    }
-
-    expect(seen).toEqual({
-      ClassDeclaration: "Derived",
-      ClassBody: "Derived",
-      TSPropertySignature: "Derived",
-      PropertyDefinition: "Derived",
-      NewExpression: "Derived",
-    });
-  });
+    },
+  );
 
   stableTypeScript7Case("preserves terminal base symbols for namespace-scoped leaves", () => {
     const seen: { text: string; symbol: string | null }[] = [];

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -563,7 +563,10 @@ export class CorsaProjectSession {
     return this.#classDeclarationByTypeId.get(type.id);
   }
 
-  rememberTypeLookupFromType(type: CorsaType | undefined, relatedType: CorsaType | undefined): void {
+  rememberTypeLookupFromType(
+    type: CorsaType | undefined,
+    relatedType: CorsaType | undefined,
+  ): void {
     if (!type || !relatedType || type.id === relatedType.id) {
       return;
     }


### PR DESCRIPTION
## Summary
- reformat the first-touch type symbol lookup fix to satisfy the JS/TS formatter
- carry no behavioral changes beyond the already-merged fix on `main`

## Why
PR #419 merged into `main` at 2026-07-31T00:14:48Z, but the post-merge CI run on commit `10560b5` failed `JS/TS Format`. This follow-up restores `main` to green so the minor release can proceed safely.

## Validation
- `pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts -t "resolves symbols for first-touch class field and new expression types" --reporter=verbose`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->