### PR TITLE
feat(lsp): support params-less graceful shutdown

### DIFF
--- a/src/bindings/rust/corsa/src/bin/mock_corsa/lsp.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_corsa/lsp.rs
@@ -1,25 +1,39 @@
 use crate::{Result, jsonrpc};
 use corsa::fast::{CompactString, FastMap};
-use corsa::jsonrpc::{RawMessage, RequestId};
+use corsa::jsonrpc::{RawMessage, RequestId, RpcResponseError};
 use corsa::lsp::{VirtualChange, VirtualDocument};
 use lsp_types::{
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
 };
 use serde_json::{Value, json};
-use std::io::{BufReader, BufWriter};
+use std::{
+    fs::OpenOptions,
+    io::{BufReader, BufWriter, Write},
+    path::{Path, PathBuf},
+};
 
-pub fn run() -> Result<()> {
+pub fn run(args: &[String]) -> Result<()> {
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
     let mut reader = BufReader::new(stdin.lock());
     let mut writer = BufWriter::new(stdout.lock());
     let mut last_configuration = Value::Null;
     let mut documents = FastMap::<CompactString, VirtualDocument>::default();
+    let strict_shutdown_state = args.iter().find_map(|arg| {
+        arg.strip_prefix("--strict-lsp-shutdown=")
+            .map(PathBuf::from)
+    });
+    let ignore_shutdown = args.iter().any(|arg| arg == "--ignore-lsp-shutdown");
+    let mut shutdown_received = false;
     loop {
         let Some(message) = jsonrpc::read_message(&mut reader)? else {
+            if let Some(path) = strict_shutdown_state.as_deref() {
+                append_shutdown_state(path, "context canceled")?;
+            }
             return Ok(());
         };
         let method = message.method.unwrap_or_default();
+        let has_params = message.params.is_some();
         let params = message.params.unwrap_or(Value::Null);
         match (message.id, method.as_str()) {
             (Some(id), "initialize") => {
@@ -73,6 +87,30 @@ pub fn run() -> Result<()> {
                     ),
                 )?;
             }
+            (Some(id), "shutdown") => {
+                if let Some(path) = strict_shutdown_state.as_deref() {
+                    if has_params {
+                        append_shutdown_state(path, "invalid params")?;
+                        jsonrpc::write_message(
+                            &mut writer,
+                            &RawMessage::error(
+                                id,
+                                RpcResponseError {
+                                    code: -32602,
+                                    message: "expected no params, got null".into(),
+                                    data: None,
+                                },
+                            ),
+                        )?;
+                        continue;
+                    }
+                    append_shutdown_state(path, "shutdown")?;
+                }
+                shutdown_received = true;
+                if !ignore_shutdown {
+                    jsonrpc::write_message(&mut writer, &RawMessage::response(id, Value::Null))?;
+                }
+            }
             (Some(id), _) => {
                 jsonrpc::write_message(&mut writer, &RawMessage::response(id, Value::Null))?;
             }
@@ -105,10 +143,29 @@ pub fn run() -> Result<()> {
                 let params: DidCloseTextDocumentParams = serde_json::from_value(params)?;
                 documents.remove(params.text_document.uri.as_str());
             }
-            (None, "exit") => return Ok(()),
+            (None, "exit") => {
+                if let Some(path) = strict_shutdown_state.as_deref() {
+                    if has_params {
+                        append_shutdown_state(path, "invalid exit params")?;
+                        return Err("expected exit without params".into());
+                    }
+                    if !shutdown_received {
+                        append_shutdown_state(path, "exit before shutdown")?;
+                        return Err("expected shutdown before exit".into());
+                    }
+                    append_shutdown_state(path, "exit")?;
+                }
+                return Ok(());
+            }
             (None, _) => {
                 let _ = params;
             }
         }
     }
+}
+
+fn append_shutdown_state(path: &Path, state: &str) -> Result<()> {
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    writeln!(file, "{state}")?;
+    Ok(())
 }

--- a/src/bindings/rust/corsa/src/bin/mock_corsa/main.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_corsa/main.rs
@@ -23,7 +23,7 @@ fn main() -> Result<()> {
         .map(|list| list.split(',').map(str::to_owned).collect::<Vec<_>>())
         .unwrap_or_default();
     if args.iter().any(|arg| arg == "--lsp") {
-        return lsp::run();
+        return lsp::run(&args);
     }
     if args.iter().any(|arg| arg == "--api") && args.iter().any(|arg| arg == "--async") {
         return api_async::run(cwd, callbacks);

--- a/src/bindings/rust/corsa/tests/lsp_stdio.rs
+++ b/src/bindings/rust/corsa/tests/lsp_stdio.rs
@@ -196,3 +196,56 @@ fn lsp_overlay_close_of_missing_document_is_a_noop() {
         client.close().await.unwrap();
     });
 }
+
+#[test]
+fn lsp_graceful_close_omits_params_and_is_idempotent_across_clones() {
+    run_async_test(async {
+        let directory = tempfile::tempdir().unwrap();
+        let state_path = directory.path().join("shutdown-state.txt");
+        let client = LspClient::spawn(
+            support::lsp_config()
+                .with_arg(format!("--strict-lsp-shutdown={}", state_path.display())),
+        )
+        .await
+        .unwrap();
+        let clone = client.clone();
+        let repeated_close = thread::spawn(move || block_on(clone.graceful_close()));
+
+        client.graceful_close().await.unwrap();
+        repeated_close.join().unwrap().unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(state_path).unwrap(),
+            "shutdown\nexit\n"
+        );
+    });
+}
+
+#[test]
+fn lsp_graceful_close_reaps_the_process_after_shutdown_timeout() {
+    run_async_test(async {
+        let directory = tempfile::tempdir().unwrap();
+        let state_path = directory.path().join("shutdown-state.txt");
+        let client = LspClient::spawn(
+            support::lsp_config()
+                .with_arg(format!("--strict-lsp-shutdown={}", state_path.display()))
+                .with_arg("--ignore-lsp-shutdown")
+                .with_request_timeout(Some(Duration::from_secs(1)))
+                .with_shutdown_timeout(Duration::from_millis(300)),
+        )
+        .await
+        .unwrap();
+        let clone = client.clone();
+        let started = std::time::Instant::now();
+
+        let error = client.graceful_close().await.unwrap_err();
+        assert!(matches!(error, corsa::CorsaError::Timeout(_)));
+        let repeated_error = clone.graceful_close().await.unwrap_err();
+        assert!(matches!(repeated_error, corsa::CorsaError::Timeout(_)));
+        assert!(started.elapsed() < Duration::from_secs(3));
+        assert_eq!(
+            std::fs::read_to_string(state_path).unwrap(),
+            "shutdown\ncontext canceled\n"
+        );
+    });
+}

--- a/src/bindings/rust/corsa/tests/lsp_stdio.rs
+++ b/src/bindings/rust/corsa/tests/lsp_stdio.rs
@@ -8,6 +8,8 @@ use corsa::{
 use serde_json::{Value, json};
 use std::{future::Future, str::FromStr, thread, time::Duration};
 
+use lsp_types::request::Shutdown;
+
 struct OverlayStateRequest;
 
 impl lsp_types::request::Request for OverlayStateRequest {
@@ -246,6 +248,31 @@ fn lsp_graceful_close_reaps_the_process_after_shutdown_timeout() {
         assert_eq!(
             std::fs::read_to_string(state_path).unwrap(),
             "shutdown\ncontext canceled\n"
+        );
+    });
+}
+
+#[test]
+fn lsp_strict_shutdown_rejects_explicit_null_params() {
+    run_async_test(async {
+        let directory = tempfile::tempdir().unwrap();
+        let state_path = directory.path().join("shutdown-state.txt");
+        let client = LspClient::spawn(
+            support::lsp_config()
+                .with_arg(format!("--strict-lsp-shutdown={}", state_path.display())),
+        )
+        .await
+        .unwrap();
+
+        let error = client.request::<Shutdown>(()).await.unwrap_err();
+        assert!(matches!(
+            error,
+            corsa::CorsaError::Rpc(error) if error.code == -32602
+        ));
+        client.close().await.unwrap();
+        assert_eq!(
+            std::fs::read_to_string(state_path).unwrap(),
+            "invalid params\ncontext canceled\n"
         );
     });
 }

--- a/src/core/corsa_jsonrpc/src/jsonrpc/connection.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/connection.rs
@@ -290,21 +290,37 @@ impl JsonRpcConnection {
         Ok(serde_json::from_value(value)?)
     }
 
+    /// Sends a JSON-RPC request with the `params` member omitted.
+    ///
+    /// This is distinct from passing `()` or [`Value::Null`], both of which
+    /// serialize as `"params": null`.
+    pub async fn request_without_params<Response>(&self, method: &str) -> Result<Response>
+    where
+        Response: DeserializeOwned,
+    {
+        let value = self.request_optional_value(method, None).await?;
+        Ok(serde_json::from_value(value)?)
+    }
+
     /// Sends a JSON-RPC request and returns the raw JSON value.
     ///
     /// Use this when a typed response model is not available yet.
     pub async fn request_value(&self, method: &str, params: Value) -> Result<Value> {
+        self.request_optional_value(method, Some(params)).await
+    }
+
+    async fn request_optional_value(&self, method: &str, params: Option<Value>) -> Result<Value> {
         if self.inner.closed.load(Ordering::SeqCst) {
             return Err(CorsaError::Closed("jsonrpc connection"));
         }
         let id = RequestId::integer(self.inner.next_id.fetch_add(1, Ordering::SeqCst) + 1);
         let (tx, rx) = mpsc::sync_channel(1);
         self.inner.pending.lock().insert(id.clone(), tx);
-        if let Err(error) = self.inner.send_outbound(RawMessage::request(
-            id.clone(),
-            CompactString::from(method),
-            params,
-        )) {
+        let message = match params {
+            Some(params) => RawMessage::request(id.clone(), CompactString::from(method), params),
+            None => RawMessage::request_without_params(id.clone(), CompactString::from(method)),
+        };
+        if let Err(error) = self.inner.send_outbound(message) {
             self.inner.pending.lock().remove(&id);
             return Err(error);
         }
@@ -338,6 +354,18 @@ impl JsonRpcConnection {
             CompactString::from(method),
             params,
         ))?;
+        Ok(())
+    }
+
+    /// Sends a JSON-RPC notification with the `params` member omitted.
+    ///
+    /// This is distinct from passing `()` or [`Value::Null`], both of which
+    /// serialize as `"params": null`.
+    pub fn notify_without_params(&self, method: &str) -> Result<()> {
+        self.inner
+            .send_outbound(RawMessage::notification_without_params(
+                CompactString::from(method),
+            ))?;
         Ok(())
     }
 

--- a/src/core/corsa_jsonrpc/src/jsonrpc/connection_tests.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/connection_tests.rs
@@ -1,6 +1,9 @@
 #![cfg(unix)]
 
-use super::{InboundEvent, JsonRpcConnection, JsonRpcConnectionOptions, RpcHandlerMap};
+use super::{
+    InboundEvent, JsonRpcConnection, JsonRpcConnectionOptions, RawMessage, RpcHandlerMap,
+    read_frame, write_frame,
+};
 use corsa_core::{CorsaEvent, CorsaObserver};
 use serde_json::json;
 use std::sync::{Arc, Mutex};
@@ -46,6 +49,44 @@ fn routes_request_and_response() {
         corsa_runtime::block_on(client.request("ping", json!({"value": 1}))).unwrap();
     waiter.join().unwrap();
     assert_eq!(response, json!({"pong": true}));
+}
+
+#[test]
+fn params_less_send_apis_omit_params_on_the_wire() {
+    let (client_socket, mut server_socket) = UnixStream::pair().unwrap();
+    let client = JsonRpcConnection::try_spawn(
+        BufReader::new(client_socket.try_clone().unwrap()),
+        client_socket,
+        RpcHandlerMap::default(),
+    )
+    .unwrap();
+    let server_reader = server_socket.try_clone().unwrap();
+    let server = thread::spawn(move || {
+        let mut reader = BufReader::new(server_reader);
+        let request_payload = read_frame(&mut reader).unwrap();
+        let request: serde_json::Value = serde_json::from_slice(&request_payload).unwrap();
+        assert_eq!(request["method"], json!("shutdown"));
+        assert!(!request.as_object().unwrap().contains_key("params"));
+
+        let response = RawMessage::response(
+            serde_json::from_value(request["id"].clone()).unwrap(),
+            json!({"ok": true}),
+        );
+        write_frame(&mut server_socket, &serde_json::to_vec(&response).unwrap()).unwrap();
+
+        let notification_payload = read_frame(&mut reader).unwrap();
+        let notification: serde_json::Value =
+            serde_json::from_slice(&notification_payload).unwrap();
+        assert_eq!(notification["method"], json!("exit"));
+        assert!(!notification.as_object().unwrap().contains_key("params"));
+    });
+
+    let response: serde_json::Value =
+        corsa_runtime::block_on(client.request_without_params("shutdown")).unwrap();
+    assert_eq!(response, json!({"ok": true}));
+    client.notify_without_params("exit").unwrap();
+    server.join().unwrap();
+    corsa_runtime::block_on(client.close()).unwrap();
 }
 
 #[test]

--- a/src/core/corsa_jsonrpc/src/jsonrpc/message.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/message.rs
@@ -69,6 +69,18 @@ impl RawMessage {
         }
     }
 
+    /// Builds a JSON-RPC request without a `params` member.
+    pub fn request_without_params(id: RequestId, method: impl Into<CompactString>) -> Self {
+        Self {
+            jsonrpc: jsonrpc_version(),
+            id: Some(id),
+            method: Some(method.into()),
+            params: None,
+            result: None,
+            error: None,
+        }
+    }
+
     /// Builds a JSON-RPC notification message.
     pub fn notification(method: impl Into<CompactString>, params: Value) -> Self {
         Self {
@@ -76,6 +88,18 @@ impl RawMessage {
             id: None,
             method: Some(method.into()),
             params: Some(params),
+            result: None,
+            error: None,
+        }
+    }
+
+    /// Builds a JSON-RPC notification without a `params` member.
+    pub fn notification_without_params(method: impl Into<CompactString>) -> Self {
+        Self {
+            jsonrpc: jsonrpc_version(),
+            id: None,
+            method: Some(method.into()),
+            params: None,
             result: None,
             error: None,
         }
@@ -244,6 +268,18 @@ mod tests {
                 error: None,
             } if id == RequestId::integer(1)
         ));
+    }
+
+    #[test]
+    fn params_less_messages_omit_params_instead_of_serializing_null() {
+        let request = RawMessage::request_without_params(RequestId::integer(1), "shutdown");
+        let notification = RawMessage::notification_without_params("exit");
+
+        let request = serde_json::to_value(request).unwrap();
+        let notification = serde_json::to_value(notification).unwrap();
+
+        assert!(!request.as_object().unwrap().contains_key("params"));
+        assert!(!notification.as_object().unwrap().contains_key("params"));
     }
 
     #[test]

--- a/src/core/corsa_jsonrpc/src/jsonrpc/message.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/message.rs
@@ -30,6 +30,7 @@ pub struct RawMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method: Option<CompactString>,
     /// Request or notification parameters.
+    #[serde(default, deserialize_with = "deserialize_present_value")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub params: Option<Value>,
     /// Successful response body.
@@ -280,6 +281,26 @@ mod tests {
 
         assert!(!request.as_object().unwrap().contains_key("params"));
         assert!(!notification.as_object().unwrap().contains_key("params"));
+    }
+
+    #[test]
+    fn deserialization_preserves_null_params_member_presence() {
+        let omitted: RawMessage = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "shutdown"
+        }))
+        .unwrap();
+        let explicit_null: RawMessage = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "shutdown",
+            "params": null
+        }))
+        .unwrap();
+
+        assert_eq!(omitted.params, None);
+        assert_eq!(explicit_null.params, Some(Value::Null));
     }
 
     #[test]

--- a/src/core/corsa_lsp/src/lsp/client.rs
+++ b/src/core/corsa_lsp/src/lsp/client.rs
@@ -8,9 +8,17 @@ use corsa_core::{
     fast::{CompactString, SmallVec},
 };
 use corsa_runtime::BroadcastReceiver;
-use lsp_types::{notification::Notification, request::Request};
+use lsp_types::{
+    notification::{Exit, Notification},
+    request::{Request, Shutdown},
+};
 use serde::{Serialize, de::DeserializeOwned};
-use std::{io::BufReader, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    io::BufReader,
+    path::PathBuf,
+    sync::{Arc, Condvar, Mutex},
+    time::Duration,
+};
 
 use super::{
     InitializeApiSessionParams, InitializeApiSessionRequest, InitializeApiSessionResult, LspOverlay,
@@ -27,6 +35,55 @@ pub struct LspClient {
     rpc: JsonRpcConnection,
     process: Arc<AsyncChildGuard>,
     shutdown_timeout: Duration,
+    shutdown: Arc<ShutdownCoordinator>,
+}
+
+#[derive(Default)]
+struct ShutdownCoordinator {
+    phase: Mutex<ShutdownPhase>,
+    completed: Condvar,
+}
+
+#[derive(Default)]
+enum ShutdownPhase {
+    #[default]
+    Open,
+    Closing,
+    Closed(Result<()>),
+}
+
+impl ShutdownCoordinator {
+    fn begin(&self) -> Option<Result<()>> {
+        let mut phase = self.phase.lock().unwrap_or_else(|error| error.into_inner());
+        loop {
+            match &*phase {
+                ShutdownPhase::Open => {
+                    *phase = ShutdownPhase::Closing;
+                    return None;
+                }
+                ShutdownPhase::Closing => {
+                    phase = self
+                        .completed
+                        .wait(phase)
+                        .unwrap_or_else(|error| error.into_inner());
+                }
+                ShutdownPhase::Closed(result) => return Some(clone_result(result)),
+            }
+        }
+    }
+
+    fn finish(&self, result: &Result<()>) {
+        let mut phase = self.phase.lock().unwrap_or_else(|error| error.into_inner());
+        *phase = ShutdownPhase::Closed(clone_result(result));
+        self.completed.notify_all();
+    }
+}
+
+fn clone_result(result: &Result<()>) -> Result<()> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(error) => Err(error.clone_for_pending()),
+    }
 }
 
 /// Spawn-time options for [`LspClient`].
@@ -152,6 +209,7 @@ impl LspClient {
             )?,
             process: Arc::new(AsyncChildGuard::new(child)),
             shutdown_timeout: config.shutdown_timeout,
+            shutdown: Arc::new(ShutdownCoordinator::default()),
         })
     }
 
@@ -183,6 +241,18 @@ impl LspClient {
         self.rpc.request(R::METHOD, params).await
     }
 
+    /// Sends a typed LSP request with the `params` member omitted.
+    ///
+    /// Use this for protocol methods such as [`Shutdown`] whose wire envelope
+    /// must not conflate an absent member with `"params": null`.
+    pub async fn request_without_params<R>(&self) -> Result<R::Result>
+    where
+        R: Request,
+        R::Result: DeserializeOwned,
+    {
+        self.rpc.request_without_params(R::METHOD).await
+    }
+
     /// Sends a typed LSP notification.
     ///
     /// This is the preferred way to emit standard protocol notifications such
@@ -193,6 +263,14 @@ impl LspClient {
         N::Params: Serialize,
     {
         self.rpc.notify(N::METHOD, params)
+    }
+
+    /// Sends a typed LSP notification with the `params` member omitted.
+    pub fn notify_without_params<N>(&self) -> Result<()>
+    where
+        N: Notification,
+    {
+        self.rpc.notify_without_params(N::METHOD)
     }
 
     /// Responds to an inbound request.
@@ -222,7 +300,43 @@ impl LspClient {
     /// The underlying process is shut down safely through [`AsyncChildGuard`],
     /// which ensures the child is reaped even if it needs to be killed.
     pub async fn close(&self) -> Result<()> {
-        self.rpc.close().await?;
-        self.process.shutdown(self.shutdown_timeout).await
+        if let Some(result) = self.shutdown.begin() {
+            return result;
+        }
+        let result = self.close_transport_and_process(Ok(())).await;
+        self.shutdown.finish(&result);
+        result
+    }
+
+    /// Gracefully closes the LSP session with the protocol `shutdown` / `exit` sequence.
+    ///
+    /// The params-less `shutdown` request is answered before the params-less
+    /// `exit` notification is sent. The transport is then drained and closed,
+    /// and the child is reaped or force-killed within `shutdown_timeout`.
+    /// Concurrent or repeated calls across cloned clients share one shutdown
+    /// attempt and return the same outcome.
+    pub async fn graceful_close(&self) -> Result<()> {
+        if let Some(result) = self.shutdown.begin() {
+            return result;
+        }
+
+        let protocol_result = match self.request_without_params::<Shutdown>().await {
+            Ok(()) => self.notify_without_params::<Exit>(),
+            Err(error) => Err(error),
+        };
+        let result = self.close_transport_and_process(protocol_result).await;
+        self.shutdown.finish(&result);
+        result
+    }
+
+    async fn close_transport_and_process(&self, protocol_result: Result<()>) -> Result<()> {
+        let transport_result = self.rpc.begin_close();
+        let process_result = self.process.shutdown(self.shutdown_timeout).await;
+        let reader_result = self.rpc.join_reader(self.shutdown_timeout);
+
+        protocol_result
+            .and(transport_result)
+            .and(process_result)
+            .and(reader_result)
     }
 }


### PR DESCRIPTION
## Summary

- add JSON-RPC request and notification APIs that omit the `params` member instead of serializing `null`
- add typed params-less LSP helpers and an idempotent `graceful_close` sequence shared across cloned clients
- drain the transport and reap or terminate the child after `shutdown` / `exit`, including timeout cleanup
- add wire-level serialization coverage and a strict LSP fixture that rejects `params: null`

Closes #431

## Validation

- `cargo test -p corsa_jsonrpc`
- `cargo test -p corsa_lsp`
- `cargo test -p corsa --test lsp_stdio`
- `vp check --no-fmt`
- `vp run -w fmt_check_rust`
- `vp run -w lint_rust`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graceful LSP shutdown with coordinated handling across client instances.
  * Added support for JSON-RPC requests and notifications without `params`.
  * Added strict shutdown-state tracking and validation for mock LSP processes.

* **Bug Fixes**
  * Improved process cleanup, timeout handling, and shutdown reliability.
  * Prevented duplicate shutdown attempts when closing shared clients.

* **Tests**
  * Added coverage for parameterless messages, concurrent closes, successful exits, and shutdown timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->