### PR TITLE
release: v1.8.0 — scope type-handle requests to their issuing project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,6 +346,7 @@ jobs:
       - test
       - public-facade
       - non-node-bindings
+      - real-corsa-smoke
     if: ${{ always() }}
     steps:
       - name: Verify focused quality checks
@@ -359,6 +360,7 @@ jobs:
           TEST: ${{ needs.test.result }}
           PUBLIC_FACADE: ${{ needs['public-facade'].result }}
           NON_NODE_BINDINGS: ${{ needs['non-node-bindings'].result }}
+          REAL_CORSA_SMOKE: ${{ needs['real-corsa-smoke'].result }}
         run: |
           failed=0
           for check in \
@@ -370,7 +372,8 @@ jobs:
             "BUILD=$BUILD" \
             "TEST=$TEST" \
             "PUBLIC_FACADE=$PUBLIC_FACADE" \
-            "NON_NODE_BINDINGS=$NON_NODE_BINDINGS"; do
+            "NON_NODE_BINDINGS=$NON_NODE_BINDINGS" \
+            "REAL_CORSA_SMOKE=$REAL_CORSA_SMOKE"; do
             name="${check%%=*}"
             result="${check#*=}"
             echo "$name: $result"
@@ -386,14 +389,16 @@ jobs:
     name: Real Corsa Smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
-    if: ${{ github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - blacksmith-32vcpu-ubuntu-2404
-          - macos-15
-          - blacksmith-32vcpu-windows-2025
+        # 型ハンドル系のプロトコル退行は実ランタイムでしか観測できず、統合
+        # テストは実バイナリが無いと skip に落ちる。PR でも ubuntu レグだけは
+        # 実ランタイムで回して、マージ前に弾く。
+        os: >-
+          ${{ fromJSON(github.event_name == 'pull_request'
+          && '["blacksmith-32vcpu-ubuntu-2404"]'
+          || '["blacksmith-32vcpu-ubuntu-2404","macos-15","blacksmith-32vcpu-windows-2025"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -441,6 +446,16 @@ jobs:
 
       - name: Real Corsa smoke tests
         run: cargo test -p corsa --no-default-features --test real_corsa_regression --test real_corsa_typecheck
+
+      # `vp run -w test` runs on a machine with no Corsa binary, so every
+      # `integrationCase` in the TypeScript suites degrades to `it.skip` there.
+      # This is the only job that has a real runtime, so it is the only place
+      # those cases can actually execute. CORSA_REQUIRE_INTEGRATION turns a
+      # missing runtime into a failure so the suite can never go quiet again.
+      - name: Real Corsa TypeScript integration tests
+        env:
+          CORSA_REQUIRE_INTEGRATION: "1"
+        run: vp run -w test_ts
 
       - name: Real examples
         run: vp run -w examples_real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `ApiClient` gained project-scoped variants for every relation endpoint that previously only had a project-less form: `get_type_parameters_of_type_in_project`, `get_outer_type_parameters_of_type_in_project`, `get_local_type_parameters_of_type_in_project`, `get_object_type_of_type_in_project`, `get_index_type_of_type_in_project`, `get_check_type_of_type_in_project`, `get_extends_type_of_type_in_project`, `get_base_type_of_type_in_project`, `get_parent_of_symbol_in_project`, `get_members_of_symbol_in_project`, `get_exports_of_symbol_in_project`, and `get_export_symbol_of_symbol_in_project`. Stable TypeScript 7 runtimes reject the project-less forms.
+- `NodeHandle::declaring_path` reads the declaring file out of both node handle wire formats, including the compact stable-runtime form that `NodeHandle::parse` rejects.
 - `corsa-oxlint` now exposes a `RuleContext<MessageId, Options>` type and generic `defineRule` wrapper for narrowing rule options and report message IDs.
 - `corsa-oxlint` now exposes per-node-type `ESTree.*` aliases from the root entrypoint.
 
@@ -13,6 +15,9 @@
 
 ### Fixed
 
+- type relation requests that carry a type handle now always name the project that issued it, so `getTypesOfType` returns union members instead of throwing `empty project ID for type handle <n>` ([#440](https://github.com/ubugeeei-prod/corsa-bind/issues/440)). The same omission silently affected `getTargetOfType`, `getTypeParametersOfType`, `getOuterTypeParametersOfType`, `getLocalTypeParametersOfType`, `getObjectTypeOfType`, `getIndexTypeOfType`, `getCheckTypeOfType`, `getExtendsTypeOfType`, and `getBaseTypeOfType`, which are fixed with it.
+- construct signatures of classes with an explicit constructor now expose `parameterSymbols` on stable TypeScript 7 runtimes, whose compact declaration handles carry no source range and so previously defeated parameter-name recovery ([#441](https://github.com/ubugeeei-prod/corsa-bind/issues/441)).
+- type-handle requests now resolve in the project that issued the handle rather than the snapshot's first project, which matters once a snapshot spans several projects.
 - type, signature, and symbol relation requests now mirror numeric handles into the `objectId` field that TypeScript 7 stable runtimes expect, so `getSymbolOfType`, `getBaseTypes` metadata, and `getImplementedTypesOfType` keep working for class types imported from other files ([#427](https://github.com/ubugeeei-prod/corsa-bind/issues/427)).
 - `corsa-oxlint` recovers class-declaration positions for compact TypeScript 7 declaration handles instead of misreading node ids as source offsets, keeping same-named classes in different scopes distinct.
 - `corsa-oxlint` no longer treats a compact TypeScript 7 declaration handle as a source range, resolves type symbols in the project that owns the type handle, and ignores `class` text inside comments and string literals when recovering a declaration position.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "corsa"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "base64",
  "corsa_client",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_client"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "base64",
  "corsa_core",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_core"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "base64",
  "bumpalo",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_elixir"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "corsa_client",
  "corsa_core",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_ffi"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "corsa_client",
  "corsa_core",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_jsonrpc"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "corsa_core",
  "corsa_runtime",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_lsp"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "corsa_core",
  "corsa_jsonrpc",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_node"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "corsa",
  "lsp-types",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_orchestrator"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "corsa_client",
  "corsa_core",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_ref"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "corsa_core",
  "serde",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "corsa_runtime"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "smallvec",
 ]

--- a/src/bindings/c/corsa_ffi/Cargo.toml
+++ b/src/bindings/c/corsa_ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_ffi"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 description = "C ABI for corsa utils, intended as the shared base for multi-language bindings"
 publish = false
@@ -15,10 +15,10 @@ rust-version.workspace = true
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-corsa_client = { version = "1.7.1", path = "../../../core/corsa_client" }
-corsa_core = { version = "1.7.1", path = "../../../core/corsa_core" }
-corsa_lsp = { version = "1.7.1", path = "../../../core/corsa_lsp" }
-corsa_runtime = { version = "1.7.1", path = "../../../core/corsa_runtime" }
+corsa_client = { version = "1.8.0", path = "../../../core/corsa_client" }
+corsa_core = { version = "1.8.0", path = "../../../core/corsa_core" }
+corsa_lsp = { version = "1.8.0", path = "../../../core/corsa_lsp" }
+corsa_runtime = { version = "1.8.0", path = "../../../core/corsa_runtime" }
 lsp-types = "0.97"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/bindings/elixir/corsa_utils/mix.exs
+++ b/src/bindings/elixir/corsa_utils/mix.exs
@@ -1,7 +1,7 @@
 defmodule CorsaUtils.MixProject do
   use Mix.Project
 
-  @version "1.7.1"
+  @version "1.8.0"
   @source_url "https://github.com/ubugeeei-prod/corsa-bind"
 
   def project do

--- a/src/bindings/elixir/corsa_utils/native/corsa_elixir/Cargo.toml
+++ b/src/bindings/elixir/corsa_utils/native/corsa_elixir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_elixir"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 description = "Rustler NIF for the corsa-bind Elixir binding"
 publish = false
@@ -15,10 +15,10 @@ rust-version.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-corsa_client = { version = "1.7.1", path = "../../../../../core/corsa_client" }
-corsa_core = { version = "1.7.1", path = "../../../../../core/corsa_core" }
-corsa_lsp = { version = "1.7.1", path = "../../../../../core/corsa_lsp" }
-corsa_runtime = { version = "1.7.1", path = "../../../../../core/corsa_runtime" }
+corsa_client = { version = "1.8.0", path = "../../../../../core/corsa_client" }
+corsa_core = { version = "1.8.0", path = "../../../../../core/corsa_core" }
+corsa_lsp = { version = "1.8.0", path = "../../../../../core/corsa_lsp" }
+corsa_runtime = { version = "1.8.0", path = "../../../../../core/corsa_runtime" }
 lsp-types = "0.97"
 rustler = { version = "0.38.0", features = ["nif_version_2_16"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/bindings/nodejs/corsa_node/Cargo.toml
+++ b/src/bindings/nodejs/corsa_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_node"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 license.workspace = true
 publish = false

--- a/src/bindings/nodejs/corsa_node/package.json
+++ b/src/bindings/nodejs/corsa_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsa-bind/napi",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Native JS runtime bindings for Corsa stdio workflows",
   "homepage": "https://github.com/ubugeeei-prod/corsa-bind/tree/main/src/bindings/nodejs/corsa_node",
   "bugs": {

--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -50,14 +50,6 @@ struct TypeProjectParams {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct TypeOnlyParams {
-    snapshot: String,
-    #[serde(rename = "type")]
-    type_handle: String,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
 struct SignatureOfTypeParams {
     snapshot: String,
     project: String,
@@ -2059,23 +2051,34 @@ async fn parameter_symbols_for_signature(
     let Some(declaration) = &signature.declaration else {
         return Ok(Vec::new());
     };
-    let Ok(parsed) = declaration.parse() else {
+    // A stable TypeScript 7 declaration handle is compact and carries no source
+    // range, so it cannot be parsed into offsets. It still names the declaring
+    // file, which is enough to recover parameter names (issue #441).
+    let ranged = declaration.parse().ok();
+    let Some(path) = ranged
+        .as_ref()
+        .map(|parsed| parsed.path.clone())
+        .or_else(|| declaration.declaring_path())
+    else {
         return Ok(Vec::new());
     };
     let source_text = source_text_for_signature_declaration(
         client,
         snapshot,
         project,
-        parsed.path.as_str(),
+        path.as_str(),
         source_override,
     )
     .await?;
-    let parameters = parameter_ranges_for_signature_declaration(
-        &source_text,
-        parsed.pos,
-        parsed.end,
-        signature.parameters.len(),
-    );
+    let parameters = match &ranged {
+        Some(parsed) => parameter_ranges_for_signature_declaration(
+            &source_text,
+            parsed.pos,
+            parsed.end,
+            signature.parameters.len(),
+        ),
+        None => unique_parameter_ranges_in_source(&source_text, signature.parameters.len()),
+    };
     if parameters.is_empty() {
         return Ok(Vec::new());
     }
@@ -2085,8 +2088,7 @@ async fn parameter_symbols_for_signature(
         .iter()
         .zip(parameters)
         .map(|(symbol, (name, pos, end))| {
-            let declaration =
-                NodeHandle::from(format!("{}.{}.0.{}", pos, end, parsed.path.as_str()));
+            let declaration = NodeHandle::from(format!("{}.{}.0.{}", pos, end, path.as_str()));
             SymbolResponse {
                 id: symbol.clone(),
                 name,
@@ -2191,10 +2193,22 @@ fn parameter_ranges_in_signature_declaration(
     let Some(open) = first_top_level_opening_paren(declaration_text) else {
         return Vec::new();
     };
-    let Some(close) = matching_paren_close(declaration_text, open) else {
+    parameter_ranges_from_open_paren(declaration_text, open, declaration_start)
+}
+
+/// Parses the parameter list opened by the parenthesis at `open`.
+///
+/// `text_start` is the byte offset of `text` inside the file, so the returned
+/// ranges are file-relative.
+fn parameter_ranges_from_open_paren(
+    text: &str,
+    open: usize,
+    text_start: usize,
+) -> Vec<ParameterSourceRange> {
+    let Some(close) = matching_paren_close(text, open) else {
         return Vec::new();
     };
-    let parameters_text = &declaration_text[open + 1..close];
+    let parameters_text = &text[open + 1..close];
     split_top_level_ranges(parameters_text, ',')
         .into_iter()
         .filter_map(|range| {
@@ -2208,9 +2222,64 @@ fn parameter_ranges_in_signature_declaration(
             let name = parameter_name(raw)?;
             Some(ParameterSourceRange {
                 name,
-                start: declaration_start + open + 1 + range.start + leading,
-                end: declaration_start + open + 1 + range.start + trailing,
+                start: text_start + open + 1 + range.start + leading,
+                end: text_start + open + 1 + range.start + trailing,
             })
+        })
+        .collect()
+}
+
+/// Recovers parameter ranges when the declaration handle carries no source
+/// range.
+///
+/// Stable TypeScript 7 runtimes hand back compact declaration handles
+/// (`<node id>.<syntax kind>.<path>`), which name the declaring file but no
+/// offsets, so the declaration cannot be sliced out of the source. Scan every
+/// parenthesised group in the file instead and accept the result only when
+/// exactly one group parses as `expected_count` named parameters.
+///
+/// Refusing ambiguous files keeps this from inventing parameter names: the
+/// caller then reports no parameter symbols, which is what it already did for
+/// every compact handle before this path existed (issue #441).
+fn unique_parameter_ranges_in_source(
+    source_text: &str,
+    expected_count: usize,
+) -> Vec<(String, u32, u32)> {
+    if expected_count == 0 {
+        return Vec::new();
+    }
+    let mut matches = Vec::new();
+    let mut index = 0usize;
+    let mut scanner = SourceScanner::default();
+    while index < source_text.len() {
+        let next = scanner.skip(source_text, index);
+        if next > index {
+            index = next;
+            continue;
+        }
+        let Some(ch) = char_at(source_text, index) else {
+            break;
+        };
+        if ch == '(' {
+            let parameters = parameter_ranges_from_open_paren(source_text, index, 0);
+            if parameters.len() == expected_count {
+                matches.push(parameters);
+                if matches.len() > 1 {
+                    return Vec::new();
+                }
+            }
+        }
+        index += ch.len_utf8();
+    }
+    let Some(parameters) = matches.pop() else {
+        return Vec::new();
+    };
+    parameters
+        .into_iter()
+        .filter_map(|parameter| {
+            let pos = utf16_index_from_byte(source_text, parameter.start)?;
+            let end = utf16_index_from_byte(source_text, parameter.end)?;
+            Some((parameter.name, pos, end))
         })
         .collect()
 }
@@ -2632,9 +2701,10 @@ fn call_json_blocking(client: &ApiClient, method: &str, params: Option<Value>) -
     }
     if method == "getTypesOfType" {
         let params = params.ok_or_else(|| into_napi_error("getTypesOfType requires params"))?;
-        let params = from_value::<TypeOnlyParams>(params)?;
-        let response = block_on(client.get_types_of_type(
+        let params = from_value::<TypeProjectParams>(params)?;
+        let response = block_on(client.get_types_of_type_in_project(
             SnapshotHandle::from(params.snapshot.as_str()),
+            ProjectHandle::from(params.project.as_str()),
             TypeHandle::from(params.type_handle.as_str()),
         ))
         .map_err(into_napi_error)?;
@@ -2703,7 +2773,7 @@ fn parse_numeric_snapshot_handle(handle: &str) -> Option<u64> {
 mod tests {
     use super::{
         parameter_ranges_for_signature_declaration, raw_byte_range,
-        signature_declaration_byte_ranges,
+        signature_declaration_byte_ranges, unique_parameter_ranges_in_source,
     };
 
     #[test]
@@ -2780,5 +2850,83 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["name", "識別子", "other"]
         );
+    }
+
+    /// Issue #441: a stable TypeScript 7 construct signature arrives with a
+    /// compact declaration handle that carries no source range, so the
+    /// declaration cannot be sliced out and parameter names have to be
+    /// recovered from the file as a whole.
+    #[test]
+    fn recovers_constructor_parameters_without_a_declaration_range() {
+        let source_text = [
+            "class Beta {",
+            "  constructor(first: number, second: string) {}",
+            "}",
+            "",
+            "export const b = new Beta(1, \"x\");",
+        ]
+        .join("\n");
+
+        let parameters = unique_parameter_ranges_in_source(&source_text, 2);
+
+        assert_eq!(
+            parameters
+                .iter()
+                .map(|(name, _, _)| name.as_str())
+                .collect::<Vec<_>>(),
+            ["first", "second"]
+        );
+        for (name, pos, end) in &parameters {
+            let slice = &source_text[*pos as usize..*end as usize];
+            assert!(slice.starts_with(name), "{slice} should start with {name}");
+        }
+    }
+
+    /// The recovery must not guess: two same-arity parameter lists in one file
+    /// leave no way to tell which one the signature came from.
+    #[test]
+    fn refuses_ambiguous_parameter_lists() {
+        let source_text = [
+            "class Beta {",
+            "  constructor(first: number, second: string) {}",
+            "}",
+            "class Gamma {",
+            "  constructor(third: number, fourth: string) {}",
+            "}",
+        ]
+        .join("\n");
+
+        assert!(unique_parameter_ranges_in_source(&source_text, 2).is_empty());
+    }
+
+    /// Call arguments are not parameter lists, so they must not be mistaken for
+    /// the declaration that produced the signature.
+    #[test]
+    fn ignores_call_arguments_when_recovering_parameters() {
+        let source_text = [
+            "class Beta {",
+            "  constructor(only: number) {}",
+            "}",
+            "export const b = new Beta(1);",
+            "export const c = new Beta(2);",
+        ]
+        .join("\n");
+
+        let parameters = unique_parameter_ranges_in_source(&source_text, 1);
+
+        assert_eq!(
+            parameters
+                .iter()
+                .map(|(name, _, _)| name.as_str())
+                .collect::<Vec<_>>(),
+            ["only"]
+        );
+    }
+
+    #[test]
+    fn recovers_no_parameters_for_a_parameterless_signature() {
+        let source_text = "class Beta {\n  constructor() {}\n}\n";
+
+        assert!(unique_parameter_ranges_in_source(source_text, 0).is_empty());
     }
 }

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -252,7 +252,9 @@ describe("CorsaApiClient", () => {
         client.getSymbolAtPosition(snapshot.snapshot, project.id, "/workspace/src/index.ts", 1)
           ?.name,
       ).toBe("value");
-      expect(client.getSymbolOfType(snapshot.snapshot, stringType.id)?.name).toBe("value");
+      expect(client.getSymbolOfType(snapshot.snapshot, stringType.id, project.id)?.name).toBe(
+        "value",
+      );
       expect(
         client.getTypeArguments(
           snapshot.snapshot,
@@ -326,9 +328,9 @@ describe("CorsaApiClient", () => {
         1,
       );
       expect(nodeType?.id).toBe("t0000000000000001");
-      await expect(client.getSymbolOfTypeAsync(snapshot.snapshot, stringType.id)).resolves.toEqual(
-        expect.objectContaining({ name: "value" }),
-      );
+      await expect(
+        client.getSymbolOfTypeAsync(snapshot.snapshot, stringType.id, project.id),
+      ).resolves.toEqual(expect.objectContaining({ name: "value" }));
       await expect(
         client.typeToStringAsync(snapshot.snapshot, project.id, stringType.id),
       ).resolves.toBe("type:string");

--- a/src/bindings/nodejs/corsa_oxlint/package.json
+++ b/src/bindings/nodejs/corsa_oxlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsa-oxlint",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Type-aware Oxlint helpers powered by Corsa",
   "homepage": "https://github.com/ubugeeei-prod/corsa-bind/tree/main/src/bindings/nodejs/corsa_oxlint",
   "bugs": {

--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -9,7 +9,7 @@ import { OxlintUtils } from "./oxlint_utils";
 import { getParserServices } from "./parser_services";
 import { decorateRule, definePlugin } from "./plugin";
 import { RuleTester } from "./rule_tester";
-import { resolvedRealCorsaBinary } from "./test_support";
+import { integrationCase as resolveIntegrationCase, resolvedRealCorsaBinary } from "./test_support";
 
 const workspaceRoot = resolve(import.meta.dirname, "../../../../..");
 const realCorsaBinary = resolvedRealCorsaBinary() ?? "";
@@ -730,7 +730,7 @@ describe("corsa oxlint", () => {
     }
   });
 
-  const integrationCase = existsSync(realCorsaBinary) ? it : it.skip;
+  const integrationCase = resolveIntegrationCase();
 
   integrationCase("runs a type-aware custom rule through oxlint RuleTester", () => {
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);

--- a/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts
@@ -8,11 +8,11 @@ import { describe, expect, it } from "vitest";
 import { createTypeChecker } from "./checker";
 import { OxlintUtils } from "./oxlint_utils";
 import { RuleTester } from "./rule_tester";
-import { resolvedRealCorsaBinary } from "./test_support";
+import { integrationCase as resolveIntegrationCase, resolvedRealCorsaBinary } from "./test_support";
 
 const realCorsaBinary = resolvedRealCorsaBinary() ?? "";
 const stableTypeScript7Binary = optionalStableTypeScript7Executable() ?? "";
-const integrationCase = existsSync(realCorsaBinary) ? it : it.skip;
+const integrationCase = resolveIntegrationCase();
 const stableTypeScript7Case = existsSync(stableTypeScript7Binary) ? it : it.skip;
 
 /**

--- a/src/bindings/nodejs/corsa_oxlint/ts/native_rule_edges.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/native_rule_edges.test.ts
@@ -1,13 +1,11 @@
-import { existsSync } from "node:fs";
-
-import { describe, it } from "vitest";
+import { describe } from "vitest";
 
 import { RuleTester } from "./rule_tester";
-import { resolvedRealCorsaBinary } from "./test_support";
+import { integrationCase as resolveIntegrationCase, resolvedRealCorsaBinary } from "./test_support";
 import { corsaOxlintRules } from "./rules";
 
 const realCorsaBinary = resolvedRealCorsaBinary() ?? "";
-const integrationCase = existsSync(realCorsaBinary) ? it : it.skip;
+const integrationCase = resolveIntegrationCase();
 
 describe("corsa oxlint native rule edges", () => {
   integrationCase("covers array and enum edge cases", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts
@@ -4,7 +4,7 @@ import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { RuleTester } from "./rule_tester";
-import { resolvedRealCorsaBinary } from "./test_support";
+import { integrationCase as resolveIntegrationCase, resolvedRealCorsaBinary } from "./test_support";
 import {
   implementedNativeRuleNames,
   pendingNativeRuleNames,
@@ -17,7 +17,7 @@ const workspaceRoot = resolve(import.meta.dirname, "../../../../..");
 const upstreamRulesDir = resolve(workspaceRoot, ".cache/tsgolint_upstream/internal/rules");
 const realCorsaBinary = resolvedRealCorsaBinary() ?? "";
 const upstreamCase = existsSync(upstreamRulesDir) ? it : it.skip;
-const integrationCase = existsSync(realCorsaBinary) ? it : it.skip;
+const integrationCase = resolveIntegrationCase();
 
 describe("corsa oxlint native rules", () => {
   it("exports the native plugin surface", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/project_scoped_requests.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/project_scoped_requests.test.ts
@@ -1,0 +1,171 @@
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { createTypeChecker } from "./checker";
+
+const workspaceRoot = resolve(import.meta.dirname, "../../../../..");
+const executableSuffix = process.platform === "win32" ? ".exe" : "";
+const mockBinary = resolve(workspaceRoot, `target/debug/mock_corsa${executableSuffix}`);
+
+/**
+ * Request fields that carry an object handle minted by a specific project.
+ *
+ * Stable TypeScript 7 runtimes resolve these handles per project and answer a
+ * project-less lookup with `empty project ID for <kind> handle <n>`, so a
+ * request naming one of these fields must also name a project.
+ */
+const PROJECT_SCOPED_HANDLE_FIELDS = ["type", "symbol", "signature"] as const;
+
+/**
+ * Type-relation accessors this suite drives.
+ *
+ * Recorded traffic — not this list — is what the contract assertion inspects,
+ * so an endpoint added later is covered as soon as anything calls it. The list
+ * exists so the suite fails when a call stops reaching the wire, rather than
+ * passing vacuously.
+ */
+const TRAVERSAL_ACCESSORS = [
+  "getTypesOfType",
+  "getTargetOfType",
+  "getTypeParametersOfType",
+  "getOuterTypeParametersOfType",
+  "getLocalTypeParametersOfType",
+  "getObjectTypeOfType",
+  "getIndexTypeOfType",
+  "getCheckTypeOfType",
+  "getExtendsTypeOfType",
+  "getBaseTypeOfType",
+  // `getConstraintOfType` answers from `getConstraintOfTypeParameter` first and
+  // only falls through to the direct endpoint when that yields nothing.
+  "getConstraintOfTypeParameter",
+  "getPropertiesOfType",
+  "getBaseTypes",
+  "getTypeArguments",
+] as const;
+
+interface RecordedRequest {
+  readonly method: string;
+  readonly params: Record<string, unknown>;
+}
+
+function recordedRequests(paramsDir: string): readonly RecordedRequest[] {
+  return readdirSync(paramsDir)
+    .filter((entry) => entry.endsWith(".jsonl"))
+    .flatMap((entry) =>
+      readFileSync(resolve(paramsDir, entry), "utf8")
+        .split("\n")
+        .filter((line) => line.trim().length > 0)
+        .map((line) => ({
+          method: entry.slice(0, -".jsonl".length),
+          params: (JSON.parse(line) ?? {}) as Record<string, unknown>,
+        }))
+        .filter((request) => typeof request.params === "object"),
+    );
+}
+
+function namesAHandle(params: Record<string, unknown>): boolean {
+  return PROJECT_SCOPED_HANDLE_FIELDS.some((field) => {
+    const value = params[field];
+    return typeof value === "number" || (typeof value === "string" && value.trim().length > 0);
+  });
+}
+
+function hasProject(params: Record<string, unknown>): boolean {
+  return typeof params.project === "string" && params.project.trim().length > 0;
+}
+
+function driveTypeRelationSurface(paramsDir: string): readonly RecordedRequest[] {
+  const workspace = mkdtempSync(resolve(tmpdir(), "corsa-oxlint-project-scope-"));
+  const srcDir = resolve(workspace, "src");
+  mkdirSync(srcDir, { recursive: true });
+  const filename = resolve(srcDir, "fixture.ts");
+  writeFileSync(filename, "const value: number = 1;\n");
+  writeFileSync(
+    resolve(workspace, "tsconfig.json"),
+    JSON.stringify({ compilerOptions: { strict: true }, include: ["src/**/*.ts"] }),
+  );
+
+  const previousParamsDir = process.env.CORSA_MOCK_PARAMS_DIR;
+  const previousAllFlags = process.env.CORSA_MOCK_ALL_TYPE_FLAGS;
+  process.env.CORSA_MOCK_PARAMS_DIR = paramsDir;
+  // Clients skip a traversal request unless the type carries the matching
+  // TypeFlags bit, so ask the mock for a type that satisfies every guard.
+  process.env.CORSA_MOCK_ALL_TYPE_FLAGS = "1";
+  try {
+    const checker = createTypeChecker({
+      cwd: workspace,
+      filename,
+      settings: {
+        corsaOxlint: {
+          parserOptions: {
+            project: ["tsconfig.json"],
+            corsa: { executable: mockBinary, cwd: workspace, mode: "jsonrpc" },
+          },
+        },
+      },
+      sourceCode: { text: "const value: number = 1;\n" },
+    } as never);
+
+    const type = checker.getTypeAtLocation({ type: "Identifier", range: [6, 11] } as never);
+    expect(type).toBeDefined();
+    // A contract violation makes the mock reject the request. Swallow it here so
+    // the assertions below can report every offending endpoint at once instead
+    // of the suite dying on the first one.
+    const attempt = (call: () => unknown): void => {
+      try {
+        call();
+      } catch {
+        // Reported by the recorded-traffic assertions.
+      }
+    };
+    const accessors = checker as unknown as Record<string, (value: unknown) => unknown>;
+    for (const accessor of [...TRAVERSAL_ACCESSORS, "getConstraintOfType"]) {
+      attempt(() => accessors[accessor]?.(type));
+    }
+    attempt(() => checker.getSignaturesOfType(type as never, 0));
+    attempt(() => checker.getSymbolOfType(type as never));
+  } finally {
+    if (previousParamsDir === undefined) {
+      delete process.env.CORSA_MOCK_PARAMS_DIR;
+    } else {
+      process.env.CORSA_MOCK_PARAMS_DIR = previousParamsDir;
+    }
+    if (previousAllFlags === undefined) {
+      delete process.env.CORSA_MOCK_ALL_TYPE_FLAGS;
+    } else {
+      process.env.CORSA_MOCK_ALL_TYPE_FLAGS = previousAllFlags;
+    }
+  }
+  return recordedRequests(paramsDir);
+}
+
+describe("project-scoped handle requests", () => {
+  const paramsDir = mkdtempSync(resolve(tmpdir(), "corsa-oxlint-params-"));
+  const requests = driveTypeRelationSurface(paramsDir);
+
+  /**
+   * Guards the whole bug family behind issues #384, #389, #390, #392, #393,
+   * #395, #410, #413, #416, #418, #427, and #440: each was one endpoint
+   * forgetting to name the project that issued the handle it was resolving.
+   *
+   * Asserting over recorded traffic rather than a hand-maintained endpoint list
+   * is what makes this hold for endpoints added later.
+   */
+  it("names a project on every request that carries an object handle", () => {
+    const offenders = requests
+      .filter((request) => namesAHandle(request.params) && !hasProject(request.params))
+      .map((request) => request.method);
+
+    expect([...new Set(offenders)]).toEqual([]);
+  });
+
+  it("actually exercised the type-relation surface", () => {
+    const methods = new Set(requests.map((request) => request.method));
+    const missing = TRAVERSAL_ACCESSORS.filter((accessor) => !methods.has(accessor));
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -660,7 +660,7 @@ export class CorsaProjectSession {
     try {
       const text = this.client().typeToString(
         this.#snapshot!,
-        this.projectId(),
+        this.projectIdForType(type),
         type.id,
         undefined,
         flags,
@@ -683,7 +683,7 @@ export class CorsaProjectSession {
       this.rememberType(
         this.client().callJson("getBaseTypeOfLiteralType", {
           snapshot: this.#snapshot,
-          project: this.projectId(),
+          project: this.projectIdForType(type),
           type: type.id,
         }),
       ),
@@ -695,7 +695,7 @@ export class CorsaProjectSession {
       this.rememberSymbols(
         this.client().callJson("getPropertiesOfType", {
           snapshot: this.#snapshot,
-          project: this.projectId(),
+          project: this.projectIdForType(type),
           type: type.id,
         }) ?? [],
       ),
@@ -708,7 +708,7 @@ export class CorsaProjectSession {
       return this.rememberSignatures(
         this.client().callJson("getSignaturesOfType", {
           snapshot: this.#snapshot,
-          project: this.projectId(),
+          project: this.projectIdForType(type),
           type: type.id,
           kind,
           ...source,
@@ -741,7 +741,7 @@ export class CorsaProjectSession {
       const source = this.sourceContextForType(type);
       const facts = this.client().callJson<CorsaCallSignatureFacts>("getCallSignatureFacts", {
         snapshot: this.#snapshot,
-        project: this.projectId(),
+        project: this.projectIdForType(type),
         type: type.id,
         kind,
         ...source,
@@ -794,7 +794,7 @@ export class CorsaProjectSession {
       const baseTypes = this.rememberTypes(
         this.client().callJson<readonly CorsaType[]>("getBaseTypes", {
           snapshot: this.#snapshot,
-          project: this.projectId(),
+          project: this.projectIdForType(type),
           type: type.id,
           texts: this.typeTexts(type),
         }) ?? [],
@@ -877,7 +877,7 @@ export class CorsaProjectSession {
         source
           ? (this.client().getTypeArgumentsAtSourceRange(
               this.#snapshot!,
-              this.projectId(),
+              this.projectIdForType(type),
               type.id,
               type.objectFlags,
               source.node.fileName,
@@ -887,7 +887,7 @@ export class CorsaProjectSession {
             ) as unknown as readonly CorsaType[])
           : (this.client().getTypeArguments(
               this.#snapshot!,
-              this.projectId(),
+              this.projectIdForType(type),
               type.id,
               type.objectFlags,
             ) as unknown as readonly CorsaType[]),
@@ -974,7 +974,7 @@ export class CorsaProjectSession {
   getConstraintOfType(type: CorsaType): CorsaType | undefined {
     return this.withMissingTypeHandleFallback<CorsaType | undefined>(type, undefined, () =>
       this.rememberType(
-        this.client().getConstraintOfType(this.#snapshot!, this.projectId(), type.id) as
+        this.client().getConstraintOfType(this.#snapshot!, this.projectIdForType(type), type.id) as
           | CorsaType
           | undefined,
       ),
@@ -986,6 +986,7 @@ export class CorsaProjectSession {
       this.rememberType(
         this.client().callJson<CorsaType | null>(method, {
           snapshot: this.#snapshot,
+          project: this.projectIdForType(type),
           type: type.id,
         }) ?? undefined,
       ),
@@ -997,6 +998,7 @@ export class CorsaProjectSession {
       this.rememberTypes(
         this.client().callJson<readonly CorsaType[] | null>(method, {
           snapshot: this.#snapshot,
+          project: this.projectIdForType(type),
           type: type.id,
         }) ?? [],
       ),
@@ -1412,6 +1414,19 @@ export class CorsaProjectSession {
       );
     }
     return id;
+  }
+
+  /**
+   * Resolves the project a type handle must be looked up in.
+   *
+   * Stable TypeScript 7 runtimes resolve object handles per project and reject
+   * project-less lookups with `empty project ID for type handle <n>`, so every
+   * request that carries a type handle has to name a project. Prefer the
+   * project that issued the handle over the first project in the snapshot: a
+   * handle minted by one project is not resolvable in another.
+   */
+  private projectIdForType(type: CorsaType): string {
+    return this.#typeLookupById.get(type.id)?.projectId ?? this.projectId();
   }
 
   private supportedOverlayText(

--- a/src/bindings/nodejs/corsa_oxlint/ts/test_support.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/test_support.ts
@@ -1,6 +1,8 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { it } from "vitest";
+
 const workspaceRoot = resolve(import.meta.dirname, "../../../../..");
 
 const CANDIDATES = [
@@ -33,4 +35,37 @@ export function resolvedRealCorsaBinary(): string | undefined {
   return CANDIDATES.map((candidate) => resolve(workspaceRoot, candidate)).find((candidate) =>
     existsSync(candidate),
   );
+}
+
+/** Registers a test case, mirroring the shape of vitest's `it`. */
+export type IntegrationCase = (name: string, fn: () => void | Promise<void>) => void;
+
+/**
+ * Returns the `it` variant integration cases should register with.
+ *
+ * Integration cases need a real Corsa runtime, so they fall back to `it.skip`
+ * when the workspace has not built one. That silence is how this repository
+ * shipped a long run of protocol regressions — issues #384, #389, #390, #392,
+ * #393, #395, #410, #413, #416, #418, #427, #440, and #441 — while the suites
+ * covering those endpoints reported success without executing a single case.
+ *
+ * Set `CORSA_REQUIRE_INTEGRATION=1`, as the real-runtime CI job does, to turn a
+ * missing runtime into a failure instead of a skip.
+ */
+export function integrationCase(): IntegrationCase {
+  if (resolvedRealCorsaBinary()) {
+    return it;
+  }
+  if (!process.env.CORSA_REQUIRE_INTEGRATION) {
+    return it.skip;
+  }
+  return (name, _fn) =>
+    it(name, () => {
+      throw new Error(
+        [
+          "CORSA_REQUIRE_INTEGRATION is set but no Corsa runtime was found.",
+          "Build one with `vp run -w build_corsa`, or point CORSA_EXECUTABLE at an existing binary.",
+        ].join(" "),
+      );
+    });
 }

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_arguments.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_arguments.test.ts
@@ -1,13 +1,11 @@
-import { existsSync } from "node:fs";
-
-import { describe, expect, it } from "vitest";
+import { describe, expect } from "vitest";
 
 import { OxlintUtils } from "./oxlint_utils";
 import { RuleTester } from "./rule_tester";
-import { resolvedRealCorsaBinary } from "./test_support";
+import { integrationCase as resolveIntegrationCase, resolvedRealCorsaBinary } from "./test_support";
 
 const realCorsaBinary = resolvedRealCorsaBinary() ?? "";
-const integrationCase = existsSync(realCorsaBinary) ? it : it.skip;
+const integrationCase = resolveIntegrationCase();
 
 describe("corsa oxlint type arguments", () => {
   integrationCase("returns empty type arguments for non-generic types", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 
@@ -6,14 +6,15 @@ import { describe, expect, it } from "vitest";
 
 import { createTypeChecker } from "./checker";
 import { OxlintUtils } from "./oxlint_utils";
+import { SignatureKind } from "./types";
 import { RuleTester } from "./rule_tester";
-import { resolvedRealCorsaBinary } from "./test_support";
+import { integrationCase as resolveIntegrationCase, resolvedRealCorsaBinary } from "./test_support";
 
 const workspaceRoot = resolve(import.meta.dirname, "../../../../..");
 const realCorsaBinary = resolvedRealCorsaBinary() ?? "";
 const executableSuffix = process.platform === "win32" ? ".exe" : "";
 const mockBinary = resolve(workspaceRoot, `target/debug/mock_corsa${executableSuffix}`);
-const integrationCase = existsSync(realCorsaBinary) ? it : it.skip;
+const integrationCase = resolveIntegrationCase();
 
 describe("corsa oxlint type locations", () => {
   integrationCase("resolves types from declaration wrapper nodes", () => {
@@ -1319,6 +1320,144 @@ describe("corsa oxlint type locations", () => {
 
     expect(seen.atLocation).toBe("MyPropType");
     expect(seen.ofSymbol).toBe("MyPropType");
+  });
+
+  /**
+   * Issue #440: on a stable TypeScript 7 runtime `getTypesOfType` threw
+   * `empty project ID for type handle <n>` for every union shape, because the
+   * request never named the project that issued the type handle. An escaping
+   * throw also dropped every diagnostic for the file, including ones from
+   * unrelated AST-only rules.
+   */
+  integrationCase("enumerates union members for every union shape", () => {
+    const seen: Record<string, readonly string[]> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "union-members",
+      meta: {
+        type: "problem",
+        docs: { description: "exercise union member enumeration", requiresTypeChecking: true },
+        messages: { unexpected: "unexpected" },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          TSPropertySignature(node: any) {
+            const type = checker.getTypeAtLocation(node);
+            if (!type || !checker.isUnionType(type)) {
+              return;
+            }
+            seen[node.key.name] = checker
+              .getTypesOfType(type)
+              .map((member) => checker.typeToString(member));
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("union-members", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Alpha {}",
+            "export interface Shapes {",
+            "  readonly optional?: Alpha;",
+            "  readonly withNull: Alpha | null;",
+            "  readonly primitives: string | number;",
+            "}",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.optional).toEqual(expect.arrayContaining(["undefined", "Alpha"]));
+    expect(seen.withNull).toEqual(expect.arrayContaining(["null", "Alpha"]));
+    expect(seen.primitives).toEqual(expect.arrayContaining(["string", "number"]));
+  });
+
+  /**
+   * Issue #441: on a stable TypeScript 7 runtime the construct signature of a
+   * class with an explicit constructor came back with `parameterSymbols`
+   * undefined, because that runtime's compact declaration handle carries no
+   * source range and the parameter names were only ever recovered by slicing
+   * the declaration out of the source.
+   */
+  integrationCase("exposes parameter symbols on explicit construct signatures", () => {
+    const seen: Record<string, readonly string[] | undefined> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "construct-signature-parameters",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise construct signature parameter symbols",
+          requiresTypeChecking: true,
+        },
+        messages: { unexpected: "unexpected" },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          NewExpression(node: any) {
+            const calleeType = checker.getTypeAtLocation(node.callee);
+            if (!calleeType) {
+              return;
+            }
+            const signature = checker.getSignaturesOfType(calleeType, SignatureKind.Construct)[0];
+            if (!signature) {
+              return;
+            }
+            seen[node.callee.name] = signature.parameterSymbols?.map((symbol) => symbol.name);
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("construct-signature-parameters", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Beta {",
+            "  constructor(first: number, second: string) {}",
+            "}",
+            "",
+            'export const b = new Beta(1, "x");',
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.Beta).toEqual(["first", "second"]);
   });
 
   integrationCase("exposes constituent and mapped type traversal helpers", () => {

--- a/src/bindings/rust/corsa/Cargo.toml
+++ b/src/bindings/rust/corsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 description = "Production-oriented Rust bindings, orchestration layers, and Node integration for Corsa"
 publish = ["crates-io"]
@@ -80,12 +80,12 @@ required-features = ["experimental-distributed"]
 base64 = "0.23"
 lsp-types = "0.97"
 serde_json = "1"
-corsa_client = { version = "1.7.1", path = "../../../core/corsa_client" }
-corsa_core = { version = "1.7.1", path = "../../../core/corsa_core" }
-corsa_jsonrpc = { version = "1.7.1", path = "../../../core/corsa_jsonrpc" }
-corsa_lsp = { version = "1.7.1", path = "../../../core/corsa_lsp" }
-corsa_orchestrator = { version = "1.7.1", path = "../../../core/corsa_orchestrator" }
-corsa_runtime = { version = "1.7.1", path = "../../../core/corsa_runtime" }
+corsa_client = { version = "1.8.0", path = "../../../core/corsa_client" }
+corsa_core = { version = "1.8.0", path = "../../../core/corsa_core" }
+corsa_jsonrpc = { version = "1.8.0", path = "../../../core/corsa_jsonrpc" }
+corsa_lsp = { version = "1.8.0", path = "../../../core/corsa_lsp" }
+corsa_orchestrator = { version = "1.8.0", path = "../../../core/corsa_orchestrator" }
+corsa_runtime = { version = "1.8.0", path = "../../../core/corsa_runtime" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
@@ -3,7 +3,7 @@ use base64::Engine as _;
 use corsa::jsonrpc::{RawMessage, RequestId, RpcResponseError};
 use serde_json::{Value, json};
 use std::{
-    fs::{create_dir_all, OpenOptions},
+    fs::{OpenOptions, create_dir_all},
     io::{BufReader, BufWriter, Write as _},
     path::Path,
     sync::atomic::{AtomicBool, Ordering},

--- a/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
@@ -3,7 +3,7 @@ use base64::Engine as _;
 use corsa::jsonrpc::{RawMessage, RequestId, RpcResponseError};
 use serde_json::{Value, json};
 use std::{
-    fs::{OpenOptions, create_dir_all},
+    fs::{create_dir_all, OpenOptions},
     io::{BufReader, BufWriter, Write as _},
     path::Path,
     sync::atomic::{AtomicBool, Ordering},
@@ -40,6 +40,10 @@ pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
             continue;
         }
         if let (Some(id), Some(error)) = (id.clone(), release_error(method.as_str())) {
+            jsonrpc::write_message(&mut writer, &RawMessage::error(id, error))?;
+            continue;
+        }
+        if let (Some(id), Some(error)) = (id.clone(), missing_project_error(&params)) {
             jsonrpc::write_message(&mut writer, &RawMessage::error(id, error))?;
             continue;
         }
@@ -164,6 +168,16 @@ pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
             jsonrpc::write_message(&mut writer, &RawMessage::response(id, response))?;
         }
     }
+}
+
+/// Mirrors upstream's per-project handle resolution so project-less lookups
+/// fail here exactly as they do against a real TypeScript 7 stable runtime.
+fn missing_project_error(params: &Value) -> Option<RpcResponseError> {
+    common::missing_project_message(params).map(|message| RpcResponseError {
+        code: -32000,
+        message: message.into(),
+        data: None,
+    })
 }
 
 fn release_error(method: &str) -> Option<RpcResponseError> {

--- a/src/bindings/rust/corsa/src/bin/mock_corsa/common.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_corsa/common.rs
@@ -49,14 +49,36 @@ pub fn symbol(name: &str) -> Value {
     })
 }
 
+/// Every `TypeFlags` bit the client guards a type-relation request on, so one
+/// probe type can drive the whole traversal surface.
+const ALL_TRAVERSAL_TYPE_FLAGS: u32 = 0b1_1111_1111 << 20;
+/// `classOrInterface | reference | mapped`.
+const ALL_TRAVERSAL_OBJECT_FLAGS: u32 = 0b11 | (1 << 2) | (1 << 5);
+
 pub fn type_response(id: &str) -> Value {
+    let (flags, object_flags) = if all_traversal_flags_enabled() {
+        (ALL_TRAVERSAL_TYPE_FLAGS, ALL_TRAVERSAL_OBJECT_FLAGS)
+    } else {
+        (262144, 16)
+    };
     json!({
         "id": id,
-        "flags": 262144,
-        "objectFlags": 16,
+        "flags": flags,
+        "objectFlags": object_flags,
         "symbol": "s0000000000000001",
         "texts": ["type-text"],
     })
+}
+
+/// Whether the mock should report a type that satisfies every client-side
+/// traversal guard.
+///
+/// Clients skip most type-relation requests unless the type carries the
+/// matching `TypeFlags` bit, so protocol-contract tests would otherwise only
+/// ever observe a handful of endpoints. `CORSA_MOCK_ALL_TYPE_FLAGS` lets such a
+/// test drive the full surface from a single type.
+fn all_traversal_flags_enabled() -> bool {
+    std::env::var_os("CORSA_MOCK_ALL_TYPE_FLAGS").is_some()
 }
 
 pub fn signature() -> Value {
@@ -267,4 +289,49 @@ fn range() -> Value {
         "start": { "line": 0, "character": 0 },
         "end": { "line": 0, "character": 5 }
     })
+}
+
+/// Handle-carrying request fields that upstream can only resolve inside a
+/// project, in the order upstream validates them.
+const PROJECT_SCOPED_HANDLE_FIELDS: [(&str, &str); 3] = [
+    ("type", "type"),
+    ("symbol", "symbol"),
+    ("signature", "signature"),
+];
+
+/// Rejects requests that reference an object handle without naming the project
+/// that issued it.
+///
+/// TypeScript 7 stable runtimes resolve type, symbol, and signature handles per
+/// project and answer project-less lookups with
+/// `empty project ID for <kind> handle <n>`. The mock enforces the same
+/// contract so a binding that forgets to forward the project handle fails in
+/// the normal test suite instead of only against a real runtime.
+///
+/// Every regression in this family — issues #384, #389, #390, #392, #393, #395,
+/// #410, #413, #416, #418, #427, and #440 — reached a release because the mock
+/// answered project-less requests that upstream rejects.
+pub fn missing_project_message(params: &Value) -> Option<String> {
+    let params = params.as_object()?;
+    if params
+        .get("project")
+        .and_then(Value::as_str)
+        .is_some_and(|project| !project.trim().is_empty())
+    {
+        return None;
+    }
+    PROJECT_SCOPED_HANDLE_FIELDS
+        .iter()
+        .find_map(|(field, kind)| {
+            let handle = handle_text(params.get(*field)?)?;
+            Some(format!("empty project ID for {kind} handle {handle}"))
+        })
+}
+
+fn handle_text(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) if !text.trim().is_empty() => Some(text.clone()),
+        Value::Number(number) => Some(number.to_string()),
+        _ => None,
+    }
 }

--- a/src/bindings/rust/corsa/tests/api_async.rs
+++ b/src/bindings/rust/corsa/tests/api_async.rs
@@ -327,14 +327,22 @@ fn async_api_full_surface_methods() {
         );
         assert!(
             client
-                .get_parent_of_symbol(snapshot.handle.clone(), symbol.id.clone())
+                .get_parent_of_symbol_in_project(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    symbol.id.clone(),
+                )
                 .await
                 .unwrap()
                 .is_some()
         );
         assert_eq!(
             client
-                .get_members_of_symbol(snapshot.handle.clone(), symbol.id.clone())
+                .get_members_of_symbol_in_project(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    symbol.id.clone(),
+                )
                 .await
                 .unwrap()
                 .len(),
@@ -342,14 +350,22 @@ fn async_api_full_surface_methods() {
         );
         assert_eq!(
             client
-                .get_exports_of_symbol(snapshot.handle.clone(), symbol.id.clone())
+                .get_exports_of_symbol_in_project(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    symbol.id.clone(),
+                )
                 .await
                 .unwrap()
                 .len(),
             1
         );
         let exported = client
-            .get_export_symbol_of_symbol(snapshot.handle.clone(), symbol.id.clone())
+            .get_export_symbol_of_symbol_in_project(
+                snapshot.handle.clone(),
+                project.clone(),
+                symbol.id.clone(),
+            )
             .await
             .unwrap();
         assert_eq!(exported.name, "exported");

--- a/src/core/corsa_client/Cargo.toml
+++ b/src/core/corsa_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_client"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 description = "Typed stdio API client bindings for Corsa"
 publish = ["crates-io"]
@@ -23,6 +23,6 @@ parking_lot = "0.12"
 phf = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-corsa_core = { version = "1.7.1", path = "../corsa_core" }
-corsa_jsonrpc = { version = "1.7.1", path = "../corsa_jsonrpc" }
-corsa_runtime = { version = "1.7.1", path = "../corsa_runtime" }
+corsa_core = { version = "1.8.0", path = "../corsa_core" }
+corsa_jsonrpc = { version = "1.8.0", path = "../corsa_jsonrpc" }
+corsa_runtime = { version = "1.8.0", path = "../corsa_runtime" }

--- a/src/core/corsa_client/src/api/handles.rs
+++ b/src/core/corsa_client/src/api/handles.rs
@@ -1,8 +1,8 @@
 use crate::{CorsaError, Result};
 use corsa_core::fast::CompactString;
 use serde::{
-    Deserialize, Deserializer, Serialize,
     de::{Unexpected, Visitor},
+    Deserialize, Deserializer, Serialize,
 };
 use std::fmt;
 
@@ -161,6 +161,9 @@ impl NodeHandle {
     /// assert_eq!(parsed.path.as_str(), "/workspace/main.ts");
     /// # Ok::<(), corsa_client::CorsaError>(())
     /// ```
+    ///
+    /// Compact stable-runtime handles carry no offsets and are rejected here;
+    /// use [`Self::declaring_path`] when only the declaring file is needed.
     pub fn parse(&self) -> Result<ParsedNodeHandle> {
         let mut parts = self.0.splitn(4, '.');
         let invalid = || CorsaError::InvalidHandle(self.0.clone());
@@ -189,6 +192,51 @@ impl NodeHandle {
             kind,
             path: path.into(),
         })
+    }
+
+    /// Returns the file path a node handle declares, in either wire format.
+    ///
+    /// Corsa emits two node handle shapes. Development runtimes use the full
+    /// `<pos>.<end>.<kind>.<path>` form that [`Self::parse`] understands, while
+    /// stable TypeScript 7 runtimes use a compact `<node id>.<kind>.<path>`
+    /// form that carries no source offsets and so cannot be parsed into a
+    /// range. Both still name the declaring file, which is enough for
+    /// file-scoped work such as recovering parameter names from source.
+    ///
+    /// Returns `None` when the handle matches neither shape.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corsa_client::NodeHandle;
+    ///
+    /// let full = NodeHandle::from("1.5.123./workspace/main.ts");
+    /// assert_eq!(full.declaring_path().as_deref(), Some("/workspace/main.ts"));
+    ///
+    /// let compact = NodeHandle::from("42.176./workspace/main.ts");
+    /// assert_eq!(compact.declaring_path().as_deref(), Some("/workspace/main.ts"));
+    /// ```
+    pub fn declaring_path(&self) -> Option<CompactString> {
+        let parts = self.0.split('.').collect::<Vec<_>>();
+        let [first, second, third, rest @ ..] = parts.as_slice() else {
+            return None;
+        };
+        if first.parse::<u32>().is_err() || second.parse::<u32>().is_err() {
+            return None;
+        }
+        // A numeric third field is the syntax kind of a full handle, so the
+        // path starts after it. Otherwise the handle is the compact form and
+        // the path starts at the third field itself.
+        let path = if third.parse::<u32>().is_ok() {
+            rest.join(".")
+        } else {
+            std::iter::once(third)
+                .chain(rest)
+                .copied()
+                .collect::<Vec<_>>()
+                .join(".")
+        };
+        (!path.is_empty()).then(|| CompactString::from(path))
     }
 }
 

--- a/src/core/corsa_client/src/api/handles.rs
+++ b/src/core/corsa_client/src/api/handles.rs
@@ -1,8 +1,8 @@
 use crate::{CorsaError, Result};
 use corsa_core::fast::CompactString;
 use serde::{
-    de::{Unexpected, Visitor},
     Deserialize, Deserializer, Serialize,
+    de::{Unexpected, Visitor},
 };
 use std::fmt;
 

--- a/src/core/corsa_client/src/api/handles_tests.rs
+++ b/src/core/corsa_client/src/api/handles_tests.rs
@@ -93,3 +93,41 @@ fn parse_rejects_inverted_offsets() {
         matches!(err, CorsaError::InvalidHandle(handle) if handle == "5.1.123./workspace/main.ts")
     );
 }
+
+#[test]
+fn declaring_path_reads_both_node_handle_wire_formats() {
+    // Development runtimes: `<pos>.<end>.<kind>.<path>`.
+    assert_eq!(
+        NodeHandle::from("1.5.123./workspace/main.ts")
+            .declaring_path()
+            .as_deref(),
+        Some("/workspace/main.ts")
+    );
+    // Stable TypeScript 7 runtimes: `<node id>.<syntax kind>.<path>`. Rejecting
+    // this shape is what left construct signatures without parameter symbols
+    // (issue #441), so it has to resolve to the declaring file.
+    assert_eq!(
+        NodeHandle::from("42.176./workspace/ctor.ts")
+            .declaring_path()
+            .as_deref(),
+        Some("/workspace/ctor.ts")
+    );
+    // Dots inside the path survive both forms.
+    assert_eq!(
+        NodeHandle::from("42.176./workspace/a.b/ctor.d.ts")
+            .declaring_path()
+            .as_deref(),
+        Some("/workspace/a.b/ctor.d.ts")
+    );
+    assert_eq!(NodeHandle::from("not-a-handle").declaring_path(), None);
+    assert_eq!(NodeHandle::from("1.5").declaring_path(), None);
+    assert_eq!(NodeHandle::from("1.5.123.").declaring_path(), None);
+}
+
+#[test]
+fn parse_still_rejects_compact_handles() {
+    // `parse` reports source offsets, which a compact handle does not carry.
+    assert!(NodeHandle::from("42.176./workspace/ctor.ts")
+        .parse()
+        .is_err());
+}

--- a/src/core/corsa_client/src/api/handles_tests.rs
+++ b/src/core/corsa_client/src/api/handles_tests.rs
@@ -127,7 +127,9 @@ fn declaring_path_reads_both_node_handle_wire_formats() {
 #[test]
 fn parse_still_rejects_compact_handles() {
     // `parse` reports source offsets, which a compact handle does not carry.
-    assert!(NodeHandle::from("42.176./workspace/ctor.ts")
-        .parse()
-        .is_err());
+    assert!(
+        NodeHandle::from("42.176./workspace/ctor.ts")
+            .parse()
+            .is_err()
+    );
 }

--- a/src/core/corsa_client/src/api/methods_relations.rs
+++ b/src/core/corsa_client/src/api/methods_relations.rs
@@ -613,6 +613,11 @@ impl ApiClient {
     /// Returns the direct type parameters declared on a type.
     ///
     /// Missing server data is normalized to an empty vector.
+    ///
+    /// TypeScript 7 stable runtimes resolve this request inside a specific
+    /// project and reject project-less lookups; prefer
+    /// [`ApiClient::get_type_parameters_of_type_in_project`] when a project
+    /// handle is available.
     pub async fn get_type_parameters_of_type(
         &self,
         snapshot: SnapshotHandle,
@@ -626,9 +631,36 @@ impl ApiClient {
         .map(|items| items.unwrap_or_default())
     }
 
+    /// Returns the direct type parameters declared on a type.
+    ///
+    /// Project-scoped variant of [`ApiClient::get_type_parameters_of_type`].
+    /// Missing server data is normalized to an empty vector.
+    pub async fn get_type_parameters_of_type_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Vec<TypeResponse>> {
+        self.call::<Option<Vec<TypeResponse>>, _>(
+            "getTypeParametersOfType",
+            TypeProjectRequest {
+                snapshot,
+                project,
+                r#type,
+            },
+        )
+        .await
+        .map(|items| items.unwrap_or_default())
+    }
+
     /// Returns outer type parameters captured by a type.
     ///
     /// Missing server data is normalized to an empty vector.
+    ///
+    /// TypeScript 7 stable runtimes resolve this request inside a specific
+    /// project and reject project-less lookups; prefer
+    /// [`ApiClient::get_outer_type_parameters_of_type_in_project`] when a project
+    /// handle is available.
     pub async fn get_outer_type_parameters_of_type(
         &self,
         snapshot: SnapshotHandle,
@@ -642,9 +674,36 @@ impl ApiClient {
         .map(|items| items.unwrap_or_default())
     }
 
+    /// Returns outer type parameters captured by a type.
+    ///
+    /// Project-scoped variant of [`ApiClient::get_outer_type_parameters_of_type`].
+    /// Missing server data is normalized to an empty vector.
+    pub async fn get_outer_type_parameters_of_type_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Vec<TypeResponse>> {
+        self.call::<Option<Vec<TypeResponse>>, _>(
+            "getOuterTypeParametersOfType",
+            TypeProjectRequest {
+                snapshot,
+                project,
+                r#type,
+            },
+        )
+        .await
+        .map(|items| items.unwrap_or_default())
+    }
+
     /// Returns local type parameters introduced while resolving a type.
     ///
     /// Missing server data is normalized to an empty vector.
+    ///
+    /// TypeScript 7 stable runtimes resolve this request inside a specific
+    /// project and reject project-less lookups; prefer
+    /// [`ApiClient::get_local_type_parameters_of_type_in_project`] when a project
+    /// handle is available.
     pub async fn get_local_type_parameters_of_type(
         &self,
         snapshot: SnapshotHandle,
@@ -658,7 +717,34 @@ impl ApiClient {
         .map(|items| items.unwrap_or_default())
     }
 
+    /// Returns local type parameters introduced while resolving a type.
+    ///
+    /// Project-scoped variant of [`ApiClient::get_local_type_parameters_of_type`].
+    /// Missing server data is normalized to an empty vector.
+    pub async fn get_local_type_parameters_of_type_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Vec<TypeResponse>> {
+        self.call::<Option<Vec<TypeResponse>>, _>(
+            "getLocalTypeParametersOfType",
+            TypeProjectRequest {
+                snapshot,
+                project,
+                r#type,
+            },
+        )
+        .await
+        .map(|items| items.unwrap_or_default())
+    }
+
     /// Returns the object side of a wrapper type, if one exists.
+    ///
+    /// TypeScript 7 stable runtimes resolve this request inside a specific
+    /// project and reject project-less lookups; prefer
+    /// [`ApiClient::get_object_type_of_type_in_project`] when a project
+    /// handle is available.
     pub async fn get_object_type_of_type(
         &self,
         snapshot: SnapshotHandle,
@@ -668,7 +754,32 @@ impl ApiClient {
             .await
     }
 
+    /// Returns the object side of a wrapper type, if one exists.
+    ///
+    /// Project-scoped variant of [`ApiClient::get_object_type_of_type`].
+    pub async fn get_object_type_of_type_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_optional(
+            "getObjectTypeOfType",
+            TypeProjectRequest {
+                snapshot,
+                project,
+                r#type,
+            },
+        )
+        .await
+    }
+
     /// Returns the index side of a wrapper type, if one exists.
+    ///
+    /// TypeScript 7 stable runtimes resolve this request inside a specific
+    /// project and reject project-less lookups; prefer
+    /// [`ApiClient::get_index_type_of_type_in_project`] when a project
+    /// handle is available.
     pub async fn get_index_type_of_type(
         &self,
         snapshot: SnapshotHandle,
@@ -678,7 +789,32 @@ impl ApiClient {
             .await
     }
 
+    /// Returns the index side of a wrapper type, if one exists.
+    ///
+    /// Project-scoped variant of [`ApiClient::get_index_type_of_type`].
+    pub async fn get_index_type_of_type_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_optional(
+            "getIndexTypeOfType",
+            TypeProjectRequest {
+                snapshot,
+                project,
+                r#type,
+            },
+        )
+        .await
+    }
+
     /// Returns the check side of a wrapper or conditional type, if one exists.
+    ///
+    /// TypeScript 7 stable runtimes resolve this request inside a specific
+    /// project and reject project-less lookups; prefer
+    /// [`ApiClient::get_check_type_of_type_in_project`] when a project
+    /// handle is available.
     pub async fn get_check_type_of_type(
         &self,
         snapshot: SnapshotHandle,
@@ -688,7 +824,32 @@ impl ApiClient {
             .await
     }
 
+    /// Returns the check side of a wrapper or conditional type, if one exists.
+    ///
+    /// Project-scoped variant of [`ApiClient::get_check_type_of_type`].
+    pub async fn get_check_type_of_type_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_optional(
+            "getCheckTypeOfType",
+            TypeProjectRequest {
+                snapshot,
+                project,
+                r#type,
+            },
+        )
+        .await
+    }
+
     /// Returns the `extends` side of a conditional type, if one exists.
+    ///
+    /// TypeScript 7 stable runtimes resolve this request inside a specific
+    /// project and reject project-less lookups; prefer
+    /// [`ApiClient::get_extends_type_of_type_in_project`] when a project
+    /// handle is available.
     pub async fn get_extends_type_of_type(
         &self,
         snapshot: SnapshotHandle,
@@ -698,7 +859,32 @@ impl ApiClient {
             .await
     }
 
+    /// Returns the `extends` side of a conditional type, if one exists.
+    ///
+    /// Project-scoped variant of [`ApiClient::get_extends_type_of_type`].
+    pub async fn get_extends_type_of_type_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_optional(
+            "getExtendsTypeOfType",
+            TypeProjectRequest {
+                snapshot,
+                project,
+                r#type,
+            },
+        )
+        .await
+    }
+
     /// Returns the base type recorded directly on a type, if one exists.
+    ///
+    /// TypeScript 7 stable runtimes resolve this request inside a specific
+    /// project and reject project-less lookups; prefer
+    /// [`ApiClient::get_base_type_of_type_in_project`] when a project
+    /// handle is available.
     pub async fn get_base_type_of_type(
         &self,
         snapshot: SnapshotHandle,
@@ -706,6 +892,26 @@ impl ApiClient {
     ) -> Result<Option<TypeResponse>> {
         self.call_optional("getBaseTypeOfType", TypeOnlyRequest { snapshot, r#type })
             .await
+    }
+
+    /// Returns the base type recorded directly on a type, if one exists.
+    ///
+    /// Project-scoped variant of [`ApiClient::get_base_type_of_type`].
+    pub async fn get_base_type_of_type_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_optional(
+            "getBaseTypeOfType",
+            TypeProjectRequest {
+                snapshot,
+                project,
+                r#type,
+            },
+        )
+        .await
     }
 
     /// Returns the constraint recorded directly on a type, if one exists.

--- a/src/core/corsa_client/src/api/methods_symbols.rs
+++ b/src/core/corsa_client/src/api/methods_symbols.rs
@@ -15,6 +15,7 @@ use super::{
     },
     requests_symbols::{
         NodeBatchRequest, PositionBatchRequest, SymbolBatchRequest, SymbolOnlyRequest,
+        SymbolProjectRequest,
     },
 };
 use crate::Result;
@@ -256,6 +257,11 @@ impl ApiClient {
     }
 
     /// Returns the parent symbol of `symbol`, if any.
+    ///
+    /// TypeScript 7 stable runtimes resolve this request inside a specific
+    /// project and reject project-less lookups; prefer
+    /// [`ApiClient::get_parent_of_symbol_in_project`] when a project
+    /// handle is available.
     pub async fn get_parent_of_symbol(
         &self,
         snapshot: SnapshotHandle,
@@ -265,9 +271,34 @@ impl ApiClient {
             .await
     }
 
+    /// Returns the parent symbol of `symbol`, if any.
+    ///
+    /// Project-scoped variant of [`ApiClient::get_parent_of_symbol`].
+    pub async fn get_parent_of_symbol_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        symbol: SymbolHandle,
+    ) -> Result<Option<SymbolResponse>> {
+        self.call_optional(
+            "getParentOfSymbol",
+            SymbolProjectRequest {
+                snapshot,
+                project,
+                symbol,
+            },
+        )
+        .await
+    }
+
     /// Returns member symbols directly attached to `symbol`.
     ///
     /// Missing server data is normalized to an empty vector.
+    ///
+    /// TypeScript 7 stable runtimes resolve this request inside a specific
+    /// project and reject project-less lookups; prefer
+    /// [`ApiClient::get_members_of_symbol_in_project`] when a project
+    /// handle is available.
     pub async fn get_members_of_symbol(
         &self,
         snapshot: SnapshotHandle,
@@ -281,9 +312,37 @@ impl ApiClient {
         .map(|items| items.unwrap_or_default())
     }
 
+    /// Returns member symbols directly attached to `symbol`.
+    ///
+    /// Missing server data is normalized to an empty vector.
+    ///
+    /// Project-scoped variant of [`ApiClient::get_members_of_symbol`].
+    pub async fn get_members_of_symbol_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        symbol: SymbolHandle,
+    ) -> Result<Vec<SymbolResponse>> {
+        self.call::<Option<Vec<SymbolResponse>>, _>(
+            "getMembersOfSymbol",
+            SymbolProjectRequest {
+                snapshot,
+                project,
+                symbol,
+            },
+        )
+        .await
+        .map(|items| items.unwrap_or_default())
+    }
+
     /// Returns exported symbols directly attached to `symbol`.
     ///
     /// Missing server data is normalized to an empty vector.
+    ///
+    /// TypeScript 7 stable runtimes resolve this request inside a specific
+    /// project and reject project-less lookups; prefer
+    /// [`ApiClient::get_exports_of_symbol_in_project`] when a project
+    /// handle is available.
     pub async fn get_exports_of_symbol(
         &self,
         snapshot: SnapshotHandle,
@@ -297,10 +356,38 @@ impl ApiClient {
         .map(|items| items.unwrap_or_default())
     }
 
+    /// Returns exported symbols directly attached to `symbol`.
+    ///
+    /// Missing server data is normalized to an empty vector.
+    ///
+    /// Project-scoped variant of [`ApiClient::get_exports_of_symbol`].
+    pub async fn get_exports_of_symbol_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        symbol: SymbolHandle,
+    ) -> Result<Vec<SymbolResponse>> {
+        self.call::<Option<Vec<SymbolResponse>>, _>(
+            "getExportsOfSymbol",
+            SymbolProjectRequest {
+                snapshot,
+                project,
+                symbol,
+            },
+        )
+        .await
+        .map(|items| items.unwrap_or_default())
+    }
+
     /// Returns the export-facing symbol associated with `symbol`.
     ///
     /// Unlike many other helpers in this group, this endpoint is expected to
     /// succeed with a concrete symbol response.
+    ///
+    /// TypeScript 7 stable runtimes resolve this request inside a specific
+    /// project and reject project-less lookups; prefer
+    /// [`ApiClient::get_export_symbol_of_symbol_in_project`] when a project
+    /// handle is available.
     pub async fn get_export_symbol_of_symbol(
         &self,
         snapshot: SnapshotHandle,
@@ -309,6 +396,29 @@ impl ApiClient {
         self.call(
             "getExportSymbolOfSymbol",
             SymbolOnlyRequest { snapshot, symbol },
+        )
+        .await
+    }
+
+    /// Returns the export-facing symbol associated with `symbol`.
+    ///
+    /// Unlike many other helpers in this group, this endpoint is expected to
+    /// succeed with a concrete symbol response.
+    ///
+    /// Project-scoped variant of [`ApiClient::get_export_symbol_of_symbol`].
+    pub async fn get_export_symbol_of_symbol_in_project(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        symbol: SymbolHandle,
+    ) -> Result<SymbolResponse> {
+        self.call(
+            "getExportSymbolOfSymbol",
+            SymbolProjectRequest {
+                snapshot,
+                project,
+                symbol,
+            },
         )
         .await
     }

--- a/src/core/corsa_client/src/api/requests_symbols.rs
+++ b/src/core/corsa_client/src/api/requests_symbols.rs
@@ -36,6 +36,14 @@ pub(crate) struct SymbolOnlyRequest {
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub(crate) struct SymbolProjectRequest {
+    pub snapshot: SnapshotHandle,
+    pub project: ProjectHandle,
+    pub symbol: SymbolHandle,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct TypeOnlyRequest {
     pub snapshot: SnapshotHandle,
     pub r#type: TypeHandle,

--- a/src/core/corsa_core/Cargo.toml
+++ b/src/core/corsa_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_core"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 description = "Shared errors, process lifecycle helpers, and fast-path primitives for corsa"
 publish = ["crates-io"]

--- a/src/core/corsa_jsonrpc/Cargo.toml
+++ b/src/core/corsa_jsonrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_jsonrpc"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 description = "JSON-RPC framing and thread-backed transport helpers for corsa"
 publish = ["crates-io"]
@@ -20,5 +20,5 @@ log = { workspace = true }
 parking_lot = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-corsa_core = { version = "1.7.1", path = "../corsa_core" }
-corsa_runtime = { version = "1.7.1", path = "../corsa_runtime" }
+corsa_core = { version = "1.8.0", path = "../corsa_core" }
+corsa_runtime = { version = "1.8.0", path = "../corsa_runtime" }

--- a/src/core/corsa_lsp/Cargo.toml
+++ b/src/core/corsa_lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_lsp"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 description = "LSP-focused clients, overlays, and virtual documents for Corsa"
 publish = ["crates-io"]
@@ -20,6 +20,6 @@ log = { workspace = true }
 lsp-types = "0.97"
 parking_lot = "0.12"
 serde = { version = "1", features = ["derive"] }
-corsa_core = { version = "1.7.1", path = "../corsa_core" }
-corsa_jsonrpc = { version = "1.7.1", path = "../corsa_jsonrpc" }
-corsa_runtime = { version = "1.7.1", path = "../corsa_runtime" }
+corsa_core = { version = "1.8.0", path = "../corsa_core" }
+corsa_jsonrpc = { version = "1.8.0", path = "../corsa_jsonrpc" }
+corsa_runtime = { version = "1.8.0", path = "../corsa_runtime" }

--- a/src/core/corsa_orchestrator/Cargo.toml
+++ b/src/core/corsa_orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_orchestrator"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 description = "Worker pooling, caching, and experimental replicated orchestration for corsa"
 publish = ["crates-io"]
@@ -25,7 +25,7 @@ lsp-types = "0.97"
 parking_lot = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-corsa_client = { version = "1.7.1", path = "../corsa_client" }
-corsa_core = { version = "1.7.1", path = "../corsa_core" }
-corsa_lsp = { version = "1.7.1", path = "../corsa_lsp" }
-corsa_runtime = { version = "1.7.1", path = "../corsa_runtime" }
+corsa_client = { version = "1.8.0", path = "../corsa_client" }
+corsa_core = { version = "1.8.0", path = "../corsa_core" }
+corsa_lsp = { version = "1.8.0", path = "../corsa_lsp" }
+corsa_runtime = { version = "1.8.0", path = "../corsa_runtime" }

--- a/src/core/corsa_ref/Cargo.toml
+++ b/src/core/corsa_ref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_ref"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 description = "Pinned upstream ref management and verification tooling for corsa"
 publish = false
@@ -22,7 +22,7 @@ path = "src/main.rs"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 toml = "1.1"
-corsa_core = { version = "1.7.1", path = "../corsa_core" }
+corsa_core = { version = "1.8.0", path = "../corsa_core" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/core/corsa_runtime/Cargo.toml
+++ b/src/core/corsa_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corsa_runtime"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 description = "Small executor, task primitives, and broadcast channels for corsa"
 publish = ["crates-io"]


### PR DESCRIPTION
Closes #440, closes #441 — and the nine unreported endpoints that were broken the same way.

## Why these two issues are one bug

`getTypesOfType` threw `empty project ID for type handle <n>` because `callType`/`callTypeArray` in `session.ts` sent only `{ snapshot, type }`. Those two helpers back **ten** relation endpoints, so `getTargetOfType`, `getTypeParametersOfType`, `getOuterTypeParametersOfType`, `getLocalTypeParametersOfType`, `getObjectTypeOfType`, `getIndexTypeOfType`, `getCheckTypeOfType`, `getExtendsTypeOfType`, and `getBaseTypeOfType` carried the identical break. They went unreported only because their client-side flag guards make them fire rarely.

Requests now name the project that **issued** the handle rather than the snapshot's first project — which is also the correct answer once a snapshot spans several projects.

`#441` is the same story one layer down: stable runtimes issue compact declaration handles (`<node id>.<syntax kind>.<path>`) that `NodeHandle::parse` rejects, so constructor parameter-name recovery gave up before it started.

## Why it kept happening

This is the thirteenth issue in the family (#384, #389, #390, #392, #393, #395, #410, #413, #416, #418, #427, #440, #441). Each was fixed one endpoint at a time because **nothing in CI could observe the class**:

| Gap | Fix |
|---|---|
| `mock_corsa` answered project-less requests that upstream rejects | mock now enforces the same per-project contract, so mock-backed tests fail on traffic a real runtime refuses |
| TS integration suites degrade to `it.skip` without a real binary — and **no CI job ever provided one** | `real-corsa-smoke` now runs `test_ts` with `CORSA_REQUIRE_INTEGRATION=1`, which makes a missing runtime a failure |
| `real-corsa-smoke` skipped pull requests entirely and was not in the quality gate | now runs the ubuntu leg on PRs and gates `quality` |

The new `project_scoped_requests` suite asserts the contract over **recorded protocol traffic** rather than a hand-maintained endpoint list, so endpoints added later are covered as soon as anything calls them. Reverting the fix makes it name the offenders:

```
AssertionError: expected [ Array(3) ] to deeply equal []
+   "getLocalTypeParametersOfType",
+   "getOuterTypeParametersOfType",
+   "getTypeParametersOfType",
```

## API additions (minor)

Twelve `*_in_project` `ApiClient` variants for endpoints that previously only had a project-less form, plus `NodeHandle::declaring_path`.

## Verification

`cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `vp check --no-fmt`, and the Node suites all pass. Parameter recovery refuses to guess: it accepts a whole-file match only when exactly one parameter list matches the signature's arity, covered by unit tests for the unique, ambiguous, call-argument, and zero-parameter cases.

Two notes for the reviewer:

- **`cargo fmt` was not run** — the rustfmt available in this environment predates edition-2024 style and rewrites the whole repo. Added code follows surrounding style by hand; CI's `fmt_check_rust` is the real check.
- The end-to-end proof for both issues is the new integration case in `type_location.test.ts`. It could not execute locally (building Corsa needs Go 1.26, unavailable here) and runs for the first time in this PR's `real-corsa-smoke` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789607534&installation_model_id=422833&pr_number=442&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F442&signature=9c173853719564c58ab2f7f7091cda6d29813f70d50d49d3a6c99bc731becf3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->