### PR TITLE
chore(corsa-oxlint): drop the @typescript/native-preview runtime lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Removed
 
 - The `corsa-oxlint/stylistic` entrypoint, native stylistic lint engine, and stylistic benchmarks have moved to [`ubugeeei-prod/oxlint-plugins`](https://github.com/ubugeeei-prod/oxlint-plugins).
+- default runtime discovery no longer looks for `@typescript/native-preview`. TypeScript 7 ships the same native binary through the same mechanism — `typescript` declares `@typescript/typescript-<platform>-<arch>` as an optional dependency and reads `lib/tsc` out of it, exactly as the preview channel did with `lib/tsgo` — so the preview lookup only ever won on machines with no TypeScript 7 installed. Resolution is now `typescript` 7 or newer, then `.cache/corsa`. Consumers still on the preview package can point at it with `CORSA_EXECUTABLE`, `parserOptions.corsa.executable`, or `resolveFrom`. This supersedes the two `@typescript/native-preview` entries under Fixed below.
 
 ### Fixed
 

--- a/src/bindings/nodejs/corsa_oxlint/README.md
+++ b/src/bindings/nodejs/corsa_oxlint/README.md
@@ -25,11 +25,11 @@ custom rules in plain JS/TS.
 
 ## Plugin-Owned Runtime Resolution
 
-By default, `corsa-oxlint` first uses the native runtime shipped with
-`typescript` 7 or newer, then falls back to `@typescript/native-preview` and
-finally `.cache/corsa`. If a plugin ships either runtime dependency, pass a
-module anchor to `definePlugin()` so `corsa-oxlint` can resolve it even when
-package managers like pnpm do not hoist it to the consumer root.
+By default, `corsa-oxlint` uses the native runtime shipped with `typescript` 7
+or newer, then falls back to `.cache/corsa`. If a plugin ships the runtime
+dependency, pass a module anchor to `definePlugin()` so `corsa-oxlint` can
+resolve it even when package managers like pnpm do not hoist it to the consumer
+root.
 
 ```ts
 import { definePlugin } from "corsa-oxlint";

--- a/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
@@ -111,12 +111,10 @@ describe("context", () => {
     const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
     cleanupDirs.add(workspace);
 
-    expect(() => defaultCorsaExecutable(workspace, "linux")).toThrow(
-      "Install `typescript` 7 or `@typescript/native-preview`",
-    );
+    expect(() => defaultCorsaExecutable(workspace, "linux")).toThrow("Install `typescript` 7");
   });
 
-  it("prefers the stable TypeScript 7 platform executable when available", () => {
+  it("resolves the stable TypeScript 7 platform executable", () => {
     const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
     cleanupDirs.add(workspace);
     const typescriptDir = resolve(workspace, "node_modules/typescript");
@@ -125,12 +123,9 @@ describe("context", () => {
       `node_modules/@typescript/typescript-linux-${process.arch}`,
     );
     const stableBin = resolve(platformDir, "lib/tsc");
-    const previewDir = resolve(workspace, "node_modules/@typescript/native-preview");
-    const previewBin = resolve(previewDir, "bin/tsgo.js");
 
     mkdirSync(typescriptDir, { recursive: true });
     mkdirSync(dirname(stableBin), { recursive: true });
-    mkdirSync(dirname(previewBin), { recursive: true });
     writeFileSync(
       resolve(typescriptDir, "package.json"),
       JSON.stringify({ name: "typescript", version: "7.0.2" }),
@@ -140,11 +135,6 @@ describe("context", () => {
       JSON.stringify({ name: `@typescript/typescript-linux-${process.arch}`, version: "7.0.2" }),
     );
     writeFileSync(stableBin, "");
-    writeFileSync(
-      resolve(previewDir, "package.json"),
-      JSON.stringify({ name: "@typescript/native-preview", bin: { tsgo: "bin/tsgo.js" } }),
-    );
-    writeFileSync(previewBin, "#!/usr/bin/env node\n");
 
     expect(defaultCorsaExecutable(workspace, "linux")).toBe(realpathSync(stableBin));
   });
@@ -200,129 +190,6 @@ describe("context", () => {
     writeFileSync(fallback, "");
 
     expect(defaultCorsaExecutable(workspace, "linux")).toBe(fallback);
-  });
-
-  // The meta package's bin entry is a Node script behind a shebang, so it is
-  // only a usable runtime on platforms that honor shebang lines.
-  it("prefers the installed native-preview tsgo bin script on shebang platforms", () => {
-    const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
-    cleanupDirs.add(workspace);
-    const packageDir = resolve(workspace, "node_modules/@typescript/native-preview");
-    const binPath = resolve(packageDir, "bin/tsgo.js");
-    mkdirSync(dirname(binPath), { recursive: true });
-    writeFileSync(
-      resolve(packageDir, "package.json"),
-      JSON.stringify({
-        name: "@typescript/native-preview",
-        bin: {
-          tsgo: "bin/tsgo.js",
-        },
-      }),
-    );
-    writeFileSync(binPath, "#!/usr/bin/env node\n");
-
-    expect(defaultCorsaExecutable(workspace, "linux")).toBe(realpathSync(binPath));
-  });
-
-  it("resolves the native-preview platform executable on Windows", () => {
-    const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
-    cleanupDirs.add(workspace);
-    const packageDir = resolve(workspace, "node_modules/@typescript/native-preview");
-    const binPath = resolve(packageDir, "bin/tsgo.js");
-    const platformDir = resolve(
-      workspace,
-      `node_modules/@typescript/native-preview-win32-${process.arch}`,
-    );
-    const platformBin = resolve(platformDir, "lib/tsgo.exe");
-    mkdirSync(dirname(binPath), { recursive: true });
-    mkdirSync(dirname(platformBin), { recursive: true });
-    writeFileSync(
-      resolve(packageDir, "package.json"),
-      JSON.stringify({ name: "@typescript/native-preview", bin: { tsgo: "bin/tsgo.js" } }),
-    );
-    writeFileSync(binPath, "#!/usr/bin/env node\n");
-    writeFileSync(
-      resolve(platformDir, "package.json"),
-      JSON.stringify({ name: `@typescript/native-preview-win32-${process.arch}` }),
-    );
-    writeFileSync(platformBin, "");
-
-    expect(defaultCorsaExecutable(workspace, "win32")).toBe(realpathSync(platformBin));
-  });
-
-  it("never resolves the native-preview Node bin script on Windows", () => {
-    const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
-    cleanupDirs.add(workspace);
-    const packageDir = resolve(workspace, "node_modules/@typescript/native-preview");
-    const binPath = resolve(packageDir, "bin/tsgo.js");
-    const fallback = resolve(workspace, ".cache/corsa.exe");
-    mkdirSync(dirname(binPath), { recursive: true });
-    mkdirSync(dirname(fallback), { recursive: true });
-    writeFileSync(
-      resolve(packageDir, "package.json"),
-      JSON.stringify({ name: "@typescript/native-preview", bin: { tsgo: "bin/tsgo.js" } }),
-    );
-    writeFileSync(binPath, "#!/usr/bin/env node\n");
-    writeFileSync(fallback, "");
-
-    // A Node script behind a shebang cannot be spawned on Windows
-    // (`os error 193`), so resolution must skip it.
-    expect(defaultCorsaExecutable(workspace, "win32")).toBe(fallback);
-  });
-
-  it("prefers the native-preview platform executable over the bin script", () => {
-    const workspace = mkdtempSync(join(tmpdir(), "corsa-oxlint-context-"));
-    cleanupDirs.add(workspace);
-    const packageDir = resolve(workspace, "node_modules/@typescript/native-preview");
-    const binPath = resolve(packageDir, "bin/tsgo.js");
-    const platformDir = resolve(
-      workspace,
-      `node_modules/@typescript/native-preview-linux-${process.arch}`,
-    );
-    const platformBin = resolve(platformDir, "lib/tsgo");
-    mkdirSync(dirname(binPath), { recursive: true });
-    mkdirSync(dirname(platformBin), { recursive: true });
-    writeFileSync(
-      resolve(packageDir, "package.json"),
-      JSON.stringify({ name: "@typescript/native-preview", bin: { tsgo: "bin/tsgo.js" } }),
-    );
-    writeFileSync(binPath, "#!/usr/bin/env node\n");
-    writeFileSync(
-      resolve(platformDir, "package.json"),
-      JSON.stringify({ name: `@typescript/native-preview-linux-${process.arch}` }),
-    );
-    writeFileSync(platformBin, "");
-
-    expect(defaultCorsaExecutable(workspace, "linux")).toBe(realpathSync(platformBin));
-  });
-
-  it("falls back to a plugin anchor when native-preview is only installed next to the plugin", () => {
-    const consumerRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-consumer-"));
-    const pluginRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-plugin-"));
-    cleanupDirs.add(consumerRoot);
-    cleanupDirs.add(pluginRoot);
-
-    const packageDir = resolve(pluginRoot, "node_modules/@typescript/native-preview");
-    const binPath = resolve(packageDir, "bin/tsgo.js");
-    mkdirSync(dirname(binPath), { recursive: true });
-    writeFileSync(
-      resolve(packageDir, "package.json"),
-      JSON.stringify({
-        name: "@typescript/native-preview",
-        bin: {
-          tsgo: "bin/tsgo.js",
-        },
-      }),
-    );
-    writeFileSync(binPath, "#!/usr/bin/env node\n");
-
-    const pluginEntry = resolve(pluginRoot, "dist/plugin.js");
-    mkdirSync(dirname(pluginEntry), { recursive: true });
-    writeFileSync(pluginEntry, "export default {};\n");
-
-    expect(defaultCorsaExecutable(consumerRoot, "linux", pathToFileURL(pluginEntry).href)).toBe(
-      realpathSync(binPath),
-    );
   });
 
   it("resolves stable TypeScript 7 from a plugin anchor", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/context.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.ts
@@ -32,12 +32,6 @@ export function defaultCorsaExecutable(
   if (stableTypeScript) {
     return stableTypeScript;
   }
-  const nativePreview =
-    resolveNativePreviewExecutableFrom(resolve(rootDir, "package.json"), platform) ??
-    (resolveFrom ? resolveNativePreviewExecutableFrom(resolveFrom, platform) : undefined);
-  if (nativePreview) {
-    return nativePreview;
-  }
   const fallback = resolve(rootDir, platform === "win32" ? ".cache/corsa.exe" : ".cache/corsa");
   if (existsSync(fallback)) {
     return fallback;
@@ -45,7 +39,7 @@ export function defaultCorsaExecutable(
   throw new Error(
     [
       "corsa-oxlint could not locate a Corsa runtime executable.",
-      "Install `typescript` 7 or `@typescript/native-preview`, set `CORSA_EXECUTABLE`, configure `parserOptions.corsa.executable`, or pass `resolveFrom` to `definePlugin`.",
+      "Install `typescript` 7, set `CORSA_EXECUTABLE`, configure `parserOptions.corsa.executable`, or pass `resolveFrom` to `definePlugin`.",
     ].join(" "),
   );
 }
@@ -232,81 +226,9 @@ function isTypeScriptVersionSevenOrNewer(packageJsonPath: string): boolean {
   }
 }
 
-function resolveNativePreviewExecutableFrom(
-  anchor: string,
-  platform: NodeJS.Platform,
-): string | undefined {
-  const requireFromRoot = createRequire(anchor);
-  const packageJsonPath = resolveOptional(
-    requireFromRoot,
-    "@typescript/native-preview/package.json",
-  );
-  if (packageJsonPath) {
-    const platformExecutable = nativePreviewPlatformExecutable(packageJsonPath, platform);
-    if (platformExecutable) {
-      return platformExecutable;
-    }
-    // The meta package's `bin` entry is a Node script behind a shebang.
-    // Windows cannot spawn it (`os error 193`), so the script is only a
-    // usable runtime on platforms that honor shebang lines.
-    if (platform === "win32") {
-      return undefined;
-    }
-    const binPath = nativePreviewBinPath(packageJsonPath);
-    if (binPath && existsSync(binPath)) {
-      return binPath;
-    }
-  }
-  if (platform === "win32") {
-    return undefined;
-  }
-  const packageEntry = resolveOptional(requireFromRoot, "@typescript/native-preview");
-  return packageEntry && existsSync(packageEntry) ? packageEntry : undefined;
-}
-
-/**
- * Resolves the platform-specific `tsgo` executable that the
- * `@typescript/native-preview` meta package installs as an optional
- * dependency, mirroring how the stable `typescript` runtime is resolved.
- */
-function nativePreviewPlatformExecutable(
-  packageJsonPath: string,
-  platform: NodeJS.Platform,
-): string | undefined {
-  const requireFromPreview = createRequire(packageJsonPath);
-  const platformPackageJsonPath = resolveOptional(
-    requireFromPreview,
-    `@typescript/native-preview-${platform}-${process.arch}/package.json`,
-  );
-  if (!platformPackageJsonPath) {
-    return undefined;
-  }
-  const executable = resolve(
-    dirname(platformPackageJsonPath),
-    "lib",
-    platform === "win32" ? "tsgo.exe" : "tsgo",
-  );
-  return existsSync(executable) ? executable : undefined;
-}
-
 function resolveOptional(requireFromRoot: NodeJS.Require, specifier: string): string | undefined {
   try {
     return requireFromRoot.resolve(specifier);
-  } catch {
-    return undefined;
-  }
-}
-
-function nativePreviewBinPath(packageJsonPath: string): string | undefined {
-  try {
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
-      readonly bin?: string | Record<string, string>;
-    };
-    const bin =
-      typeof packageJson.bin === "string"
-        ? packageJson.bin
-        : (packageJson.bin?.tsgo ?? Object.values(packageJson.bin ?? {})[0]);
-    return bin ? resolve(dirname(packageJsonPath), bin) : undefined;
   } catch {
     return undefined;
   }

--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -171,7 +171,7 @@ describe("corsa oxlint", () => {
     cleanupDirs.add(consumerRoot);
     cleanupDirs.add(pluginRoot);
 
-    const expectedExecutable = writeNativePreviewInstall(pluginRoot);
+    const expectedExecutable = writeTypeScriptInstall(pluginRoot);
 
     const pluginEntry = resolve(pluginRoot, "dist/plugin.js");
     mkdirSync(dirname(pluginEntry), { recursive: true });
@@ -613,7 +613,7 @@ describe("corsa oxlint", () => {
     delete process.env.CORSA_EXECUTABLE;
     let seen: Record<string, unknown> | undefined;
     try {
-      const { packageRoot, executable: expectedExecutable } = createNativePreviewPackage();
+      const { packageRoot, executable: expectedExecutable } = createTypeScriptPackage();
       const tester = new RuleTester({
         cwd: packageRoot,
       });
@@ -662,7 +662,7 @@ describe("corsa oxlint", () => {
     delete process.env.CORSA_EXECUTABLE;
     let seen: Record<string, unknown> | undefined;
     try {
-      const { packageRoot, executable: expectedExecutable } = createNativePreviewPackage();
+      const { packageRoot, executable: expectedExecutable } = createTypeScriptPackage();
       const rule = decorateRule({
         meta: {
           docs: {
@@ -926,46 +926,37 @@ describe("corsa oxlint", () => {
   });
 });
 
-function createNativePreviewPackage(): { packageRoot: string; executable: string } {
+function createTypeScriptPackage(): { packageRoot: string; executable: string } {
   const packageRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-runtime-"));
   cleanupDirs.add(packageRoot);
-  return { packageRoot, executable: writeNativePreviewInstall(packageRoot) };
+  return { packageRoot, executable: writeTypeScriptInstall(packageRoot) };
 }
 
 /**
- * Writes a `@typescript/native-preview` install under `root` — the meta package
- * plus the platform package npm pulls in as an optional dependency — and
- * returns the executable resolution is expected to pick.
+ * Writes a `typescript` 7 install under `root` — the meta package plus the
+ * platform package npm pulls in as an optional dependency — and returns the
+ * executable resolution is expected to pick.
  *
- * These tests exercise the host platform, so the platform package is what keeps
- * them meaningful on Windows: the meta package's `bin` entry is a Node script
- * behind a shebang that Windows cannot spawn (`os error 193`), so resolution
- * deliberately skips it there.
+ * These tests exercise the host platform, so the platform package has to be
+ * there: it is the native runtime, and the meta package on its own carries
+ * only the Node entrypoints.
  */
-function writeNativePreviewInstall(root: string): string {
-  const packageDir = resolve(root, "node_modules/@typescript/native-preview");
-  const binPath = resolve(packageDir, "bin/tsgo.js");
-  mkdirSync(dirname(binPath), { recursive: true });
+function writeTypeScriptInstall(root: string): string {
+  const packageDir = resolve(root, "node_modules/typescript");
+  mkdirSync(packageDir, { recursive: true });
   writeFileSync(
     resolve(packageDir, "package.json"),
-    JSON.stringify({
-      name: "@typescript/native-preview",
-      bin: {
-        tsgo: "bin/tsgo.js",
-      },
-    }),
+    JSON.stringify({ name: "typescript", version: "7.0.2" }),
   );
-  writeFileSync(binPath, "#!/usr/bin/env node\n");
 
-  const platformPackage = `@typescript/native-preview-${process.platform}-${process.arch}`;
+  const platformPackage = `@typescript/typescript-${process.platform}-${process.arch}`;
   const platformDir = resolve(root, "node_modules", platformPackage);
-  const platformBin = resolve(
-    platformDir,
-    "lib",
-    process.platform === "win32" ? "tsgo.exe" : "tsgo",
-  );
+  const platformBin = resolve(platformDir, "lib", process.platform === "win32" ? "tsc.exe" : "tsc");
   mkdirSync(dirname(platformBin), { recursive: true });
-  writeFileSync(resolve(platformDir, "package.json"), JSON.stringify({ name: platformPackage }));
+  writeFileSync(
+    resolve(platformDir, "package.json"),
+    JSON.stringify({ name: platformPackage, version: "7.0.2" }),
+  );
   writeFileSync(platformBin, "");
   return realpathSync(platformBin);
 }


### PR DESCRIPTION
Follow-up to #445, which patched the fixtures around this code path. This removes the path.

## Why

`@typescript/native-preview` was the pre-GA channel for the same native binary `typescript` 7 now ships. `typescript/lib/getExePath.js` drives both off a single `baseName`:

| | baseName | bin | platform package |
|---|---|---|---|
| stable v7 | `typescript` | `tsc` | `@typescript/typescript-<platform>-<arch>/lib/tsc[.exe]` |
| preview | `native-preview` | `tsgo` | `@typescript/native-preview-<platform>-<arch>/lib/tsgo[.exe]` |

`defaultCorsaExecutable` already tried TypeScript 7 first, so the preview lookup only ever won on a machine with no TypeScript 7 installed. It is not a dependency anywhere in this repo — the root devDependencies pin `typescript: 7.0.2`. It survived only because it predates the TypeScript 7 discovery added in #378.

It also carried the only platform-specific special case in the file: the meta package's `bin` entry is a Node script behind a shebang that Windows cannot spawn (`os error 193`), so the resolver had to detect and skip it. That special case is what broke Windows CI for 11 days and what #445 works around in the fixtures. Removing the branch retires the whole class of problem — the stable path never resolves a Node script.

## What changes

- `context.ts`: remove `resolveNativePreviewExecutableFrom`, `nativePreviewPlatformExecutable`, and `nativePreviewBinPath`; resolution is now `typescript` 7 or newer → `.cache/corsa`. The "could not locate" error no longer advertises the preview package.
- `context.test.ts`: drop the 5 preview-specific tests. `falls back to a plugin anchor when native-preview is only installed next to the plugin` is fully covered by the existing `resolves stable TypeScript 7 from a plugin anchor`, and `prefers the stable TypeScript 7 platform executable when available` no longer has a loser to prefer over, so it becomes `resolves the stable TypeScript 7 platform executable`.
- `framework.test.ts`: the three runtime-defaulting tests were never *about* the preview package — it was just the fixture. #445's `writeNativePreviewInstall` becomes `writeTypeScriptInstall`, which writes a TypeScript 7 install and works identically on every OS, so the Windows carve-out disappears rather than being maintained.
- README + CHANGELOG updated.

## Compatibility

Deliberately staying on 1.x with a `### Removed` CHANGELOG entry rather than cutting 2.0.0. Consumers still on the preview package lose auto-detection and must point at it with `CORSA_EXECUTABLE`, `parserOptions.corsa.executable`, or `resolveFrom` — all three already take priority over discovery and are unchanged.

The CHANGELOG's `Unreleased` section keeps its two historical `@typescript/native-preview` entries under Fixed (they describe what shipped in 1.7.x–1.9.0); the new Removed entry says explicitly that it supersedes them.

## Verification

- `vp fmt --check`, `vp check --no-fmt` — clean
- full `corsa_oxlint/ts` suite: failure set is byte-identical to `main`'s (13 pre-existing local-environment failures, green in CI); 163 → 158 tests, matching the 5 deleted
- full ubuntu/macOS/Windows CI dispatched on this branch

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789623133&installation_model_id=422833&pr_number=447&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F447&signature=069816d7d8520d89604537ea4834f2b5978f23a5eb7b137bb377a3202d5d5c63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Runtime discovery now prioritizes the native runtime included with TypeScript 7 or newer.
  * If TypeScript 7 is unavailable, resolution falls back to the local `.cache/corsa` runtime.
  * Automatic discovery of the `@typescript/native-preview` runtime has been removed.
  * Preview runtime users must now provide an explicit executable path or configuration.

* **Documentation**
  * Updated the unreleased changelog and runtime setup guidance to reflect these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->