### PR TITLE
fix(corsa-oxlint): model native-preview installs the way Windows sees them

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
@@ -202,7 +202,9 @@ describe("context", () => {
     expect(defaultCorsaExecutable(workspace, "linux")).toBe(fallback);
   });
 
-  it("prefers the installed native-preview tsgo binary when available", () => {
+  // The meta package's bin entry is a Node script behind a shebang, so it is
+  // only a usable runtime on platforms that honor shebang lines.
+  it("prefers the installed native-preview tsgo bin script on shebang platforms", () => {
     const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
     cleanupDirs.add(workspace);
     const packageDir = resolve(workspace, "node_modules/@typescript/native-preview");
@@ -219,7 +221,7 @@ describe("context", () => {
     );
     writeFileSync(binPath, "#!/usr/bin/env node\n");
 
-    expect(defaultCorsaExecutable(workspace)).toBe(realpathSync(binPath));
+    expect(defaultCorsaExecutable(workspace, "linux")).toBe(realpathSync(binPath));
   });
 
   it("resolves the native-preview platform executable on Windows", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -171,19 +171,7 @@ describe("corsa oxlint", () => {
     cleanupDirs.add(consumerRoot);
     cleanupDirs.add(pluginRoot);
 
-    const packageDir = resolve(pluginRoot, "node_modules/@typescript/native-preview");
-    const binPath = resolve(packageDir, "bin/tsgo.js");
-    mkdirSync(dirname(binPath), { recursive: true });
-    writeFileSync(
-      resolve(packageDir, "package.json"),
-      JSON.stringify({
-        name: "@typescript/native-preview",
-        bin: {
-          tsgo: "bin/tsgo.js",
-        },
-      }),
-    );
-    writeFileSync(binPath, "#!/usr/bin/env node\n");
+    const expectedExecutable = writeNativePreviewInstall(pluginRoot);
 
     const pluginEntry = resolve(pluginRoot, "dist/plugin.js");
     mkdirSync(dirname(pluginEntry), { recursive: true });
@@ -226,7 +214,7 @@ describe("corsa oxlint", () => {
         },
       } as any);
 
-      expect(seen).toBe(realpathSync(binPath));
+      expect(seen).toBe(expectedExecutable);
     } finally {
       if (previousExecutable == null) {
         delete process.env.CORSA_EXECUTABLE;
@@ -625,10 +613,7 @@ describe("corsa oxlint", () => {
     delete process.env.CORSA_EXECUTABLE;
     let seen: Record<string, unknown> | undefined;
     try {
-      const packageRoot = createNativePreviewPackage();
-      const expectedExecutable = realpathSync(
-        resolve(packageRoot, "node_modules/@typescript/native-preview/bin/tsgo.js"),
-      );
+      const { packageRoot, executable: expectedExecutable } = createNativePreviewPackage();
       const tester = new RuleTester({
         cwd: packageRoot,
       });
@@ -677,10 +662,7 @@ describe("corsa oxlint", () => {
     delete process.env.CORSA_EXECUTABLE;
     let seen: Record<string, unknown> | undefined;
     try {
-      const packageRoot = createNativePreviewPackage();
-      const expectedExecutable = realpathSync(
-        resolve(packageRoot, "node_modules/@typescript/native-preview/bin/tsgo.js"),
-      );
+      const { packageRoot, executable: expectedExecutable } = createNativePreviewPackage();
       const rule = decorateRule({
         meta: {
           docs: {
@@ -944,10 +926,24 @@ describe("corsa oxlint", () => {
   });
 });
 
-function createNativePreviewPackage(): string {
+function createNativePreviewPackage(): { packageRoot: string; executable: string } {
   const packageRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-runtime-"));
   cleanupDirs.add(packageRoot);
-  const packageDir = resolve(packageRoot, "node_modules/@typescript/native-preview");
+  return { packageRoot, executable: writeNativePreviewInstall(packageRoot) };
+}
+
+/**
+ * Writes a `@typescript/native-preview` install under `root` — the meta package
+ * plus the platform package npm pulls in as an optional dependency — and
+ * returns the executable resolution is expected to pick.
+ *
+ * These tests exercise the host platform, so the platform package is what keeps
+ * them meaningful on Windows: the meta package's `bin` entry is a Node script
+ * behind a shebang that Windows cannot spawn (`os error 193`), so resolution
+ * deliberately skips it there.
+ */
+function writeNativePreviewInstall(root: string): string {
+  const packageDir = resolve(root, "node_modules/@typescript/native-preview");
   const binPath = resolve(packageDir, "bin/tsgo.js");
   mkdirSync(dirname(binPath), { recursive: true });
   writeFileSync(
@@ -960,5 +956,16 @@ function createNativePreviewPackage(): string {
     }),
   );
   writeFileSync(binPath, "#!/usr/bin/env node\n");
-  return packageRoot;
+
+  const platformPackage = `@typescript/native-preview-${process.platform}-${process.arch}`;
+  const platformDir = resolve(root, "node_modules", platformPackage);
+  const platformBin = resolve(
+    platformDir,
+    "lib",
+    process.platform === "win32" ? "tsgo.exe" : "tsgo",
+  );
+  mkdirSync(dirname(platformBin), { recursive: true });
+  writeFileSync(resolve(platformDir, "package.json"), JSON.stringify({ name: platformPackage }));
+  writeFileSync(platformBin, "");
+  return realpathSync(platformBin);
 }


### PR DESCRIPTION
## Problem

CI on `main` has been red since #429 (2026-08-07). Every run — including `release: v1.7.0`, `v1.7.1`, `v1.8.0`, and `v1.9.0` — fails the same way:

```
FAIL  ts/context.test.ts > context > prefers the installed native-preview tsgo binary when available
FAIL  ts/framework.test.ts > corsa oxlint > uses plugin resolveFrom to fill the default corsa executable
FAIL  ts/framework.test.ts > corsa oxlint > defaults RuleTester corsa executable from the configured cwd
FAIL  ts/framework.test.ts > corsa oxlint > defaults decorated type-aware rules to the corsa executable
Error: corsa-oxlint could not locate a Corsa runtime executable.
```

Windows only — `Test (windows-2025)` and `Real Corsa Smoke (windows-2025)`, which then fail the `Quality` gate.

## Cause

#429 taught `resolveNativePreviewExecutableFrom` to skip the `@typescript/native-preview` meta package's `bin` entry on Windows: it is a Node script behind a shebang that Windows cannot spawn (`os error 193`). That guard is correct and has its own explicit-platform tests.

The four tests above still build a meta-package-only fixture and resolve against the *host* platform, so on Windows there is nothing left to resolve and `defaultCorsaExecutable` throws. The runtime behaviour is fine; the fixtures just describe an install shape that cannot work on Windows.

## Fix

- `framework.test.ts`: extract `writeNativePreviewInstall`, which lays down the platform package (`@typescript/native-preview-<platform>-<arch>` with `lib/tsgo[.exe]`) next to the meta package — the shape npm actually installs — and returns the executable resolution should pick. `createNativePreviewPackage` now returns that path alongside the root, so the three framework tests assert against a spawnable binary on every host.
- `context.test.ts`: pin the one test that is specifically about the shebang bin script to `"linux"`, matching the rest of the file's explicit-platform convention. Windows behaviour is already covered by `never resolves the native-preview Node bin script on Windows` and `resolves the native-preview platform executable on Windows`.

No production code changes.

## Verification

- `vitest run context.test.ts framework.test.ts` — the four tests pass
- `vp fmt --check` — clean
- `vp check --no-fmt` — clean

PR runs only schedule the ubuntu leg (`ci.yml` narrows the matrix on `pull_request`), so the
Windows legs were verified by a `workflow_dispatch` run of `ci.yml` on this branch, which uses
the full ubuntu/macOS/Windows matrix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789618634&installation_model_id=422833&pr_number=445&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F445&signature=62d43def4424e4d392201991adeb58c2d69cc8c7b6b01e01a020dc6bf94edfe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated native preview executable tests to account for platform-specific resolution.
  * Improved test setup for platform-specific executable packages.
  * Aligned plugin and RuleTester expectations with the resolved platform executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->