### PR TITLE
fix: restore cross-file type metadata on stable TypeScript 7 runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ### Fixed
 
+- type, signature, and symbol relation requests now mirror numeric handles into the `objectId` field that TypeScript 7 stable runtimes expect, so `getSymbolOfType`, `getBaseTypes` metadata, and `getImplementedTypesOfType` keep working for class types imported from other files ([#427](https://github.com/ubugeeei-prod/corsa-bind/issues/427)).
+- `corsa-oxlint` recovers class-declaration positions for compact TypeScript 7 declaration handles instead of misreading node ids as source offsets, keeping same-named classes in different scopes distinct.
+- the default runtime discovery now resolves the `@typescript/native-preview` platform executable (`lib/tsgo`, `tsgo.exe` on Windows) instead of the meta package's Node bin script, which Windows cannot spawn ([#428](https://github.com/ubugeeei-prod/corsa-bind/issues/428)).
 - `corsa-oxlint` now resolves nominal type symbols for interface and class property annotations.
 - `corsa-oxlint` now returns direct and inherited implemented interfaces after symbol, base-type, and generic-argument traversal while accepting compact TypeScript 7 declaration handles.
 - `corsa-oxlint` now discovers the native Corsa runtime shipped with TypeScript 7 or newer before falling back to `@typescript/native-preview`.

--- a/src/bindings/nodejs/corsa_node/index.d.ts
+++ b/src/bindings/nodejs/corsa_node/index.d.ts
@@ -34,9 +34,14 @@ export declare class CorsaApiClient {
   /** Resolves the checker symbol visible at a file position. */
   getSymbolAtPosition(snapshot: string, project: string, file: string, position: number): any
   getSymbolAtPositionAsync(snapshot: string, project: string, file: string, position: number): Promise<unknown>
-  /** Resolves the symbol attached to a checker type. */
-  getSymbolOfType(snapshot: string, typeHandle: string): any
-  getSymbolOfTypeAsync(snapshot: string, typeHandle: string): Promise<unknown>
+  /**
+   * Resolves the symbol attached to a checker type.
+   *
+   * Passing the owning project keeps the lookup working on TypeScript 7
+   * stable runtimes, which resolve type symbols inside a project.
+   */
+  getSymbolOfType(snapshot: string, typeHandle: string, project?: string | undefined | null): any
+  getSymbolOfTypeAsync(snapshot: string, typeHandle: string, project?: string | undefined | null): Promise<unknown>
   /** Resolves type arguments for type-reference and mapped objects, and returns [] otherwise. */
   getTypeArguments(snapshot: string, project: string, typeHandle: string, objectFlags?: number | undefined | null): any
   /** Resolves type arguments and prefers structural handles from source locations when available. */

--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -207,6 +207,7 @@ enum JsonTaskKind {
     GetSymbolOfType {
         snapshot: String,
         type_handle: String,
+        project: Option<String>,
     },
     GetTypeArguments {
         snapshot: String,
@@ -353,10 +354,13 @@ impl<'task> ScopedTask<'task> for JsonApiTask {
             JsonTaskKind::GetSymbolOfType {
                 snapshot,
                 type_handle,
+                project,
             } => {
-                let response = block_on(self.client.get_symbol_of_type(
-                    SnapshotHandle::from(snapshot.as_str()),
-                    TypeHandle::from(type_handle.as_str()),
+                let response = block_on(get_symbol_of_type_with_optional_project(
+                    &self.client,
+                    snapshot,
+                    type_handle,
+                    project.as_deref(),
                 ))
                 .map_err(into_napi_error)?;
                 to_value(&response)
@@ -865,11 +869,21 @@ impl CorsaApiClient {
     }
 
     /// Resolves the symbol attached to a checker type.
+    ///
+    /// Passing the owning project keeps the lookup working on TypeScript 7
+    /// stable runtimes, which resolve type symbols inside a project.
     #[napi]
-    pub fn get_symbol_of_type(&self, snapshot: String, type_handle: String) -> Result<Value> {
-        let response = block_on(self.inner.get_symbol_of_type(
-            SnapshotHandle::from(snapshot.as_str()),
-            TypeHandle::from(type_handle.as_str()),
+    pub fn get_symbol_of_type(
+        &self,
+        snapshot: String,
+        type_handle: String,
+        project: Option<String>,
+    ) -> Result<Value> {
+        let response = block_on(get_symbol_of_type_with_optional_project(
+            &self.inner,
+            &snapshot,
+            &type_handle,
+            project.as_deref(),
         ))
         .map_err(into_napi_error)?;
         to_value(&response)
@@ -880,12 +894,14 @@ impl CorsaApiClient {
         &self,
         snapshot: String,
         type_handle: String,
+        project: Option<String>,
     ) -> AsyncTask<JsonApiTask> {
         AsyncTask::new(JsonApiTask {
             client: self.inner.clone(),
             kind: JsonTaskKind::GetSymbolOfType {
                 snapshot,
                 type_handle,
+                project,
             },
         })
     }
@@ -1217,6 +1233,33 @@ impl CorsaApiClient {
                 snapshots: self.snapshots.clone(),
             },
         })
+    }
+}
+
+async fn get_symbol_of_type_with_optional_project(
+    client: &ApiClient,
+    snapshot: &str,
+    type_handle: &str,
+    project: Option<&str>,
+) -> corsa::Result<Option<corsa::api::SymbolResponse>> {
+    match project {
+        Some(project) => {
+            client
+                .get_symbol_of_type_in_project(
+                    SnapshotHandle::from(snapshot),
+                    ProjectHandle::from(project),
+                    TypeHandle::from(type_handle),
+                )
+                .await
+        }
+        None => {
+            client
+                .get_symbol_of_type(
+                    SnapshotHandle::from(snapshot),
+                    TypeHandle::from(type_handle),
+                )
+                .await
+        }
     }
 }
 

--- a/src/bindings/nodejs/corsa_node/ts/index.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.ts
@@ -79,8 +79,12 @@ export interface CorsaApiClient {
     file: string,
     position: number,
   ): Promise<SymbolResponse | null>;
-  getSymbolOfType(snapshot: string, typeHandle: string): SymbolResponse | null;
-  getSymbolOfTypeAsync(snapshot: string, typeHandle: string): Promise<SymbolResponse | null>;
+  getSymbolOfType(snapshot: string, typeHandle: string, project?: string): SymbolResponse | null;
+  getSymbolOfTypeAsync(
+    snapshot: string,
+    typeHandle: string,
+    project?: string,
+  ): Promise<SymbolResponse | null>;
   getTypeArguments(
     snapshot: string,
     project: string,

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -2,6 +2,7 @@ import type { Node } from "@oxlint/plugins";
 
 import { createNodeMaps, toPosition } from "./node_map";
 import { sessionForContext } from "./registry";
+import { uniqueClassDeclarationPosition } from "./session";
 import type { CorsaProjectSession } from "./session";
 import { SignatureKind } from "./types";
 import type {
@@ -463,19 +464,24 @@ function implementedTypesFromTypeDeclaration(
   if (cached) {
     return cached;
   }
+  // Resolve through the session's type-symbol lookup first: it primes the
+  // declaration-position caches for compact TypeScript 7 handles before the
+  // source scans below run, while a direct `getSymbol(type.symbol)` cache hit
+  // would skip that recovery.
   const symbol =
-    (type.symbol ? session.getSymbol(type.symbol) : undefined) ?? checker.getSymbolOfType(type);
+    checker.getSymbolOfType(type) ?? (type.symbol ? session.getSymbol(type.symbol) : undefined);
   const declaration = symbol?.valueDeclaration ?? symbol?.declarations?.[0];
   const declarationNode = declaration ? session.getNode(declaration) : undefined;
+  const scanDeclarationNode = declarationNodeForImplementsScan(context, symbol, declarationNode);
   const matchedDeclarationNode = session.getClassDeclarationForType(type);
   const localImplementingDeclaration =
-    declarationNode && pathsReferToSameFile(declarationNode.fileName, context.filename)
-      ? implementingClassDeclaration(context, type, symbol, declarationNode)
+    scanDeclarationNode && pathsReferToSameFile(scanDeclarationNode.fileName, context.filename)
+      ? implementingClassDeclaration(context, type, symbol, scanDeclarationNode)
       : undefined;
   const resolvedDeclarationNode =
     matchedDeclarationNode ??
     localImplementingDeclaration ??
-    declarationNode ??
+    scanDeclarationNode ??
     implementingClassDeclaration(context, type, symbol);
   const sourceText = resolvedDeclarationNode
     ? sourceTextForPath(context, resolvedDeclarationNode.fileName)
@@ -485,6 +491,44 @@ function implementedTypesFromTypeDeclaration(
       ? implementedTypesFromSourceText(context, resolvedDeclarationNode, sourceText, checker)
       : [];
   return session.cacheOwnImplementedTypes(type.id, implemented);
+}
+
+/**
+ * Returns a declaration node whose range can anchor an `implements` source
+ * scan.
+ *
+ * Positional handles are used as-is. A compact TypeScript 7 declaration handle
+ * carries a node id instead of source offsets, so its parsed range cannot
+ * anchor a scan; the declaring file is searched for the symbol's unique class
+ * declaration instead. An ambiguous name yields no node rather than a
+ * same-named declaration from another scope.
+ */
+function declarationNodeForImplementsScan(
+  context: ContextWithParserOptions,
+  symbol: CorsaSymbol | undefined,
+  declarationNode: CorsaNode | undefined,
+): CorsaNode | undefined {
+  if (!declarationNode?.positionless) {
+    return declarationNode;
+  }
+  const name = symbol?.name;
+  if (!name) {
+    return undefined;
+  }
+  const sourceText = sourceTextForPath(context, declarationNode.fileName);
+  if (!sourceText) {
+    return undefined;
+  }
+  const pos = uniqueClassDeclarationPosition(sourceText, name);
+  if (pos === undefined) {
+    return undefined;
+  }
+  return {
+    fileName: declarationNode.fileName,
+    pos,
+    end: sourceText.length,
+    range: [pos, sourceText.length] as const,
+  };
 }
 
 function implementingClassDeclaration(

--- a/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
@@ -222,6 +222,78 @@ describe("context", () => {
     expect(defaultCorsaExecutable(workspace)).toBe(realpathSync(binPath));
   });
 
+  it("resolves the native-preview platform executable on Windows", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
+    cleanupDirs.add(workspace);
+    const packageDir = resolve(workspace, "node_modules/@typescript/native-preview");
+    const binPath = resolve(packageDir, "bin/tsgo.js");
+    const platformDir = resolve(
+      workspace,
+      `node_modules/@typescript/native-preview-win32-${process.arch}`,
+    );
+    const platformBin = resolve(platformDir, "lib/tsgo.exe");
+    mkdirSync(dirname(binPath), { recursive: true });
+    mkdirSync(dirname(platformBin), { recursive: true });
+    writeFileSync(
+      resolve(packageDir, "package.json"),
+      JSON.stringify({ name: "@typescript/native-preview", bin: { tsgo: "bin/tsgo.js" } }),
+    );
+    writeFileSync(binPath, "#!/usr/bin/env node\n");
+    writeFileSync(
+      resolve(platformDir, "package.json"),
+      JSON.stringify({ name: `@typescript/native-preview-win32-${process.arch}` }),
+    );
+    writeFileSync(platformBin, "");
+
+    expect(defaultCorsaExecutable(workspace, "win32")).toBe(realpathSync(platformBin));
+  });
+
+  it("never resolves the native-preview Node bin script on Windows", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
+    cleanupDirs.add(workspace);
+    const packageDir = resolve(workspace, "node_modules/@typescript/native-preview");
+    const binPath = resolve(packageDir, "bin/tsgo.js");
+    const fallback = resolve(workspace, ".cache/corsa.exe");
+    mkdirSync(dirname(binPath), { recursive: true });
+    mkdirSync(dirname(fallback), { recursive: true });
+    writeFileSync(
+      resolve(packageDir, "package.json"),
+      JSON.stringify({ name: "@typescript/native-preview", bin: { tsgo: "bin/tsgo.js" } }),
+    );
+    writeFileSync(binPath, "#!/usr/bin/env node\n");
+    writeFileSync(fallback, "");
+
+    // A Node script behind a shebang cannot be spawned on Windows
+    // (`os error 193`), so resolution must skip it.
+    expect(defaultCorsaExecutable(workspace, "win32")).toBe(fallback);
+  });
+
+  it("prefers the native-preview platform executable over the bin script", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
+    cleanupDirs.add(workspace);
+    const packageDir = resolve(workspace, "node_modules/@typescript/native-preview");
+    const binPath = resolve(packageDir, "bin/tsgo.js");
+    const platformDir = resolve(
+      workspace,
+      `node_modules/@typescript/native-preview-linux-${process.arch}`,
+    );
+    const platformBin = resolve(platformDir, "lib/tsgo");
+    mkdirSync(dirname(binPath), { recursive: true });
+    mkdirSync(dirname(platformBin), { recursive: true });
+    writeFileSync(
+      resolve(packageDir, "package.json"),
+      JSON.stringify({ name: "@typescript/native-preview", bin: { tsgo: "bin/tsgo.js" } }),
+    );
+    writeFileSync(binPath, "#!/usr/bin/env node\n");
+    writeFileSync(
+      resolve(platformDir, "package.json"),
+      JSON.stringify({ name: `@typescript/native-preview-linux-${process.arch}` }),
+    );
+    writeFileSync(platformBin, "");
+
+    expect(defaultCorsaExecutable(workspace, "linux")).toBe(realpathSync(platformBin));
+  });
+
   it("falls back to a plugin anchor when native-preview is only installed next to the plugin", () => {
     const consumerRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-consumer-"));
     const pluginRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-plugin-"));

--- a/src/bindings/nodejs/corsa_oxlint/ts/context.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.ts
@@ -33,8 +33,8 @@ export function defaultCorsaExecutable(
     return stableTypeScript;
   }
   const nativePreview =
-    resolveNativePreviewExecutableFrom(resolve(rootDir, "package.json")) ??
-    (resolveFrom ? resolveNativePreviewExecutableFrom(resolveFrom) : undefined);
+    resolveNativePreviewExecutableFrom(resolve(rootDir, "package.json"), platform) ??
+    (resolveFrom ? resolveNativePreviewExecutableFrom(resolveFrom, platform) : undefined);
   if (nativePreview) {
     return nativePreview;
   }
@@ -232,20 +232,61 @@ function isTypeScriptVersionSevenOrNewer(packageJsonPath: string): boolean {
   }
 }
 
-function resolveNativePreviewExecutableFrom(anchor: string): string | undefined {
+function resolveNativePreviewExecutableFrom(
+  anchor: string,
+  platform: NodeJS.Platform,
+): string | undefined {
   const requireFromRoot = createRequire(anchor);
   const packageJsonPath = resolveOptional(
     requireFromRoot,
     "@typescript/native-preview/package.json",
   );
   if (packageJsonPath) {
+    const platformExecutable = nativePreviewPlatformExecutable(packageJsonPath, platform);
+    if (platformExecutable) {
+      return platformExecutable;
+    }
+    // The meta package's `bin` entry is a Node script behind a shebang.
+    // Windows cannot spawn it (`os error 193`), so the script is only a
+    // usable runtime on platforms that honor shebang lines.
+    if (platform === "win32") {
+      return undefined;
+    }
     const binPath = nativePreviewBinPath(packageJsonPath);
     if (binPath && existsSync(binPath)) {
       return binPath;
     }
   }
+  if (platform === "win32") {
+    return undefined;
+  }
   const packageEntry = resolveOptional(requireFromRoot, "@typescript/native-preview");
   return packageEntry && existsSync(packageEntry) ? packageEntry : undefined;
+}
+
+/**
+ * Resolves the platform-specific `tsgo` executable that the
+ * `@typescript/native-preview` meta package installs as an optional
+ * dependency, mirroring how the stable `typescript` runtime is resolved.
+ */
+function nativePreviewPlatformExecutable(
+  packageJsonPath: string,
+  platform: NodeJS.Platform,
+): string | undefined {
+  const requireFromPreview = createRequire(packageJsonPath);
+  const platformPackageJsonPath = resolveOptional(
+    requireFromPreview,
+    `@typescript/native-preview-${platform}-${process.arch}/package.json`,
+  );
+  if (!platformPackageJsonPath) {
+    return undefined;
+  }
+  const executable = resolve(
+    dirname(platformPackageJsonPath),
+    "lib",
+    platform === "win32" ? "tsgo.exe" : "tsgo",
+  );
+  return existsSync(executable) ? executable : undefined;
 }
 
 function resolveOptional(requireFromRoot: NodeJS.Require, specifier: string): string | undefined {

--- a/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
@@ -1085,6 +1085,82 @@ describe("corsa oxlint implemented types", () => {
     expect(seen.b?.map((base) => base.implemented)).toEqual([[]]);
   });
 
+  stableTypeScript7Case(
+    "preserves base symbols and implemented types for imported class types",
+    () => {
+      const workspace = mkdtempSync(resolve(tmpdir(), "corsa-oxlint-cross-file-implements-"));
+      writeFileSync(
+        resolve(workspace, "tsconfig.json"),
+        JSON.stringify({
+          compilerOptions: { target: "ES2020", module: "commonjs", strict: true },
+          include: ["**/*.ts"],
+        }),
+      );
+      writeFileSync(
+        resolve(workspace, "base.ts"),
+        [
+          "export class Ancestor {}",
+          "export interface IAncestor {}",
+          "export class Descendant extends Ancestor implements IAncestor {}",
+        ].join("\n"),
+      );
+      const holderText = [
+        'import { Descendant } from "./base";',
+        "",
+        "export class Holder {",
+        "  public readonly value: Descendant;",
+        "  constructor(v: Descendant) { this.value = v; }",
+        "}",
+      ].join("\n");
+      const holderFile = resolve(workspace, "holder.ts");
+      writeFileSync(holderFile, holderText);
+
+      const checker = createTypeChecker({
+        cwd: workspace,
+        filename: holderFile,
+        sourceCode: { text: holderText },
+        settings: {
+          corsaOxlint: {
+            parserOptions: {
+              project: "tsconfig.json",
+              corsa: {
+                executable: stableTypeScript7Binary,
+                cwd: workspace,
+                mode: "jsonrpc",
+              },
+            },
+          },
+        },
+      } as any);
+
+      const propertyStart = holderText.indexOf("public readonly value");
+      const propertyEnd = holderText.indexOf(";", propertyStart) + 1;
+      const type = checker.getTypeAtLocation({
+        type: "PropertyDefinition",
+        range: [propertyStart, propertyEnd] as const,
+      } as any);
+
+      expect(type).toBeDefined();
+      const bases = type ? checker.getBaseTypes(type) : [];
+
+      // The imported class must behave exactly like a same-file class: its
+      // symbol resolves, base entries keep their symbols, and the implements
+      // clause declared in the other file stays visible.
+      expect(type ? checker.getSymbolOfType(type)?.name : undefined).toBe("Descendant");
+      expect(
+        bases.map((base) => ({
+          text: checker.typeToString(base),
+          symbol: checker.getSymbolOfType(base)?.name ?? null,
+        })),
+      ).toEqual([{ text: "Ancestor", symbol: "Ancestor" }]);
+      expect(
+        type
+          ? checker.getImplementedTypesOfType(type).map((impl) => checker.typeToString(impl))
+          : undefined,
+      ).toEqual(["IAncestor"]);
+    },
+  );
+
   integrationCase("returns implemented interfaces from external declaration class types", () => {
     const workspace = mkdtempSync(resolve(tmpdir(), "corsa-oxlint-external-implements-"));
     const depDir = resolve(workspace, "node_modules", "external-dep");

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
@@ -483,6 +483,7 @@ describe("CorsaProjectSession", () => {
       pos: 0,
       end: sourceText.length,
       range: [0, sourceText.length],
+      positionless: true,
     });
     expect(session.getNode("0.18.264./tmp/one.ts")?.range).toEqual([0, 18]);
   });

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -256,12 +256,14 @@ export class CorsaProjectSession {
     if (type.symbol) {
       const symbol = this.getSymbol(type.symbol);
       if (isUsableSymbol(symbol)) {
+        this.recoverDeclarationPositionsForSymbol(type, symbol);
         this.#symbolsByTypeId.set(type.id, symbol);
         return symbol;
       }
     }
     const symbol = this.getSymbolOfTypeById(type.id);
     if (symbol) {
+      this.recoverDeclarationPositionsForSymbol(type, symbol);
       this.#symbolsByTypeId.set(type.id, symbol);
       return symbol;
     }
@@ -272,6 +274,32 @@ export class CorsaProjectSession {
     }
     this.#symbolsByTypeId.set(type.id, null);
     return undefined;
+  }
+
+  /**
+   * Runs the source-position lookup for a natively resolved symbol whose
+   * declaration handles are compact TypeScript 7 handles without offsets.
+   *
+   * When the native `getSymbolOfType` lookup succeeds, the position-recovery
+   * path in `getSymbolOfTypeAtLookup` no longer runs, yet it is what records
+   * the class-declaration range and namespace search scope that disambiguate
+   * same-named declarations. The native symbol stays the source of truth;
+   * this only restores those positional caches.
+   */
+  private recoverDeclarationPositionsForSymbol(type: CorsaType, symbol: CorsaSymbol): void {
+    if (this.#classDeclarationByTypeId.has(type.id)) {
+      return;
+    }
+    const declarations = [symbol.valueDeclaration, ...(symbol.declarations ?? [])].filter(
+      (handle): handle is string => handle !== undefined,
+    );
+    if (declarations.length === 0 || !declarations.every(isPositionlessNodeHandle)) {
+      return;
+    }
+    if (!this.#typeLookupById.has(type.id)) {
+      return;
+    }
+    this.getSymbolOfTypeAtLookup(type);
   }
 
   private getSymbolOfTypeAtLookup(type: CorsaType): CorsaSymbol | undefined {
@@ -538,7 +566,11 @@ export class CorsaProjectSession {
     }
     try {
       return this.rememberUsableSymbol(
-        this.client().getSymbolOfType(this.#snapshot, typeId) as CorsaSymbol | null,
+        this.client().getSymbolOfType(
+          this.#snapshot,
+          typeId,
+          this.#projects[0]?.id,
+        ) as CorsaSymbol | null,
       );
     } catch (error) {
       if (isMissingTypeHandleError(error)) {
@@ -1482,7 +1514,10 @@ function classDeclarationStartAtIdentifier(
   return match ? prefixStart + match.index : undefined;
 }
 
-function uniqueClassDeclarationPosition(sourceText: string, className: string): number | undefined {
+export function uniqueClassDeclarationPosition(
+  sourceText: string,
+  className: string,
+): number | undefined {
   const escapedName = className.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const declarationPattern = new RegExp(`\\bclass\\s+${escapedName}\\b`, "gu");
   const declaration = declarationPattern.exec(sourceText);
@@ -1792,11 +1827,10 @@ function parseNodeHandle(
   const [posText, secondText, thirdText, ...remainingParts] = value.split(".");
   const pos = Number(posText);
   const second = Number(secondText);
-  const third = Number(thirdText);
   if (!Number.isFinite(pos) || !Number.isFinite(second)) {
     return undefined;
   }
-  const hasEndPosition = Number.isFinite(third);
+  const hasEndPosition = isFiniteNumberText(thirdText);
   const fileName = (hasEndPosition ? remainingParts : [thirdText, ...remainingParts]).join(".");
   if (!fileName) {
     return undefined;
@@ -1805,7 +1839,27 @@ function parseNodeHandle(
   if (end < pos) {
     return undefined;
   }
+  if (!hasEndPosition) {
+    // Compact TypeScript 7 handle: `<node id>.<syntax kind>.<path>`. The
+    // parsed numbers identify the node but are not source offsets.
+    return { id: value, fileName, pos, end, range: [pos, end], positionless: true };
+  }
   return { id: value, fileName, pos, end, range: [pos, end] };
+}
+
+/**
+ * Reports whether a node handle uses the compact TypeScript 7 wire format
+ * `<node id>.<syntax kind>.<path>`, which carries no source offsets.
+ */
+function isPositionlessNodeHandle(value: string): boolean {
+  const [posText, secondText, thirdText] = value.split(".");
+  return (
+    isFiniteNumberText(posText) && isFiniteNumberText(secondText) && !isFiniteNumberText(thirdText)
+  );
+}
+
+function isFiniteNumberText(text: string | undefined): boolean {
+  return text !== undefined && text !== "" && Number.isFinite(Number(text));
 }
 
 function isRecoverableTransportError(error: unknown): boolean {

--- a/src/bindings/nodejs/corsa_oxlint/ts/types.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/types.ts
@@ -48,6 +48,12 @@ export interface CorsaNode {
   readonly pos: number;
   readonly end: number;
   readonly range: readonly [number, number];
+  /**
+   * Set when the node was parsed from a compact TypeScript 7 declaration
+   * handle, whose leading number is a node id rather than a source offset. The
+   * range of such a node cannot anchor source-text scans.
+   */
+  readonly positionless?: boolean;
 }
 
 export interface CorsaSymbol {

--- a/src/core/corsa_client/src/api/driver.rs
+++ b/src/core/corsa_client/src/api/driver.rs
@@ -40,7 +40,7 @@ impl ClientDriver {
             Self::JsonRpc { rpc, .. } => {
                 if let Some(profiler) = profiler {
                     let started = Instant::now();
-                    let params = serialize_api_params(params)?;
+                    let params = serialize_api_params(method, params)?;
                     record_profile(
                         profiler,
                         method,
@@ -68,7 +68,7 @@ impl ClientDriver {
                     );
                     Ok(response)
                 } else {
-                    let params = serialize_api_params(params)?;
+                    let params = serialize_api_params(method, params)?;
                     let value = rpc.request_value(method, params).await?;
                     Ok(serde_json::from_value(value)?)
                 }
@@ -76,7 +76,7 @@ impl ClientDriver {
             Self::Msgpack { worker } => {
                 let payload = if let Some(profiler) = profiler {
                     let started = Instant::now();
-                    let params = serialize_api_params(params)?;
+                    let params = serialize_api_params(method, params)?;
                     let payload = serde_json::to_vec(&params)?;
                     record_profile(
                         profiler,
@@ -87,7 +87,7 @@ impl ClientDriver {
                     );
                     payload
                 } else {
-                    let params = serialize_api_params(params)?;
+                    let params = serialize_api_params(method, params)?;
                     serde_json::to_vec(&params)?
                 };
                 let started = profiler.map(|_| Instant::now());
@@ -134,7 +134,7 @@ impl ClientDriver {
             Self::JsonRpc { rpc, .. } => {
                 let params = if let Some(profiler) = profiler {
                     let started = Instant::now();
-                    let params = serialize_api_params(params)?;
+                    let params = serialize_api_params(method, params)?;
                     record_profile(
                         profiler,
                         method,
@@ -144,7 +144,7 @@ impl ClientDriver {
                     );
                     params
                 } else {
-                    serialize_api_params(params)?
+                    serialize_api_params(method, params)?
                 };
                 let started = profiler.map(|_| Instant::now());
                 let value = rpc.request_value(method, params).await?;
@@ -181,7 +181,7 @@ impl ClientDriver {
             Self::Msgpack { worker } => {
                 let payload = if let Some(profiler) = profiler {
                     let started = Instant::now();
-                    let params = serialize_api_params(params)?;
+                    let params = serialize_api_params(method, params)?;
                     let payload = serde_json::to_vec(&params)?;
                     record_profile(
                         profiler,
@@ -192,7 +192,7 @@ impl ClientDriver {
                     );
                     payload
                 } else {
-                    let params = serialize_api_params(params)?;
+                    let params = serialize_api_params(method, params)?;
                     serde_json::to_vec(&params)?
                 };
                 let started = profiler.map(|_| Instant::now());
@@ -213,6 +213,7 @@ impl ClientDriver {
 
     pub(crate) async fn request_json(&self, method: &str, mut params: Value) -> Result<Value> {
         encode_numeric_api_handles(&mut params);
+        mirror_object_relation_handles(method, &mut params);
         match self {
             Self::JsonRpc { rpc, .. } => rpc.request_value(method, params).await,
             Self::Msgpack { worker } => {
@@ -233,6 +234,7 @@ impl ClientDriver {
         mut params: Value,
     ) -> Result<Option<Vec<u8>>> {
         encode_numeric_api_handles(&mut params);
+        mirror_object_relation_handles(method, &mut params);
         match self {
             Self::JsonRpc { rpc, .. } => {
                 let value = rpc.request_value(method, params).await?;
@@ -295,13 +297,75 @@ impl ClientDriver {
     }
 }
 
-fn serialize_api_params<P>(params: &P) -> Result<Value>
+fn serialize_api_params<P>(method: &str, params: &P) -> Result<Value>
 where
     P: Serialize + ?Sized,
 {
     let mut value = serde_json::to_value(params)?;
     encode_numeric_api_handles(&mut value);
+    mirror_object_relation_handles(method, &mut value);
     Ok(value)
+}
+
+/// Returns the legacy handle field a relation method used before upstream
+/// re-keyed it, or `None` when the method's wire contract never changed.
+///
+/// TypeScript 7 stable servers resolve these methods through a shared
+/// `{snapshot, project, objectId}` parameter shape, while the pinned Corsa
+/// build still reads the original `type`/`symbol`/`signature` field.
+fn object_relation_legacy_key(method: &str) -> Option<&'static str> {
+    match method {
+        "getSymbolOfType"
+        | "getAliasSymbolOfType"
+        | "getTargetOfType"
+        | "getFreshTypeOfType"
+        | "getRegularTypeOfType"
+        | "getTrueTypeOfConditionalType"
+        | "getFalseTypeOfConditionalType"
+        | "getBaseTypeOfType"
+        | "getCheckTypeOfType"
+        | "getConstraintOfType"
+        | "getExtendsTypeOfType"
+        | "getIndexTypeOfType"
+        | "getObjectTypeOfType"
+        | "getTypesOfType"
+        | "getTypeParametersOfType"
+        | "getOuterTypeParametersOfType"
+        | "getLocalTypeParametersOfType"
+        | "getAliasTypeArgumentsOfType" => Some("type"),
+        "getTypeParametersOfSignature"
+        | "getParametersOfSignature"
+        | "getThisParameterOfSignature"
+        | "getTargetOfSignature" => Some("signature"),
+        "getParentOfSymbol"
+        | "getExportSymbolOfSymbol"
+        | "getMembersOfSymbol"
+        | "getExportsOfSymbol" => Some("symbol"),
+        _ => None,
+    }
+}
+
+/// Mirrors a numeric relation handle into the `objectId` field expected by
+/// TypeScript 7 stable servers.
+///
+/// The legacy field is kept so servers that predate the re-keyed protocol keep
+/// resolving the same request, and both server generations tolerate the field
+/// they do not read. Non-numeric handles only exist on legacy servers, so they
+/// are never mirrored: stable servers reject string object ids outright.
+fn mirror_object_relation_handles(method: &str, value: &mut Value) {
+    let Some(legacy_key) = object_relation_legacy_key(method) else {
+        return;
+    };
+    let Value::Object(fields) = value else {
+        return;
+    };
+    if fields.contains_key("objectId") {
+        return;
+    }
+    let Some(handle) = fields.get(legacy_key).and_then(Value::as_u64) else {
+        return;
+    };
+    fields.insert("objectId".into(), Value::Number(handle.into()));
 }
 
 fn encode_numeric_api_handles(value: &mut Value) {
@@ -398,15 +462,18 @@ mod tests {
 
     #[test]
     fn serializes_numeric_api_handles_as_numbers_for_wire_requests() {
-        let params = serialize_api_params(&Params {
-            snapshot: SnapshotHandle::from("1"),
-            project: ProjectHandle::from("project-1"),
-            symbol: SymbolHandle::from("2"),
-            symbols: vec![SymbolHandle::from("3")],
-            type_handle: TypeHandle::from("4"),
-            signature: SignatureHandle::from("5"),
-            location: NodeHandle::from("1.2.3./workspace/main.ts"),
-        })
+        let params = serialize_api_params(
+            "getBaseTypes",
+            &Params {
+                snapshot: SnapshotHandle::from("1"),
+                project: ProjectHandle::from("project-1"),
+                symbol: SymbolHandle::from("2"),
+                symbols: vec![SymbolHandle::from("3")],
+                type_handle: TypeHandle::from("4"),
+                signature: SignatureHandle::from("5"),
+                location: NodeHandle::from("1.2.3./workspace/main.ts"),
+            },
+        )
         .unwrap();
 
         assert_eq!(params["snapshot"], json!(1));
@@ -416,19 +483,23 @@ mod tests {
         assert_eq!(params["type"], json!(4));
         assert_eq!(params["signature"], json!(5));
         assert_eq!(params["location"], json!("1.2.3./workspace/main.ts"));
+        assert_eq!(params.get("objectId"), None);
     }
 
     #[test]
     fn leaves_non_numeric_api_handles_as_strings_for_wire_requests() {
-        let params = serialize_api_params(&Params {
-            snapshot: SnapshotHandle::from("snapshot-1"),
-            project: ProjectHandle::from("project-1"),
-            symbol: SymbolHandle::from("s0000000000000001"),
-            symbols: vec![SymbolHandle::from("s0000000000000002")],
-            type_handle: TypeHandle::from("t0000000000000001"),
-            signature: SignatureHandle::from("sig-1"),
-            location: NodeHandle::from("1.2.3./workspace/main.ts"),
-        })
+        let params = serialize_api_params(
+            "getBaseTypes",
+            &Params {
+                snapshot: SnapshotHandle::from("snapshot-1"),
+                project: ProjectHandle::from("project-1"),
+                symbol: SymbolHandle::from("s0000000000000001"),
+                symbols: vec![SymbolHandle::from("s0000000000000002")],
+                type_handle: TypeHandle::from("t0000000000000001"),
+                signature: SignatureHandle::from("sig-1"),
+                location: NodeHandle::from("1.2.3./workspace/main.ts"),
+            },
+        )
         .unwrap();
 
         assert_eq!(params["snapshot"], json!("snapshot-1"));
@@ -436,6 +507,62 @@ mod tests {
         assert_eq!(params["symbols"], json!(["s0000000000000002"]));
         assert_eq!(params["type"], json!("t0000000000000001"));
         assert_eq!(params["signature"], json!("sig-1"));
+    }
+
+    #[test]
+    fn mirrors_numeric_type_handles_into_object_id_for_relation_requests() {
+        let mut params = json!({ "snapshot": "1", "type": "86" });
+
+        super::encode_numeric_api_handles(&mut params);
+        super::mirror_object_relation_handles("getSymbolOfType", &mut params);
+
+        assert_eq!(params["type"], json!(86));
+        assert_eq!(params["objectId"], json!(86));
+    }
+
+    #[test]
+    fn mirrors_numeric_signature_and_symbol_handles_into_object_id() {
+        let mut signature_params = json!({ "snapshot": 1, "signature": "7" });
+        super::encode_numeric_api_handles(&mut signature_params);
+        super::mirror_object_relation_handles("getParametersOfSignature", &mut signature_params);
+        assert_eq!(signature_params["objectId"], json!(7));
+
+        let mut symbol_params = json!({ "snapshot": 1, "symbol": "9" });
+        super::encode_numeric_api_handles(&mut symbol_params);
+        super::mirror_object_relation_handles("getMembersOfSymbol", &mut symbol_params);
+        assert_eq!(symbol_params["objectId"], json!(9));
+    }
+
+    #[test]
+    fn does_not_mirror_legacy_string_handles_into_object_id() {
+        let mut params = json!({ "snapshot": "s0000000000000001", "type": "t0000000000000056" });
+
+        super::encode_numeric_api_handles(&mut params);
+        super::mirror_object_relation_handles("getSymbolOfType", &mut params);
+
+        assert_eq!(params["type"], json!("t0000000000000056"));
+        assert_eq!(params.get("objectId"), None);
+    }
+
+    #[test]
+    fn does_not_mirror_handles_for_type_keyed_relation_requests() {
+        let mut params = json!({ "snapshot": 1, "project": "p", "type": "86" });
+
+        super::encode_numeric_api_handles(&mut params);
+        super::mirror_object_relation_handles("getBaseTypes", &mut params);
+
+        assert_eq!(params["type"], json!(86));
+        assert_eq!(params.get("objectId"), None);
+    }
+
+    #[test]
+    fn keeps_caller_supplied_object_id_untouched() {
+        let mut params = json!({ "snapshot": 1, "type": 86, "objectId": 99 });
+
+        super::encode_numeric_api_handles(&mut params);
+        super::mirror_object_relation_handles("getSymbolOfType", &mut params);
+
+        assert_eq!(params["objectId"], json!(99));
     }
 
     #[test]

--- a/src/core/corsa_client/src/api/methods_relations.rs
+++ b/src/core/corsa_client/src/api/methods_relations.rs
@@ -13,6 +13,11 @@ use corsa_core::utils::split_top_level_type_text;
 
 impl ApiClient {
     /// Returns the symbol attached to a type, if one exists.
+    ///
+    /// TypeScript 7 stable runtimes resolve this request inside a specific
+    /// project and reject project-less lookups; prefer
+    /// [`ApiClient::get_symbol_of_type_in_project`] when a project handle is
+    /// available.
     pub async fn get_symbol_of_type(
         &self,
         snapshot: SnapshotHandle,
@@ -20,6 +25,27 @@ impl ApiClient {
     ) -> Result<Option<super::SymbolResponse>> {
         self.call_optional("getSymbolOfType", TypeOnlyRequest { snapshot, r#type })
             .await
+    }
+
+    /// Returns the symbol attached to a type, resolved inside a project.
+    ///
+    /// This is the project-scoped variant of [`ApiClient::get_symbol_of_type`]
+    /// that TypeScript 7 stable runtimes require.
+    pub async fn get_symbol_of_type_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<super::SymbolResponse>> {
+        self.call_optional(
+            "getSymbolOfType",
+            TypeProjectRequest {
+                snapshot,
+                project,
+                r#type,
+            },
+        )
+        .await
     }
 
     /// Returns the return type of a signature.
@@ -106,7 +132,7 @@ impl ApiClient {
         }
 
         if let Some(target) = self
-            .get_target_of_type_or_none(snapshot.clone(), r#type.clone())
+            .get_target_of_type_or_none(snapshot.clone(), project.clone(), r#type.clone())
             .await?
             .filter(|target| target.id != r#type)
         {
@@ -140,7 +166,11 @@ impl ApiClient {
                 .await?;
             if return_bases.is_empty() {
                 if let Some(target) = self
-                    .get_target_of_type_or_none(snapshot.clone(), return_type.id.clone())
+                    .get_target_of_type_or_none(
+                        snapshot.clone(),
+                        project.clone(),
+                        return_type.id.clone(),
+                    )
                     .await?
                     .filter(|target| target.id != return_type.id)
                 {
@@ -151,7 +181,7 @@ impl ApiClient {
             }
             if return_bases.is_empty() {
                 return_bases = self
-                    .get_types_of_type(snapshot.clone(), return_type.id)
+                    .get_types_of_type_in_project(snapshot.clone(), project.clone(), return_type.id)
                     .await?;
             }
             append_unique_types(&mut construct_return_bases, return_bases);
@@ -161,7 +191,7 @@ impl ApiClient {
         }
 
         let intersection_parts = self
-            .get_types_of_type(snapshot.clone(), r#type.clone())
+            .get_types_of_type_in_project(snapshot.clone(), project.clone(), r#type.clone())
             .await?;
         if !intersection_parts.is_empty() {
             return Ok(intersection_parts);
@@ -213,9 +243,13 @@ impl ApiClient {
     async fn get_target_of_type_or_none(
         &self,
         snapshot: SnapshotHandle,
+        project: ProjectHandle,
         r#type: TypeHandle,
     ) -> Result<Option<TypeResponse>> {
-        match self.get_target_of_type(snapshot, r#type).await {
+        match self
+            .get_target_of_type_in_project(snapshot, project, r#type)
+            .await
+        {
             Ok(target) => Ok(target),
             Err(error)
                 if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
@@ -485,6 +519,10 @@ impl ApiClient {
     }
 
     /// Returns the target type underlying an instantiated or mapped type.
+    ///
+    /// TypeScript 7 stable runtimes resolve this request inside a specific
+    /// project; prefer [`ApiClient::get_target_of_type_in_project`] when a
+    /// project handle is available.
     pub async fn get_target_of_type(
         &self,
         snapshot: SnapshotHandle,
@@ -494,9 +532,31 @@ impl ApiClient {
             .await
     }
 
+    /// Returns the target type underlying an instantiated or mapped type,
+    /// resolved inside a project.
+    pub async fn get_target_of_type_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_optional(
+            "getTargetOfType",
+            TypeProjectRequest {
+                snapshot,
+                project,
+                r#type,
+            },
+        )
+        .await
+    }
+
     /// Returns nested or constituent types associated with a type.
     ///
-    /// Missing server data is normalized to an empty vector.
+    /// Missing server data is normalized to an empty vector. TypeScript 7
+    /// stable runtimes resolve this request inside a specific project; prefer
+    /// [`ApiClient::get_types_of_type_in_project`] when a project handle is
+    /// available.
     pub async fn get_types_of_type(
         &self,
         snapshot: SnapshotHandle,
@@ -506,6 +566,37 @@ impl ApiClient {
             .call::<Option<Vec<TypeResponse>>, _>(
                 "getTypesOfType",
                 TypeOnlyRequest { snapshot, r#type },
+            )
+            .await
+        {
+            Ok(items) => Ok(items.unwrap_or_default()),
+            Err(error)
+                if Self::is_stale_handle_error(&error) || Self::is_protocol_panic_error(&error) =>
+            {
+                Ok(Vec::new())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Returns nested or constituent types associated with a type, resolved
+    /// inside a project.
+    ///
+    /// Missing server data is normalized to an empty vector.
+    pub async fn get_types_of_type_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Vec<TypeResponse>> {
+        match self
+            .call::<Option<Vec<TypeResponse>>, _>(
+                "getTypesOfType",
+                TypeProjectRequest {
+                    snapshot,
+                    project,
+                    r#type,
+                },
             )
             .await
         {
@@ -625,21 +716,30 @@ impl ApiClient {
         r#type: TypeHandle,
     ) -> Result<Option<TypeResponse>> {
         if let Some(constraint) = self
-            .get_constraint_of_type_parameter(snapshot.clone(), project, r#type.clone())
+            .get_constraint_of_type_parameter(snapshot.clone(), project.clone(), r#type.clone())
             .await?
         {
             return Ok(Some(constraint));
         }
-        self.get_constraint_of_type_direct(snapshot, r#type).await
+        self.get_constraint_of_type_direct(snapshot, project, r#type)
+            .await
     }
 
     async fn get_constraint_of_type_direct(
         &self,
         snapshot: SnapshotHandle,
+        project: ProjectHandle,
         r#type: TypeHandle,
     ) -> Result<Option<TypeResponse>> {
         match self
-            .call_optional("getConstraintOfType", TypeOnlyRequest { snapshot, r#type })
+            .call_optional(
+                "getConstraintOfType",
+                TypeProjectRequest {
+                    snapshot,
+                    project,
+                    r#type,
+                },
+            )
             .await
         {
             Ok(constraint) => Ok(constraint),


### PR DESCRIPTION
## Summary

Fixes #427 and #428.

TypeScript 7 stable runtimes (`typescript@7.0.2`) re-keyed the type/signature/symbol relation endpoints to a shared `{snapshot, project, objectId}` parameter shape (numeric handles only) and reject the legacy `type`/`signature`/`symbol` fields. corsa-bind still sent the legacy shape, so the native `getSymbolOfType` lookup failed with `empty type handle`, and the TS-layer source-scan heuristics could only compensate for classes declared in the linted file itself. Any class type imported from another file lost its base-type symbols (`getBaseTypes` entries with `null` symbols) and its implements list (`getImplementedTypesOfType` returning `[]`).

### Protocol fix (Rust)

- `corsa_client` driver now mirrors numeric relation handles into the `objectId` field for the re-keyed methods (types, signatures, symbols) while keeping the legacy field, so both server generations resolve the same request. Non-numeric (pinned-server) handles are never mirrored.
- new project-scoped `get_symbol_of_type_in_project`, `get_target_of_type_in_project`, and `get_types_of_type_in_project` client methods, since stable runtimes require the owning project for object resolution; the `getBaseTypes` fallback chain now uses them.
- napi `getSymbolOfType(snapshot, typeHandle, project?)` accepts the owning project and the oxlint session passes it.

### Compact declaration handles (TS layer)

Stable runtimes return compact declaration handles (`<node id>.<syntax kind>.<path>`) with no source offsets. Parsed nodes are now marked `positionless`, the implements scan recovers the class-declaration range by scanning the declaring file for the symbol's unique class declaration (never picking a same-named class from another scope), and a native symbol with compact handles primes the existing declaration-position caches so namespace-scoped disambiguation keeps working.

### Windows runtime resolution (#428)

`defaultCorsaExecutable` now resolves the `@typescript/native-preview` platform package executable (`lib/tsgo`, `tsgo.exe` on win32) the same way the stable `typescript` branch does, instead of the meta package's Node bin script, which Windows cannot spawn (`os error 193`). The script fallback remains for non-Windows platforms.

## Tests

- new stable-TS7 regression test reproducing #427: imported class property keeps `sym=Descendant`, `bases=[Ancestor]` (with symbol), `impls=[IAncestor]`
- new `defaultCorsaExecutable` tests: win32 platform executable resolution, never resolving the Node bin script on win32, platform binary preferred over the script
- driver unit tests for the objectId mirroring rules
- existing stable-TS7 suites (base-type identity, namespace-scoped leaves, duplicate base names) pass unchanged

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript 7 compatibility for symbol, class, inheritance, and interface resolution.
  - Added project-aware type lookups for runtimes requiring project context.
  - Fixed native runtime discovery on Windows and preserved reliable fallback behavior on other platforms.
  - Improved handling of legacy relation handles and existing object identifiers.
- **Tests**
  - Added regression coverage for imported classes, cross-file relationships, executable selection, and TypeScript 7 declaration handles.
- **Documentation**
  - Updated the unreleased changelog with the compatibility and runtime discovery fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->