### PR TITLE
fix(jsonrpc): preserve split header terminators

### DIFF
--- a/src/core/corsa_jsonrpc/src/jsonrpc/frame.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/frame.rs
@@ -107,14 +107,19 @@ where
         if chunk.is_empty() {
             return Err(CorsaError::Closed("jsonrpc reader"));
         }
-        if let Some(index) = memmem::find(chunk, HEADER_END) {
-            // Copy only the current frame's header bytes so downstream parsing
-            // sees a contiguous header even when the reader buffer is chunked.
-            header.extend_from_slice(&chunk[..index + HEADER_END.len()]);
-            reader.consume(index + HEADER_END.len());
+        let previous_len = header.len();
+        header.extend_from_slice(chunk);
+        if let Some(index) = memmem::find(&header, HEADER_END) {
+            // Search the accumulated header rather than only the latest
+            // `fill_buf` slice: stdio transports may split `\r\n\r\n` across
+            // reads. Consume only bytes that belong to this frame's header so
+            // any already-buffered body bytes remain available to `read_exact`.
+            let header_len = index + HEADER_END.len();
+            let consumed = header_len.saturating_sub(previous_len);
+            reader.consume(consumed);
+            header.truncate(header_len);
             return parse_content_length(&header);
         }
-        header.extend_from_slice(chunk);
         if header.len() > MAX_HEADER_BYTES {
             return Err(CorsaError::Protocol("jsonrpc header is too large".into()));
         }

--- a/src/core/corsa_jsonrpc/src/jsonrpc/frame_tests.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/frame_tests.rs
@@ -1,6 +1,6 @@
 use super::{MAX_BODY_BYTES, MAX_HEADER_BYTES, read_frame, write_frame};
 use crate::CorsaError;
-use std::io::BufReader;
+use std::io::{BufRead, BufReader};
 #[cfg(unix)]
 use std::{os::unix::net::UnixStream, thread};
 
@@ -23,6 +23,15 @@ fn reads_headers_with_small_reader_buffers() {
     let payload = br#"{"jsonrpc":"2.0","method":"ping"}"#;
     let frame = frame_with_length(payload, b"X-Test: 1\r\n");
     let mut reader = BufReader::with_capacity(7, frame.as_slice());
+    assert_eq!(read_frame(&mut reader).unwrap(), payload);
+}
+
+#[test]
+fn reads_header_terminators_split_across_bufread_chunks() {
+    let payload = br#"{"jsonrpc":"2.0","method":"ping"}"#;
+    let header = format!("Content-Length: {}\r\n\r", payload.len());
+    let mut reader = ChunkedReader::new(vec![header.as_bytes(), b"\n", payload]);
+
     assert_eq!(read_frame(&mut reader).unwrap(), payload);
 }
 
@@ -99,4 +108,50 @@ fn assert_protocol(frame: Vec<u8>, needle: &str) {
     let mut reader = BufReader::new(frame.as_slice());
     let err = read_frame(&mut reader).unwrap_err();
     assert!(matches!(err, CorsaError::Protocol(message) if message.contains(needle)));
+}
+
+struct ChunkedReader<'a> {
+    chunks: Vec<&'a [u8]>,
+    chunk: usize,
+    offset: usize,
+}
+
+impl<'a> ChunkedReader<'a> {
+    fn new(chunks: Vec<&'a [u8]>) -> Self {
+        Self {
+            chunks,
+            chunk: 0,
+            offset: 0,
+        }
+    }
+}
+
+impl std::io::Read for ChunkedReader<'_> {
+    fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+        let available = self.fill_buf()?;
+        if available.is_empty() {
+            return Ok(0);
+        }
+        let written = available.len().min(output.len());
+        output[..written].copy_from_slice(&available[..written]);
+        self.consume(written);
+        Ok(written)
+    }
+}
+
+impl BufRead for ChunkedReader<'_> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        while self.chunk < self.chunks.len() && self.offset == self.chunks[self.chunk].len() {
+            self.chunk += 1;
+            self.offset = 0;
+        }
+        Ok(self
+            .chunks
+            .get(self.chunk)
+            .map_or(&[], |chunk| &chunk[self.offset..]))
+    }
+
+    fn consume(&mut self, amount: usize) {
+        self.offset += amount;
+    }
 }

--- a/src/core/corsa_jsonrpc/src/jsonrpc/frame_tests.rs
+++ b/src/core/corsa_jsonrpc/src/jsonrpc/frame_tests.rs
@@ -30,7 +30,8 @@ fn reads_headers_with_small_reader_buffers() {
 fn reads_header_terminators_split_across_bufread_chunks() {
     let payload = br#"{"jsonrpc":"2.0","method":"ping"}"#;
     let header = format!("Content-Length: {}\r\n\r", payload.len());
-    let mut reader = ChunkedReader::new(vec![header.as_bytes(), b"\n", payload]);
+    let body_chunk = [b"\n".as_slice(), payload].concat();
+    let mut reader = ChunkedReader::new(vec![header.as_bytes(), body_chunk.as_slice()]);
 
     assert_eq!(read_frame(&mut reader).unwrap(), payload);
 }


### PR DESCRIPTION
## Summary

- fix JSON-RPC frame reading when the LSP header terminator is split across `BufRead::fill_buf` chunks
- keep already-buffered body bytes unconsumed for `read_exact`
- add a deterministic chunked-reader regression for the split `\r\n\r\n` boundary

## Validation

- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/corsa-bind/target cargo test -p corsa_jsonrpc --lib -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/corsa-bind/target cargo clippy -p corsa_jsonrpc --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/corsa-bind/target cargo fmt --all -- --check`

## Related

- Unblocks ubugeeei-prod/vize#4157


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON-RPC message parsing when header terminators are split across buffered reads.
  * Preserved message body data correctly after reading headers, preventing malformed or incomplete message processing.
  * Improved reliability when messages arrive in multiple network or input chunks.

* **Tests**
  * Added regression coverage for messages received in separate input chunks.
  * Verified that buffered message data remains available for subsequent processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->