### PR TITLE
feat: expose the checker endpoints the binding was working around

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/project_scoped_requests.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/project_scoped_requests.test.ts
@@ -44,7 +44,16 @@ const TRAVERSAL_ACCESSORS = [
   "getConstraintOfTypeParameter",
   "getPropertiesOfType",
   "getBaseTypes",
-  "getTypeArguments",
+] as const;
+
+/**
+ * Endpoints where more than one wire call is a correct answer, so coverage is
+ * satisfied by any of them. A mapped type resolves its arguments through
+ * `getAliasTypeArgumentsOfType`, because upstream `getTypeArguments` panics on
+ * one.
+ */
+const TRAVERSAL_ALTERNATIVES = [
+  ["getTypeArguments", "getAliasTypeArgumentsOfType"],
 ] as const;
 
 interface RecordedRequest {
@@ -123,7 +132,11 @@ function driveTypeRelationSurface(paramsDir: string): readonly RecordedRequest[]
       }
     };
     const accessors = checker as unknown as Record<string, (value: unknown) => unknown>;
-    for (const accessor of [...TRAVERSAL_ACCESSORS, "getConstraintOfType"]) {
+    for (const accessor of [
+      ...TRAVERSAL_ACCESSORS,
+      ...TRAVERSAL_ALTERNATIVES.map(([accessor]) => accessor),
+      "getConstraintOfType",
+    ]) {
       attempt(() => accessors[accessor]?.(type));
     }
     attempt(() => checker.getSignaturesOfType(type as never, 0));
@@ -231,7 +244,12 @@ describe("project-scoped handle requests", () => {
 
   it("actually exercised the type-relation surface", () => {
     const methods = new Set(requests.map((request) => request.method));
-    const missing = TRAVERSAL_ACCESSORS.filter((accessor) => !methods.has(accessor));
+    const missing = [
+      ...TRAVERSAL_ACCESSORS.filter((accessor) => !methods.has(accessor)),
+      ...TRAVERSAL_ALTERNATIVES.filter(
+        (alternatives) => !alternatives.some((method) => methods.has(method)),
+      ).map((alternatives) => alternatives.join(" | ")),
+    ];
 
     expect(missing).toEqual([]);
   });

--- a/src/bindings/nodejs/corsa_oxlint/ts/project_scoped_requests.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/project_scoped_requests.test.ts
@@ -52,9 +52,7 @@ const TRAVERSAL_ACCESSORS = [
  * `getAliasTypeArgumentsOfType`, because upstream `getTypeArguments` panics on
  * one.
  */
-const TRAVERSAL_ALTERNATIVES = [
-  ["getTypeArguments", "getAliasTypeArgumentsOfType"],
-] as const;
+const TRAVERSAL_ALTERNATIVES = [["getTypeArguments", "getAliasTypeArgumentsOfType"]] as const;
 
 interface RecordedRequest {
   readonly method: string;

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/native_bridge.ts
@@ -361,7 +361,7 @@ function callFactsOfNode(context: ContextWithParserOptions, node: any): Record<s
   if (signatureFacts.explicitTypeArgumentsRequired !== undefined) {
     facts.explicitTypeArgumentsRequired = signatureFacts.explicitTypeArgumentsRequired;
   }
-  const typeArgumentFacts = typeArgumentFactsOfCall(node, signatureFacts);
+  const typeArgumentFacts = typeArgumentFactsOfCall(context, node, signatureFacts);
   for (const [key, value] of Object.entries(typeArgumentFacts)) {
     facts[key] = value;
   }
@@ -514,7 +514,71 @@ function typeArgumentNodes(node: any): readonly any[] {
   return candidates.find(Array.isArray) ?? [];
 }
 
+/**
+ * Returns the defaults declared on the type parameters of the callee, when the
+ * callee is declared in the file being linted.
+ *
+ * Each entry is the rendered default text, or an empty string for a type
+ * parameter without one, so the result aligns with the type parameter list.
+ * Returns `undefined` when the declaration is not visible here, which keeps a
+ * caller from mistaking "no defaults" for "not found".
+ */
+function declaredTypeParameterDefaults(
+  context: ContextWithParserOptions,
+  node: any,
+): readonly string[] | undefined {
+  const name = identifierName(stripChainExpression(node.callee));
+  if (!name) {
+    return undefined;
+  }
+  const declaration = findTypeParameterOwner((context.sourceCode as any)?.ast, name);
+  const params = declaration?.typeParameters?.params;
+  if (!Array.isArray(params)) {
+    return undefined;
+  }
+  return params.map((param: any) =>
+    param?.default ? context.sourceCode.getText(param.default).trim() : "",
+  );
+}
+
+/**
+ * Finds the declaration of `name` that carries a type parameter list.
+ *
+ * Walks the whole tree rather than a scope chain because the oxlint context
+ * does not expose scope analysis.
+ */
+function findTypeParameterOwner(root: any, name: string): any {
+  if (!root || typeof root !== "object") {
+    return undefined;
+  }
+  const stack: any[] = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current || typeof current !== "object") {
+      continue;
+    }
+    if (Array.isArray(current)) {
+      stack.push(...current);
+      continue;
+    }
+    if (current.id?.name === name && current.typeParameters?.params) {
+      return current;
+    }
+    for (const key of Object.keys(current)) {
+      if (key === "parent") {
+        continue;
+      }
+      const value = current[key];
+      if (value && typeof value === "object") {
+        stack.push(value);
+      }
+    }
+  }
+  return undefined;
+}
+
 function typeArgumentFactsOfCall(
+  context: ContextWithParserOptions,
   node: any,
   signatureFacts: CorsaCallSignatureFacts,
 ): Record<string, unknown> {
@@ -531,26 +595,76 @@ function typeArgumentFactsOfCall(
   if (listRange) {
     facts.typeArgumentListRange = listRange;
   }
+  const declaredDefaults = declaredTypeParameterDefaults(context, node);
   const parameterCount =
     signatureFacts.signature?.typeParameters?.length ??
+    declaredDefaults?.length ??
     signatureFacts.signature?.typeParameterDefaultTexts?.length ??
     0;
   if (parameterCount > 0) {
     facts.typeParameterCount = parameterCount;
   }
-  const defaultTexts = signatureFacts.signature?.typeParameterDefaultTexts ?? [];
+  // Upstream exposes no endpoint for a type parameter's default, and a stable
+  // TypeScript 7 declaration handle carries no source range to read it from.
+  // The declaration is in the AST being linted whenever it is in this file, so
+  // read it from there and only fall back to the signature's rendered texts.
+  const defaultTexts =
+    declaredDefaults ?? signatureFacts.signature?.typeParameterDefaultTexts ?? [];
   const lastIndex = typeArguments.length - 1;
   const lastDefaultText = defaultTexts[lastIndex];
   if (lastDefaultText !== undefined) {
     const hasDefault = lastDefaultText.trim().length > 0;
     facts.lastTypeParameterHasDefault = hasDefault;
-    if (hasDefault && signatureFacts.explicitTypeArgumentsRequired === false) {
-      facts.lastTypeArgumentEqualsDefault = true;
-      facts.lastTypeArgumentSameTypeFlagsAsDefault = true;
-      facts.lastTypeArgumentIdenticalToDefault = true;
+    if (hasDefault) {
+      const identical =
+        declaredDefaults !== undefined
+          ? typeNodesResolveToSameType(
+              context,
+              typeArguments[lastIndex],
+              declaredDefaultNode(context, node, lastIndex),
+            )
+          : signatureFacts.explicitTypeArgumentsRequired === false;
+      if (identical) {
+        facts.lastTypeArgumentEqualsDefault = true;
+        facts.lastTypeArgumentSameTypeFlagsAsDefault = true;
+        facts.lastTypeArgumentIdenticalToDefault = true;
+      }
     }
   }
   return facts;
+}
+
+/**
+ * Returns the AST node of the default declared on the callee's type parameter
+ * at `index`, when the callee is declared in the file being linted.
+ */
+function declaredDefaultNode(context: ContextWithParserOptions, node: any, index: number): any {
+  const name = identifierName(stripChainExpression(node.callee));
+  if (!name) {
+    return undefined;
+  }
+  const declaration = findTypeParameterOwner((context.sourceCode as any)?.ast, name);
+  return declaration?.typeParameters?.params?.[index]?.default;
+}
+
+/**
+ * Reports whether two type nodes denote the same checker type.
+ *
+ * Comparing the checker's own type identity keeps this from depending on how
+ * either type happens to be spelled.
+ */
+function typeNodesResolveToSameType(
+  context: ContextWithParserOptions,
+  left: any,
+  right: any,
+): boolean {
+  if (!left || !right) {
+    return false;
+  }
+  const checker = checkerFor(context);
+  const leftType = checker.getTypeAtLocation(left);
+  const rightType = checker.getTypeAtLocation(right);
+  return leftType !== undefined && rightType !== undefined && leftType.id === rightType.id;
 }
 
 function typeArgumentListRange(

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -64,6 +64,11 @@ const objectFlags = {
   mapped: 1 << 5,
 } as const;
 
+const symbolFlags = {
+  /** `SymbolFlags.TypeLiteral` — the checker's anonymous `__type` symbol. */
+  typeLiteral: 1 << 11,
+} as const;
+
 export class CorsaProjectSession {
   #client?: CorsaApiClient;
   #config?: { options: unknown; fileNames: string[] };
@@ -268,6 +273,19 @@ export class CorsaProjectSession {
     }
     if (type.symbol) {
       const symbol = this.getSymbol(type.symbol);
+      if (isUsableSymbol(symbol) && !isAnonymousTypeLiteralSymbol(symbol)) {
+        this.recoverDeclarationPositionsForSymbol(type, symbol);
+        this.#symbolsByTypeId.set(type.id, symbol);
+        return symbol;
+      }
+      // The checker names an anonymous type `__type`, which tells a rule
+      // nothing. A mapped utility type like `Readonly<Dog>` still carries the
+      // alias the source actually wrote, so prefer that.
+      const alias = this.aliasSymbol(type);
+      if (alias) {
+        this.#symbolsByTypeId.set(type.id, alias);
+        return alias;
+      }
       if (isUsableSymbol(symbol)) {
         this.recoverDeclarationPositionsForSymbol(type, symbol);
         this.#symbolsByTypeId.set(type.id, symbol);
@@ -872,6 +890,15 @@ export class CorsaProjectSession {
 
   getTypeArguments(type: CorsaType): readonly CorsaType[] {
     return this.withMissingTypeHandleFallback<readonly CorsaType[]>(type, [], () => {
+      // A mapped utility type such as `Readonly<Dog>` writes its argument
+      // through an alias, and upstream `getTypeArguments` panics on it. The
+      // checker still knows the alias arguments, and unlike the source-range
+      // fallback below it answers with real type handles, so the result stays
+      // usable for follow-up lookups like `getBaseTypes`.
+      const aliasArguments = this.aliasTypeArguments(type);
+      if (aliasArguments.length > 0) {
+        return aliasArguments;
+      }
       const source = this.sourceSliceForType(type);
       return this.rememberTypes(
         source
@@ -893,6 +920,48 @@ export class CorsaProjectSession {
             ) as unknown as readonly CorsaType[]),
       );
     });
+  }
+
+  /**
+   * Returns the type arguments a type was written with through a type alias.
+   *
+   * Empty when the type is not aliased, which is the common case.
+   */
+  private aliasTypeArguments(type: CorsaType): readonly CorsaType[] {
+    if (((type.objectFlags ?? 0) & objectFlags.mapped) === 0) {
+      return [];
+    }
+    try {
+      return this.rememberTypes(
+        this.client().callJson<readonly CorsaType[] | null>("getAliasTypeArgumentsOfType", {
+          snapshot: this.#snapshot,
+          project: this.projectIdForType(type),
+          type: type.id,
+        }) ?? [],
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Returns the alias symbol a type was written through, if any.
+   *
+   * The checker names an anonymous mapped type `__type`; the alias is what the
+   * source actually said, so it is the symbol a rule wants to see.
+   */
+  private aliasSymbol(type: CorsaType): CorsaSymbol | undefined {
+    try {
+      return this.rememberUsableSymbol(
+        this.client().callJson<CorsaSymbol | null>("getAliasSymbolOfType", {
+          snapshot: this.#snapshot,
+          project: this.projectIdForType(type),
+          type: type.id,
+        }),
+      );
+    } catch {
+      return undefined;
+    }
   }
 
   getTypesOfType(type: CorsaType): readonly CorsaType[] {
@@ -1503,6 +1572,15 @@ function isArrayOrTupleLikeType(session: CorsaProjectSession, type: CorsaType): 
 
 function isUsableSymbol(symbol: CorsaSymbol | null | undefined): symbol is CorsaSymbol {
   return symbol != null && !symbol.name.includes("\ufffd");
+}
+
+/**
+ * Reports whether a symbol is the checker's anonymous type-literal symbol.
+ *
+ * These are reported as `__type` and carry no information a rule can act on.
+ */
+function isAnonymousTypeLiteralSymbol(symbol: CorsaSymbol | undefined): boolean {
+  return symbol !== undefined && (symbol.flags & symbolFlags.typeLiteral) !== 0;
 }
 
 function isSyntheticTypeHandle(handle: string): boolean {

--- a/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
@@ -93,6 +93,43 @@ pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
             {
                 Some(mapped_utility_argument(MAPPED_UTILITY_STRUCTURAL_ARGUMENT))
             }
+            // Checker endpoints that map one type to another.
+            "getApparentType"
+            | "getNonNullableType"
+            | "getWidenedType"
+            | "getBaseConstraintOfType"
+            | "getFreshTypeOfType"
+            | "getRegularTypeOfType"
+            | "getTrueTypeOfConditionalType"
+            | "getFalseTypeOfConditionalType"
+            | "getTypeFromTypeNode"
+            | "getParameterType" => Some(common::type_response("t0000000000000001")),
+            // Checker predicates. Answering these is what lets the binding stop
+            // deciding type shape by parsing rendered type text.
+            "isArrayType" | "isTupleType" | "isArrayLikeType" | "isTypeAssignableTo" => {
+                Some(json!(true))
+            }
+            "getAliasTypeArgumentsOfType" | "getTypeParametersOfSignature" => {
+                Some(json!([common::type_response("t0000000000000001")]))
+            }
+            "getResolvedSignature" | "getSignatureFromDeclaration" | "getTargetOfSignature" => {
+                Some(common::signature())
+            }
+            "getAliasSymbolOfType"
+            | "getAliasedSymbol"
+            | "getImmediateAliasedSymbol"
+            | "getPropertyOfType"
+            | "getMemberInModuleExports"
+            | "getExportSpecifierLocalTargetSymbol" => Some(common::symbol("value")),
+            "getExportsOfModule" => Some(json!([common::symbol("value")])),
+            "getJsDocTags" => Some(json!([{ "name": "deprecated", "text": "use other" }])),
+            "getDocumentationComment" => Some(json!("docs")),
+            "getConstantValue" => Some(json!(42)),
+            "getWellKnownSymbols" => Some(json!({
+                "unknown": "s0000000000000001",
+                "undefined": "s0000000000000002",
+                "arguments": "s0000000000000003",
+            })),
             "getTypeOfSymbol"
             | "getDeclaredTypeOfSymbol"
             | "getTypeAtLocation"

--- a/src/bindings/rust/corsa/tests/api_async.rs
+++ b/src/bindings/rust/corsa/tests/api_async.rs
@@ -787,3 +787,330 @@ fn async_api_supports_capabilities_overlay_diagnostics_and_editor_surface() {
         client.close().await.unwrap();
     });
 }
+
+/// Exercises the checker endpoints the client exposes for type-aware tooling.
+///
+/// These answer questions the binding used to decide by parsing rendered type
+/// text or re-reading source: assignability, array/tuple shape, apparent and
+/// non-nullable forms, alias identity, and a signature's own parameters.
+#[test]
+fn async_api_exposes_checker_endpoints_for_type_aware_tooling() {
+    block_on(async {
+        let client = ApiClient::spawn(support::api_config(ApiMode::AsyncJsonRpcStdio))
+            .await
+            .unwrap();
+        let snapshot = client
+            .update_snapshot(UpdateSnapshotParams {
+                open_project: Some("/workspace/tsconfig.json".into()),
+                file_changes: None,
+                overlay_changes: None,
+            })
+            .await
+            .unwrap();
+        let project = snapshot.projects[0].id.clone();
+        let node = corsa::api::NodeHandle("1.3.80./workspace/src/index.ts".into());
+        let ty = client
+            .get_type_at_location(snapshot.handle.clone(), project.clone(), node.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        let symbol = client
+            .get_symbol_at_location(snapshot.handle.clone(), project.clone(), node.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        let signature = client
+            .get_signatures_of_type(snapshot.handle.clone(), project.clone(), ty.id.clone(), 0)
+            .await
+            .unwrap()
+            .remove(0);
+
+        // Checker predicates, not type-text inspection.
+        assert!(
+            client
+                .is_type_assignable_to(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    ty.id.clone(),
+                    ty.id.clone()
+                )
+                .await
+                .unwrap()
+        );
+        for predicate in ["is_array_type", "is_tuple_type", "is_array_like_type"] {
+            let answered = match predicate {
+                "is_array_type" => {
+                    client
+                        .is_array_type(snapshot.handle.clone(), project.clone(), ty.id.clone())
+                        .await
+                }
+                "is_tuple_type" => {
+                    client
+                        .is_tuple_type(snapshot.handle.clone(), project.clone(), ty.id.clone())
+                        .await
+                }
+                _ => {
+                    client
+                        .is_array_like_type(snapshot.handle.clone(), project.clone(), ty.id.clone())
+                        .await
+                }
+            };
+            assert!(answered.unwrap(), "{predicate} should reach the checker");
+        }
+
+        // Type normalization.
+        for normalized in [
+            client
+                .get_apparent_type(snapshot.handle.clone(), project.clone(), ty.id.clone())
+                .await
+                .unwrap(),
+            client
+                .get_non_nullable_type(snapshot.handle.clone(), project.clone(), ty.id.clone())
+                .await
+                .unwrap(),
+            client
+                .get_widened_type(snapshot.handle.clone(), project.clone(), ty.id.clone())
+                .await
+                .unwrap(),
+            client
+                .get_base_constraint_of_type(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    ty.id.clone(),
+                )
+                .await
+                .unwrap(),
+            client
+                .get_fresh_type_of_type(snapshot.handle.clone(), project.clone(), ty.id.clone())
+                .await
+                .unwrap(),
+            client
+                .get_regular_type_of_type(snapshot.handle.clone(), project.clone(), ty.id.clone())
+                .await
+                .unwrap(),
+            client
+                .get_true_type_of_conditional_type(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    ty.id.clone(),
+                )
+                .await
+                .unwrap(),
+            client
+                .get_false_type_of_conditional_type(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    ty.id.clone(),
+                )
+                .await
+                .unwrap(),
+            client
+                .get_type_from_type_node(snapshot.handle.clone(), project.clone(), node.clone())
+                .await
+                .unwrap(),
+        ] {
+            assert!(normalized.is_some());
+        }
+
+        // Signature structure straight from the checker.
+        assert_eq!(
+            client
+                .get_parameters_of_signature(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    signature.id.clone()
+                )
+                .await
+                .unwrap()
+                .iter()
+                .map(|parameter| parameter.name.as_str())
+                .collect::<Vec<_>>(),
+            ["first", "second"]
+        );
+        assert!(
+            client
+                .get_this_parameter_of_signature(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    signature.id.clone()
+                )
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(
+            client
+                .get_type_parameters_of_signature(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    signature.id.clone()
+                )
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(
+            client
+                .get_parameter_type(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    signature.id.clone(),
+                    0
+                )
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            client
+                .get_target_of_signature(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    signature.id.clone()
+                )
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            client
+                .get_resolved_signature(snapshot.handle.clone(), project.clone(), node.clone())
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            client
+                .get_signature_from_declaration(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    node.clone()
+                )
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        // Alias and module identity.
+        assert!(
+            client
+                .get_alias_symbol_of_type(snapshot.handle.clone(), project.clone(), ty.id.clone())
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(
+            client
+                .get_alias_type_arguments_of_type(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    ty.id.clone()
+                )
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(
+            client
+                .get_aliased_symbol(snapshot.handle.clone(), project.clone(), symbol.id.clone())
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            client
+                .get_immediate_aliased_symbol(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    symbol.id.clone()
+                )
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(
+            client
+                .get_exports_of_module(snapshot.handle.clone(), project.clone(), symbol.id.clone())
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(
+            client
+                .get_member_in_module_exports(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    symbol.id.clone(),
+                    "value"
+                )
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            client
+                .get_export_specifier_local_target_symbol(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    node.clone()
+                )
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            client
+                .get_property_of_type(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    ty.id.clone(),
+                    "value"
+                )
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        // Documentation and constants.
+        assert_eq!(
+            client
+                .get_js_doc_tags(snapshot.handle.clone(), project.clone(), symbol.id.clone())
+                .await
+                .unwrap()[0]
+                .name,
+            "deprecated"
+        );
+        assert_eq!(
+            client
+                .get_documentation_comment(
+                    snapshot.handle.clone(),
+                    project.clone(),
+                    symbol.id.clone()
+                )
+                .await
+                .unwrap(),
+            "docs"
+        );
+        assert_eq!(
+            client
+                .get_constant_value(snapshot.handle.clone(), project.clone(), node.clone())
+                .await
+                .unwrap(),
+            Some(serde_json::json!(42))
+        );
+        assert_eq!(
+            client
+                .get_well_known_symbols(snapshot.handle.clone(), project.clone())
+                .await
+                .unwrap()
+                .undefined
+                .as_str(),
+            "s0000000000000002"
+        );
+
+        client.close().await.unwrap();
+    });
+}

--- a/src/core/corsa_client/src/api/methods_relations.rs
+++ b/src/core/corsa_client/src/api/methods_relations.rs
@@ -7,6 +7,7 @@ use super::{
     ApiClient, IndexInfo, ProjectHandle, SignatureHandle, SnapshotHandle, SymbolHandle, TypeHandle,
     TypePredicateResponse, TypeResponse,
     requests_symbols::{SignatureOnlyRequest, TypeOnlyRequest, TypeProjectRequest},
+    requests_types::{ParameterTypeRequest, TypeLocationRequest},
 };
 use crate::Result;
 use corsa_core::utils::split_top_level_type_text;
@@ -64,6 +65,146 @@ impl ApiClient {
             },
         )
         .await
+    }
+
+    /// Returns the signature the checker resolves a call-like node to.
+    ///
+    /// This is the entry point for rules that reason about an actual call
+    /// rather than a type's declared signatures.
+    pub async fn get_resolved_signature(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        location: super::NodeHandle,
+    ) -> Result<Option<super::SignatureResponse>> {
+        self.call_optional(
+            "getResolvedSignature",
+            TypeLocationRequest {
+                snapshot,
+                project,
+                location,
+            },
+        )
+        .await
+    }
+
+    /// Returns the signature a declaration node produces.
+    pub async fn get_signature_from_declaration(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        location: super::NodeHandle,
+    ) -> Result<Option<super::SignatureResponse>> {
+        self.call_optional(
+            "getSignatureFromDeclaration",
+            TypeLocationRequest {
+                snapshot,
+                project,
+                location,
+            },
+        )
+        .await
+    }
+
+    /// Returns the generic type parameters declared on a signature.
+    ///
+    /// Missing server data is normalized to an empty vector.
+    pub async fn get_type_parameters_of_signature(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        signature: SignatureHandle,
+    ) -> Result<Vec<TypeResponse>> {
+        self.call::<Option<Vec<TypeResponse>>, _>(
+            "getTypeParametersOfSignature",
+            SignatureOnlyRequest {
+                snapshot,
+                project,
+                signature,
+            },
+        )
+        .await
+        .map(|items| items.unwrap_or_default())
+    }
+
+    /// Returns the target signature an instantiated signature came from.
+    pub async fn get_target_of_signature(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        signature: SignatureHandle,
+    ) -> Result<Option<super::SignatureResponse>> {
+        self.call_optional(
+            "getTargetOfSignature",
+            SignatureOnlyRequest {
+                snapshot,
+                project,
+                signature,
+            },
+        )
+        .await
+    }
+
+    /// Returns the type of the parameter at `index` in a signature.
+    ///
+    /// Unlike resolving the parameter symbol and asking for its type, this
+    /// accounts for rest parameters expanded at the given position.
+    pub async fn get_parameter_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        signature: SignatureHandle,
+        index: i32,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_optional(
+            "getParameterType",
+            ParameterTypeRequest {
+                snapshot,
+                project,
+                signature,
+                index,
+            },
+        )
+        .await
+    }
+
+    /// Returns the alias symbol a type was written through, if any.
+    pub async fn get_alias_symbol_of_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<super::SymbolResponse>> {
+        self.call_optional(
+            "getAliasSymbolOfType",
+            TypeProjectRequest {
+                snapshot,
+                project,
+                r#type,
+            },
+        )
+        .await
+    }
+
+    /// Returns the type arguments supplied to a type's alias, if any.
+    ///
+    /// Missing server data is normalized to an empty vector.
+    pub async fn get_alias_type_arguments_of_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Vec<TypeResponse>> {
+        self.call::<Option<Vec<TypeResponse>>, _>(
+            "getAliasTypeArgumentsOfType",
+            TypeProjectRequest {
+                snapshot,
+                project,
+                r#type,
+            },
+        )
+        .await
+        .map(|items| items.unwrap_or_default())
     }
 
     /// Returns the parameter symbols of a signature, in declaration order.

--- a/src/core/corsa_client/src/api/methods_symbols.rs
+++ b/src/core/corsa_client/src/api/methods_symbols.rs
@@ -17,6 +17,7 @@ use super::{
         NodeBatchRequest, PositionBatchRequest, SymbolBatchRequest, SymbolOnlyRequest,
         SymbolProjectRequest,
     },
+    requests_types::{MemberInModuleExportsRequest, TypeLocationRequest},
 };
 use crate::Result;
 
@@ -414,6 +415,177 @@ impl ApiClient {
     ) -> Result<SymbolResponse> {
         self.call(
             "getExportSymbolOfSymbol",
+            SymbolProjectRequest {
+                snapshot,
+                project,
+                symbol,
+            },
+        )
+        .await
+    }
+
+    /// Returns the symbol an alias resolves to, following the whole chain.
+    pub async fn get_aliased_symbol(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        symbol: SymbolHandle,
+    ) -> Result<Option<SymbolResponse>> {
+        self.call_symbol_property("getAliasedSymbol", snapshot, project, symbol)
+            .await
+    }
+
+    /// Returns the symbol an alias resolves to, following one step only.
+    pub async fn get_immediate_aliased_symbol(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        symbol: SymbolHandle,
+    ) -> Result<Option<SymbolResponse>> {
+        self.call_symbol_property("getImmediateAliasedSymbol", snapshot, project, symbol)
+            .await
+    }
+
+    /// Returns the exported symbols of a module symbol.
+    ///
+    /// Missing server data is normalized to an empty vector.
+    pub async fn get_exports_of_module(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        symbol: SymbolHandle,
+    ) -> Result<Vec<SymbolResponse>> {
+        self.call::<Option<Vec<SymbolResponse>>, _>(
+            "getExportsOfModule",
+            SymbolProjectRequest {
+                snapshot,
+                project,
+                symbol,
+            },
+        )
+        .await
+        .map(|items| items.unwrap_or_default())
+    }
+
+    /// Returns a named export of a module symbol, if it has one.
+    pub async fn get_member_in_module_exports(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        symbol: SymbolHandle,
+        name: impl Into<String>,
+    ) -> Result<Option<SymbolResponse>> {
+        self.call_optional(
+            "getMemberInModuleExports",
+            MemberInModuleExportsRequest {
+                snapshot,
+                project,
+                symbol,
+                name: name.into(),
+            },
+        )
+        .await
+    }
+
+    /// Returns the local target symbol of an export specifier node.
+    pub async fn get_export_specifier_local_target_symbol(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        location: NodeHandle,
+    ) -> Result<Option<SymbolResponse>> {
+        self.call_optional(
+            "getExportSpecifierLocalTargetSymbol",
+            TypeLocationRequest {
+                snapshot,
+                project,
+                location,
+            },
+        )
+        .await
+    }
+
+    /// Returns the JSDoc tags attached to a symbol.
+    ///
+    /// Missing server data is normalized to an empty vector.
+    pub async fn get_js_doc_tags(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        symbol: SymbolHandle,
+    ) -> Result<Vec<super::JsDocTagInfo>> {
+        self.call::<Option<Vec<super::JsDocTagInfo>>, _>(
+            "getJsDocTags",
+            SymbolProjectRequest {
+                snapshot,
+                project,
+                symbol,
+            },
+        )
+        .await
+        .map(|items| items.unwrap_or_default())
+    }
+
+    /// Returns the rendered documentation comment of a symbol.
+    pub async fn get_documentation_comment(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        symbol: SymbolHandle,
+    ) -> Result<String> {
+        self.call(
+            "getDocumentationComment",
+            SymbolProjectRequest {
+                snapshot,
+                project,
+                symbol,
+            },
+        )
+        .await
+    }
+
+    /// Returns the compile-time constant an enum member or literal node folds
+    /// to, if the checker can compute one.
+    pub async fn get_constant_value(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        location: NodeHandle,
+    ) -> Result<Option<serde_json::Value>> {
+        self.call_optional(
+            "getConstantValue",
+            TypeLocationRequest {
+                snapshot,
+                project,
+                location,
+            },
+        )
+        .await
+    }
+
+    /// Returns handles for the checker's intrinsic well-known symbols.
+    pub async fn get_well_known_symbols(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+    ) -> Result<super::WellKnownSymbolsResponse> {
+        self.call(
+            "getWellKnownSymbols",
+            super::requests_core::IntrinsicTypeRequest { snapshot, project },
+        )
+        .await
+    }
+
+    /// Shared helper for endpoints that map one symbol to another.
+    async fn call_symbol_property(
+        &self,
+        method: &str,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        symbol: SymbolHandle,
+    ) -> Result<Option<SymbolResponse>> {
+        self.call_optional(
+            method,
             SymbolProjectRequest {
                 snapshot,
                 project,

--- a/src/core/corsa_client/src/api/methods_types.rs
+++ b/src/core/corsa_client/src/api/methods_types.rs
@@ -12,7 +12,10 @@ use super::{
     encoded::PrintNodeOptions,
     requests_core::{IntrinsicTypeRequest, TypeNodeRequest},
     requests_symbols::{PositionBatchRequest, TypeProjectRequest},
-    requests_types::{PrintNodeRequest, SignatureOfTypeRequest, TypeLocationRequest},
+    requests_types::{
+        PrintNodeRequest, PropertyOfTypeRequest, SignatureOfTypeRequest, TypeAssignabilityRequest,
+        TypeLocationRequest,
+    },
 };
 use crate::Result;
 
@@ -154,6 +157,231 @@ impl ApiClient {
     ) -> Result<Option<TypeResponse>> {
         self.call_optional(
             "getBaseTypeOfLiteralType",
+            TypeProjectRequest {
+                snapshot,
+                project,
+                r#type,
+            },
+        )
+        .await
+    }
+
+    /// Returns whether `source` is assignable to `target`.
+    ///
+    /// This is the checker's own assignability relation, and the primitive most
+    /// type-aware lint rules are built on. Prefer it over comparing rendered
+    /// type texts, which cannot model structural assignability.
+    pub async fn is_type_assignable_to(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        source: TypeHandle,
+        target: TypeHandle,
+    ) -> Result<bool> {
+        self.call(
+            "isTypeAssignableTo",
+            TypeAssignabilityRequest {
+                snapshot,
+                project,
+                source,
+                target,
+            },
+        )
+        .await
+    }
+
+    /// Returns whether a type is an array type.
+    pub async fn is_array_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<bool> {
+        self.call_type_predicate("isArrayType", snapshot, project, r#type)
+            .await
+    }
+
+    /// Returns whether a type is a tuple type.
+    pub async fn is_tuple_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<bool> {
+        self.call_type_predicate("isTupleType", snapshot, project, r#type)
+            .await
+    }
+
+    /// Returns whether a type is array-like.
+    pub async fn is_array_like_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<bool> {
+        self.call_type_predicate("isArrayLikeType", snapshot, project, r#type)
+            .await
+    }
+
+    /// Returns the apparent type of a type.
+    ///
+    /// This resolves type parameters to their constraints and primitives to
+    /// their wrapper types, which is what property lookups see.
+    pub async fn get_apparent_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_type_property("getApparentType", snapshot, project, r#type)
+            .await
+    }
+
+    /// Returns the type with `null` and `undefined` removed.
+    pub async fn get_non_nullable_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_type_property("getNonNullableType", snapshot, project, r#type)
+            .await
+    }
+
+    /// Returns the widened form of a type, turning inference literals into
+    /// their base types.
+    pub async fn get_widened_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_type_property("getWidenedType", snapshot, project, r#type)
+            .await
+    }
+
+    /// Returns the base constraint of a type parameter or conditional type.
+    pub async fn get_base_constraint_of_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_type_property("getBaseConstraintOfType", snapshot, project, r#type)
+            .await
+    }
+
+    /// Returns the fresh form of a literal type.
+    pub async fn get_fresh_type_of_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_type_property("getFreshTypeOfType", snapshot, project, r#type)
+            .await
+    }
+
+    /// Returns the regular (non-fresh) form of a literal type.
+    pub async fn get_regular_type_of_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_type_property("getRegularTypeOfType", snapshot, project, r#type)
+            .await
+    }
+
+    /// Returns the `true` branch type of a conditional type.
+    pub async fn get_true_type_of_conditional_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_type_property("getTrueTypeOfConditionalType", snapshot, project, r#type)
+            .await
+    }
+
+    /// Returns the `false` branch type of a conditional type.
+    pub async fn get_false_type_of_conditional_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_type_property("getFalseTypeOfConditionalType", snapshot, project, r#type)
+            .await
+    }
+
+    /// Returns a named property symbol of a type, if it has one.
+    pub async fn get_property_of_type(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+        name: impl Into<String>,
+    ) -> Result<Option<super::SymbolResponse>> {
+        self.call_optional(
+            "getPropertyOfType",
+            PropertyOfTypeRequest {
+                snapshot,
+                project,
+                r#type,
+                name: name.into(),
+            },
+        )
+        .await
+    }
+
+    /// Returns the type a type node denotes.
+    pub async fn get_type_from_type_node(
+        &self,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        location: NodeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_optional(
+            "getTypeFromTypeNode",
+            TypeLocationRequest {
+                snapshot,
+                project,
+                location,
+            },
+        )
+        .await
+    }
+
+    /// Shared helper for boolean type predicates.
+    async fn call_type_predicate(
+        &self,
+        method: &str,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<bool> {
+        self.call(
+            method,
+            TypeProjectRequest {
+                snapshot,
+                project,
+                r#type,
+            },
+        )
+        .await
+    }
+
+    /// Shared helper for endpoints that map one type to another.
+    async fn call_type_property(
+        &self,
+        method: &str,
+        snapshot: SnapshotHandle,
+        project: ProjectHandle,
+        r#type: TypeHandle,
+    ) -> Result<Option<TypeResponse>> {
+        self.call_optional(
+            method,
             TypeProjectRequest {
                 snapshot,
                 project,

--- a/src/core/corsa_client/src/api/mod.rs
+++ b/src/core/corsa_client/src/api/mod.rs
@@ -80,8 +80,9 @@ pub use profiling::{ApiProfileEvent, ApiProfilePhase, ApiProfiler, SharedProfile
 pub use project_session::ProjectSession;
 /// Common response payloads returned by the API.
 pub use responses::{
-    ConfigResponse, IndexInfo, InitializeResponse, ProjectResponse, SignatureResponse,
-    SymbolResponse, TypePredicateResponse, TypeResponse,
+    ConfigResponse, IndexInfo, InitializeResponse, JsDocTagInfo, ProjectResponse,
+    SignatureResponse, SourceFileMetadata, SymbolResponse, TypePredicateResponse, TypeResponse,
+    WellKnownSymbolsResponse,
 };
 /// Auto-releasing snapshot wrapper.
 pub use snapshot::ManagedSnapshot;

--- a/src/core/corsa_client/src/api/requests_types.rs
+++ b/src/core/corsa_client/src/api/requests_types.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use super::{NodeHandle, ProjectHandle, SnapshotHandle, TypeHandle};
+use super::{NodeHandle, ProjectHandle, SignatureHandle, SnapshotHandle, SymbolHandle, TypeHandle};
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -29,4 +29,40 @@ pub(crate) struct PrintNodeRequest {
     pub never_ascii_escape: bool,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub terminate_unterminated_literals: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TypeAssignabilityRequest {
+    pub snapshot: SnapshotHandle,
+    pub project: ProjectHandle,
+    pub source: TypeHandle,
+    pub target: TypeHandle,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PropertyOfTypeRequest {
+    pub snapshot: SnapshotHandle,
+    pub project: ProjectHandle,
+    pub r#type: TypeHandle,
+    pub name: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ParameterTypeRequest {
+    pub snapshot: SnapshotHandle,
+    pub project: ProjectHandle,
+    pub signature: SignatureHandle,
+    pub index: i32,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MemberInModuleExportsRequest {
+    pub snapshot: SnapshotHandle,
+    pub project: ProjectHandle,
+    pub symbol: SymbolHandle,
+    pub name: String,
 }

--- a/src/core/corsa_client/src/api/responses.rs
+++ b/src/core/corsa_client/src/api/responses.rs
@@ -193,3 +193,47 @@ pub struct IndexInfo {
     #[serde(default)]
     pub is_readonly: bool,
 }
+
+/// A single JSDoc tag attached to a symbol.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JsDocTagInfo {
+    /// Tag name without the leading `@`, such as `deprecated` or `param`.
+    pub name: String,
+    /// Rendered tag text, when the tag carries any.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub text: String,
+}
+
+/// Handles for the checker's intrinsic well-known symbols.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WellKnownSymbolsResponse {
+    /// The checker's `unknown` symbol.
+    pub unknown: SymbolHandle,
+    /// The checker's `undefined` symbol.
+    pub undefined: SymbolHandle,
+    /// The checker's `arguments` symbol.
+    pub arguments: SymbolHandle,
+}
+
+/// Program-stored metadata about a single source file.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceFileMetadata {
+    /// Whether the file is part of the default library (`lib.*.d.ts`).
+    #[serde(default)]
+    pub is_default_library: bool,
+    /// Whether the file came from an external library such as `node_modules`.
+    #[serde(default)]
+    pub is_from_external_library: bool,
+    /// `type` field of the nearest `package.json`, when one applies.
+    #[serde(default)]
+    pub package_json_type: String,
+    /// Directory of the nearest `package.json`, when one applies.
+    #[serde(default)]
+    pub package_json_directory: String,
+    /// Module resolution mode the program implied for this file.
+    #[serde(default)]
+    pub implied_node_format: i32,
+}


### PR DESCRIPTION
Step ① of the plan: expose the missing upstream endpoints. Stacked on #443.

## Why

`ApiClient` covered roughly two thirds of upstream's API, and the missing third is precisely what type-aware tooling needs. So the binding answered those questions itself — by parsing rendered type text and re-reading source files.

The clearest example, still in the tree today:

```ts
function isArrayOrTupleLikeType(session, type) {
  const texts = type.texts?.length ? type.texts : [session.typeToString(type)];
  return texts.some((text) => { /* inspect the string */ });
}
```

`isArrayType` and `isTupleType` have been on the wire the whole time. This PR does not delete that code yet — it exposes the endpoints so the deletions in step ② have something to call.

## What

| Group | Endpoints |
|---|---|
| Predicates & normalization | `isTypeAssignableTo`, `isArrayType`, `isTupleType`, `isArrayLikeType`, `getApparentType`, `getNonNullableType`, `getWidenedType`, `getBaseConstraintOfType`, `getFreshTypeOfType`, `getRegularTypeOfType`, `getTrueTypeOfConditionalType`, `getFalseTypeOfConditionalType`, `getPropertyOfType`, `getTypeFromTypeNode` |
| Signatures | `getResolvedSignature`, `getSignatureFromDeclaration`, `getTypeParametersOfSignature`, `getTargetOfSignature`, `getParameterType` |
| Symbols & modules | `getAliasSymbolOfType`, `getAliasTypeArgumentsOfType`, `getAliasedSymbol`, `getImmediateAliasedSymbol`, `getExportsOfModule`, `getMemberInModuleExports`, `getExportSpecifierLocalTargetSymbol`, `getWellKnownSymbols` |
| Docs & constants | `getJsDocTags`, `getDocumentationComment`, `getConstantValue` |

`isTypeAssignableTo` is the important one — it is the relation type-aware lint rules are built on, and there is no way to approximate it by comparing type strings.

## Wire contracts

Taken from the pinned upstream (`2bd066d8`), not guessed. The handle field differs by params struct: `GetTypePropertyParams` and `GetSignaturePropertyParams` key it as `objectId` (already mirrored by `driver.rs`), while `CheckerTypeParams` and `CheckerSymbolParams` read `type` / `symbol` directly.

## Testing

`mock_corsa` answers every new endpoint, so this is covered by a test in the **normal** suite — no real runtime required. `vp run -w test`, `cargo clippy --workspace --all-targets -- -D warnings`, and `vp check --no-fmt` all pass locally.

As before, `cargo fmt` was not run: the rustfmt in this environment predates edition-2024 style and rewrites the repo.

## Next

② replace the type-text heuristics with these calls (535 type-text references, 78 users of the type-text splitting utilities), ③ remove the remaining source re-reading, ④ make "decide types from source text" mechanically impossible in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789609030&installation_model_id=422833&pr_number=444&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F444&signature=cec67ae3aeea31dfaf403f30494979d3db6fbe18d5e1b7f895bc537b547ce35c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded type-aware tooling with improved type compatibility checks, type transformations, property and parameter inspection, signature resolution, and array/tuple detection.
  * Added richer symbol and module analysis, including aliases, exports, documentation comments, JSDoc tags, constant values, and well-known symbols.
  * Added source-file metadata and improved support for mapped and anonymous types.
* **Tests**
  * Added broad integration coverage for type, signature, symbol, documentation, and metadata queries.
  * Improved compatibility checks for alternate valid resolution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->