### PR TITLE
fix: keep compact TypeScript 7 handles out of source ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - type, signature, and symbol relation requests now mirror numeric handles into the `objectId` field that TypeScript 7 stable runtimes expect, so `getSymbolOfType`, `getBaseTypes` metadata, and `getImplementedTypesOfType` keep working for class types imported from other files ([#427](https://github.com/ubugeeei-prod/corsa-bind/issues/427)).
 - `corsa-oxlint` recovers class-declaration positions for compact TypeScript 7 declaration handles instead of misreading node ids as source offsets, keeping same-named classes in different scopes distinct.
+- `corsa-oxlint` no longer treats a compact TypeScript 7 declaration handle as a source range, resolves type symbols in the project that owns the type handle, and ignores `class` text inside comments and string literals when recovering a declaration position.
 - the default runtime discovery now resolves the `@typescript/native-preview` platform executable (`lib/tsgo`, `tsgo.exe` on Windows) instead of the meta package's Node bin script, which Windows cannot spawn ([#428](https://github.com/ubugeeei-prod/corsa-bind/issues/428)).
 - `corsa-oxlint` now resolves nominal type symbols for interface and class property annotations.
 - `corsa-oxlint` now returns direct and inherited implemented interfaces after symbol, base-type, and generic-argument traversal while accepting compact TypeScript 7 declaration handles.

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
@@ -49,7 +49,7 @@ vi.mock("@corsa-bind/napi", () => ({
   },
 }));
 
-const { CorsaProjectSession } = await import("./session");
+const { CorsaProjectSession, uniqueClassDeclarationPosition } = await import("./session");
 
 describe("CorsaProjectSession", () => {
   beforeEach(() => {
@@ -586,5 +586,84 @@ describe("CorsaProjectSession", () => {
     });
 
     expect(() => session.close()).not.toThrow();
+  });
+
+  it("resolves a type symbol in the project that owns the type handle", () => {
+    clients.length = 0;
+    clientSetups.push((client) => {
+      client.callJson.mockImplementation((method: string) => {
+        if (method === "describeCapabilities") {
+          return { overlay: { updateSnapshotOverlayChanges: false } };
+        }
+        if (method === "getDefaultProjectForFile") {
+          return { id: "project-2" };
+        }
+        return undefined;
+      });
+    });
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    const type = session.getTypeAtPosition("/tmp/two.ts", 0);
+    const client = clients[0];
+    if (!client) {
+      throw new Error("expected a fake client");
+    }
+
+    expect(session.getSymbolOfType(type as never)?.name).toBe("value");
+    expect(client.getSymbolOfType).toHaveBeenCalledWith(expect.any(String), "type-1", "project-2");
+  });
+});
+
+describe("uniqueClassDeclarationPosition", () => {
+  it("returns the position of the only class declaration", () => {
+    const sourceText = "interface I {}\nclass Descendant implements I {}";
+
+    expect(uniqueClassDeclarationPosition(sourceText, "Descendant")).toBe(
+      sourceText.indexOf("class Descendant"),
+    );
+  });
+
+  it("ignores the same declaration text inside comments", () => {
+    const sourceText =
+      "interface I {}\n// class Descendant\n/* class Descendant */\nclass Descendant implements I {}";
+
+    expect(uniqueClassDeclarationPosition(sourceText, "Descendant")).toBe(
+      sourceText.lastIndexOf("class Descendant"),
+    );
+  });
+
+  it("ignores the same declaration text inside string literals", () => {
+    const sourceText =
+      'interface I {}\nconst s = "class Descendant";\nclass Descendant implements I {}';
+
+    expect(uniqueClassDeclarationPosition(sourceText, "Descendant")).toBe(
+      sourceText.lastIndexOf("class Descendant"),
+    );
+  });
+
+  it("returns undefined when only comments or strings mention the declaration", () => {
+    const sourceText = '// class Descendant\nconst s = "class Descendant";\nnew Descendant();';
+
+    expect(uniqueClassDeclarationPosition(sourceText, "Descendant")).toBeUndefined();
+  });
+
+  it("returns undefined when the file declares the class twice", () => {
+    const sourceText = "class Descendant {}\nnamespace N {\n  export class Descendant {}\n}";
+
+    expect(uniqueClassDeclarationPosition(sourceText, "Descendant")).toBeUndefined();
   });
 });

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -40,6 +40,8 @@ type SourceRange = {
 type TypeLookup = {
   fileName: string;
   position: number;
+  /** Project that owns the file the type handle came from. */
+  projectId?: string;
   sourceText?: string;
   symbolSearchRange?: SourceRange;
 };
@@ -77,6 +79,7 @@ export class CorsaProjectSession {
   #ownImplementedTypesById = new Map<string, readonly CorsaType[]>();
   #typeLookupById = new Map<string, TypeLookup>();
   #typeSourceById = new Map<string, SourceSlice>();
+  #typeDeclarationFileById = new Map<string, string>();
   #classDeclarationByTypeId = new Map<string, CorsaNode>();
   #symbolSearchRangeByTypeId = new Map<string, SourceRange>();
   #sourceLengthByPath = new Map<string, number>();
@@ -139,7 +142,12 @@ export class CorsaProjectSession {
     }
     const type = this.rememberType(state.typeByPosition.get(position));
     if (type) {
-      this.#typeLookupById.set(type.id, { fileName, position, sourceText });
+      this.#typeLookupById.set(type.id, {
+        fileName,
+        position,
+        projectId: state.projectId,
+        sourceText,
+      });
     }
     return type;
   }
@@ -185,7 +193,12 @@ export class CorsaProjectSession {
     }
     const type = this.rememberType(state.typeBySourceRange.get(key));
     if (type) {
-      this.#typeLookupById.set(type.id, { fileName, position: start, sourceText });
+      this.#typeLookupById.set(type.id, {
+        fileName,
+        position: start,
+        projectId: state.projectId,
+        sourceText,
+      });
       if (kind !== "Identifier") {
         this.rememberTypeSourceRange(type, fileName, start, end, sourceText);
       }
@@ -569,7 +582,10 @@ export class CorsaProjectSession {
         this.client().getSymbolOfType(
           this.#snapshot,
           typeId,
-          this.#projects[0]?.id,
+          // Stable runtimes resolve object handles per project, so the lookup
+          // must name the project that produced the type rather than the first
+          // project in the snapshot.
+          this.#typeLookupById.get(typeId)?.projectId ?? this.#projects[0]?.id,
         ) as CorsaSymbol | null,
       );
     } catch (error) {
@@ -609,6 +625,10 @@ export class CorsaProjectSession {
     const source = this.#typeSourceById.get(relatedType.id);
     if (source && !this.#typeSourceById.has(type.id)) {
       this.#typeSourceById.set(type.id, source);
+    }
+    const declarationFile = this.#typeDeclarationFileById.get(relatedType.id);
+    if (declarationFile && !this.#typeDeclarationFileById.has(type.id)) {
+      this.#typeDeclarationFileById.set(type.id, declarationFile);
     }
     const symbolSearchRange = this.#symbolSearchRangeByTypeId.get(relatedType.id);
     if (symbolSearchRange && !this.#symbolSearchRangeByTypeId.has(type.id)) {
@@ -1050,6 +1070,13 @@ export class CorsaProjectSession {
     const source = this.sourceSliceForHandle(handle);
     if (source) {
       this.#typeSourceById.set(type.id, source);
+      return;
+    }
+    // A compact TypeScript 7 declaration handle carries no source range, but
+    // its path still identifies the declaring file for file-scoped requests.
+    const node = this.getNode(handle);
+    if (node?.positionless) {
+      this.#typeDeclarationFileById.set(type.id, node.fileName);
     }
   }
 
@@ -1112,6 +1139,11 @@ export class CorsaProjectSession {
     if (source) {
       const sourceText = this.sourceTextForPath(source.node.fileName);
       return sourceText ? { file: source.node.fileName, sourceText } : {};
+    }
+    const declarationFile = this.#typeDeclarationFileById.get(type.id);
+    if (declarationFile) {
+      const sourceText = this.sourceTextForPath(declarationFile);
+      return sourceText ? { file: declarationFile, sourceText } : {};
     }
     return {};
   }
@@ -1177,6 +1209,7 @@ export class CorsaProjectSession {
     this.#ownImplementedTypesById.clear();
     this.#typeLookupById.clear();
     this.#typeSourceById.clear();
+    this.#typeDeclarationFileById.clear();
     this.#classDeclarationByTypeId.clear();
     this.#symbolSearchRangeByTypeId.clear();
     this.#sourceLengthByPath.clear();
@@ -1197,7 +1230,9 @@ export class CorsaProjectSession {
 
   private sourceSliceForHandle(handle: string): SourceSlice | undefined {
     const node = this.getNode(handle);
-    if (!node) {
+    // A compact TypeScript 7 handle carries a node id and a syntax kind instead
+    // of source offsets, so its parsed range must never become a source range.
+    if (!node || node.positionless) {
       return undefined;
     }
     const sourceText = this.sourceTextForPath(node.fileName);
@@ -1514,17 +1549,53 @@ function classDeclarationStartAtIdentifier(
   return match ? prefixStart + match.index : undefined;
 }
 
+/**
+ * Returns the offset of the only `class <className>` declaration in the source,
+ * or `undefined` when the file has none or more than one.
+ *
+ * Matches inside comments and string literals are ignored, so text such as
+ * `// class Descendant` neither shadows nor duplicates a real declaration.
+ */
 export function uniqueClassDeclarationPosition(
   sourceText: string,
   className: string,
 ): number | undefined {
   const escapedName = className.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const declarationPattern = new RegExp(`\\bclass\\s+${escapedName}\\b`, "gu");
-  const declaration = declarationPattern.exec(sourceText);
-  if (!declaration || declarationPattern.exec(sourceText)) {
-    return undefined;
+  const codePositions = codePositionMask(sourceText);
+  let unique: number | undefined;
+  for (
+    let declaration = declarationPattern.exec(sourceText);
+    declaration;
+    declaration = declarationPattern.exec(sourceText)
+  ) {
+    if (codePositions[declaration.index] !== 1) {
+      continue;
+    }
+    if (unique !== undefined) {
+      return undefined;
+    }
+    unique = declaration.index;
   }
-  return declaration.index;
+  return unique;
+}
+
+/**
+ * Marks each offset that is executable code rather than comment or string
+ * literal content, using the same scanner as the namespace range helpers.
+ */
+function codePositionMask(sourceText: string): Uint8Array {
+  const mask = new Uint8Array(sourceText.length);
+  const scanner = createSourceScanner();
+  for (let index = 0; index < sourceText.length; index += 1) {
+    const nextIndex = scanner.skip(sourceText, index);
+    if (nextIndex > index) {
+      index = nextIndex - 1;
+      continue;
+    }
+    mask[index] = 1;
+  }
+  return mask;
 }
 
 function qualifiedNamespaceRangeAtIdentifier(


### PR DESCRIPTION
Follow-up to #429 (already merged), addressing three review findings on that PR.

A compact TypeScript 7 declaration handle (`<node id>.<syntax kind>.<path>`) parses into a node marked `positionless`, whose `pos`/`end` are a node id and a synthetic file length rather than offsets. `sourceSliceForHandle` still accepted those nodes, so `getTypeArguments` could send a node id as a declaration offset to `getTypeArgumentsAtSourceRange`. The slice is now refused, while the declaring file is kept separately so file-scoped requests (`getSignaturesOfType`, `getCallSignatureFacts`) do not lose cross-file context:

```ts
const source = this.sourceSliceForHandle(handle);
if (source) {
  this.#typeSourceById.set(type.id, source);
  return;
}
// A compact TypeScript 7 declaration handle carries no source range, but
// its path still identifies the declaring file for file-scoped requests.
const node = this.getNode(handle);
if (node?.positionless) {
  this.#typeDeclarationFileById.set(type.id, node.fileName);
}
```

`getSymbolOfType` previously always named `#projects[0]`, which resolves object handles in the wrong project when a snapshot spans several. `TypeLookup` now carries the `projectId` that `fileState` resolved for the file the type came from, and the symbol lookup prefers it.

`uniqueClassDeclarationPosition` matched `\bclass\s+<name>\b` anywhere in the file, so `// class Descendant` both shadowed a real declaration and made a single declaration look ambiguous, which dropped the implemented interfaces of positionless imported class handles. It now filters matches through the existing comment/string scanner already used by the namespace range helpers, and the new unit tests cover comment, string, decoy-only, and duplicate-declaration sources.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->