### PR TITLE
docs: cut the accumulated Unreleased pile into release sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,80 @@
 # Changelog
 
+Only releases that carried a documented change are listed here. Many versions
+between 0.7.1 and 1.9.0 shipped without changelog entries; this file does not
+reconstruct them, and the [GitHub Releases](https://github.com/ubugeeei-prod/corsa-bind/releases) page has the full list of
+published versions.
+
 ## Unreleased
+
+### Removed
+
+- default runtime discovery no longer looks for `@typescript/native-preview`. TypeScript 7 ships the same native binary through the same mechanism — `typescript` declares `@typescript/typescript-<platform>-<arch>` as an optional dependency and reads `lib/tsc` out of it, exactly as the preview channel did with `lib/tsgo` — so the preview lookup only ever won on machines with no TypeScript 7 installed. Resolution is now `typescript` 7 or newer, then `.cache/corsa`. Consumers still on the preview package can point at it with `CORSA_EXECUTABLE`, `parserOptions.corsa.executable`, or `resolveFrom`. This supersedes the `@typescript/native-preview` discovery entries in 1.0.0-beta.2 and 1.6.0.
+
+## 1.9.0 - 2026-08-18
+
+1.8.0 was bumped on `main` but never tagged, so it was never published. Everything
+below shipped in 1.9.0.
 
 ### Added
 
 - `ApiClient` gained project-scoped variants for every relation endpoint that previously only had a project-less form: `get_type_parameters_of_type_in_project`, `get_outer_type_parameters_of_type_in_project`, `get_local_type_parameters_of_type_in_project`, `get_object_type_of_type_in_project`, `get_index_type_of_type_in_project`, `get_check_type_of_type_in_project`, `get_extends_type_of_type_in_project`, `get_base_type_of_type_in_project`, `get_parent_of_symbol_in_project`, `get_members_of_symbol_in_project`, `get_exports_of_symbol_in_project`, and `get_export_symbol_of_symbol_in_project`. Stable TypeScript 7 runtimes reject the project-less forms.
 - `ApiClient::get_parameters_of_signature` and `ApiClient::get_this_parameter_of_signature` expose the upstream endpoints that resolve a signature's parameter symbol handles.
 - `NodeHandle::declaring_path` reads the declaring file out of both node handle wire formats, including the compact stable-runtime form that `NodeHandle::parse` rejects.
-- `corsa-oxlint` now exposes a `RuleContext<MessageId, Options>` type and generic `defineRule` wrapper for narrowing rule options and report message IDs.
-- `corsa-oxlint` now exposes per-node-type `ESTree.*` aliases from the root entrypoint.
-
-### Removed
-
-- The `corsa-oxlint/stylistic` entrypoint, native stylistic lint engine, and stylistic benchmarks have moved to [`ubugeeei-prod/oxlint-plugins`](https://github.com/ubugeeei-prod/oxlint-plugins).
-- default runtime discovery no longer looks for `@typescript/native-preview`. TypeScript 7 ships the same native binary through the same mechanism — `typescript` declares `@typescript/typescript-<platform>-<arch>` as an optional dependency and reads `lib/tsc` out of it, exactly as the preview channel did with `lib/tsgo` — so the preview lookup only ever won on machines with no TypeScript 7 installed. Resolution is now `typescript` 7 or newer, then `.cache/corsa`. Consumers still on the preview package can point at it with `CORSA_EXECUTABLE`, `parserOptions.corsa.executable`, or `resolveFrom`. This supersedes the two `@typescript/native-preview` entries under Fixed below.
 
 ### Fixed
 
 - type relation requests that carry a type handle now always name the project that issued it, so `getTypesOfType` returns union members instead of throwing `empty project ID for type handle <n>` ([#440](https://github.com/ubugeeei-prod/corsa-bind/issues/440)). The same omission silently affected `getTargetOfType`, `getTypeParametersOfType`, `getOuterTypeParametersOfType`, `getLocalTypeParametersOfType`, `getObjectTypeOfType`, `getIndexTypeOfType`, `getCheckTypeOfType`, `getExtendsTypeOfType`, and `getBaseTypeOfType`, which are fixed with it.
 - signature parameter symbols now come from the checker via `getParametersOfSignature` instead of being reconstructed by scanning the declaration out of the source file, so construct signatures of classes with an explicit constructor expose `parameterSymbols` on stable TypeScript 7 runtimes ([#441](https://github.com/ubugeeei-prod/corsa-bind/issues/441)). The old reconstruction only ever worked when the declaration handle carried source offsets, and silently produced nothing once stable runtimes moved to compact handles. `thisParameterSymbol` is resolved the same way, through `getThisParameterOfSignature`.
 - type-handle requests now resolve in the project that issued the handle rather than the snapshot's first project, which matters once a snapshot spans several projects.
+
+## 1.7.0 - 2026-08-10
+
+### Fixed
+
+- `corsa-oxlint` no longer treats a compact TypeScript 7 declaration handle as a source range, resolves type symbols in the project that owns the type handle, and ignores `class` text inside comments and string literals when recovering a declaration position.
+
+## 1.6.0 - 2026-08-07
+
+### Fixed
+
 - type, signature, and symbol relation requests now mirror numeric handles into the `objectId` field that TypeScript 7 stable runtimes expect, so `getSymbolOfType`, `getBaseTypes` metadata, and `getImplementedTypesOfType` keep working for class types imported from other files ([#427](https://github.com/ubugeeei-prod/corsa-bind/issues/427)).
 - `corsa-oxlint` recovers class-declaration positions for compact TypeScript 7 declaration handles instead of misreading node ids as source offsets, keeping same-named classes in different scopes distinct.
-- `corsa-oxlint` no longer treats a compact TypeScript 7 declaration handle as a source range, resolves type symbols in the project that owns the type handle, and ignores `class` text inside comments and string literals when recovering a declaration position.
 - the default runtime discovery now resolves the `@typescript/native-preview` platform executable (`lib/tsgo`, `tsgo.exe` on Windows) instead of the meta package's Node bin script, which Windows cannot spawn ([#428](https://github.com/ubugeeei-prod/corsa-bind/issues/428)).
+
+## 1.3.0 - 2026-07-30
+
+### Removed
+
+- The `corsa-oxlint/stylistic` entrypoint, native stylistic lint engine, and stylistic benchmarks have moved to [`ubugeeei-prod/oxlint-plugins`](https://github.com/ubugeeei-prod/oxlint-plugins).
+
+## 1.0.0-beta.5 - 2026-07-18
+
+### Fixed
+
 - `corsa-oxlint` now resolves nominal type symbols for interface and class property annotations.
 - `corsa-oxlint` now returns direct and inherited implemented interfaces after symbol, base-type, and generic-argument traversal while accepting compact TypeScript 7 declaration handles.
+
+## 1.0.0-beta.2 - 2026-07-13
+
+### Fixed
+
 - `corsa-oxlint` now discovers the native Corsa runtime shipped with TypeScript 7 or newer before falling back to `@typescript/native-preview`.
+
+## 0.43.0 - 2026-06-08
+
+### Added
+
+- `corsa-oxlint` now exposes a `RuleContext<MessageId, Options>` type and generic `defineRule` wrapper for narrowing rule options and report message IDs.
+
+## 0.42.0 - 2026-06-08
+
+### Added
+
+- `corsa-oxlint` now exposes per-node-type `ESTree.*` aliases from the root entrypoint.
+
+### Fixed
+
 - `corsa-oxlint` now reports a dependency-focused error when no default Corsa runtime executable can be found.
 - constructor signature parameter symbol fallback now preserves non-ASCII parameter names.
 - imported inherited constructor signatures with non-ASCII JSDoc retain resolvable parameter symbols.


### PR DESCRIPTION
Stacked on #447 — GitHub retargets this to `main` once #447 merges. Review the top commit only.

## Problem

`## Unreleased` has not been cut since `chore: prepare v0.7.1 release` (#48) on 2026-05-16. Every entry added across the following 60-odd published versions piled up under that one heading, so the file's newest release section reads `## 0.7.1 - 2026-05-16` while npm is at 1.9.0.

## Method

CHANGELOG.md has only been touched 10 times since #48. For each of those commits I took the earliest tag containing it, which dates every bullet to the release it actually shipped in:

| commit | shipped in |
|---|---|
| `0308ea3` feat: add ESTree aliases and signature fallbacks | 0.42.0 |
| `f7a3be9` feat: add typed rule context wrapper | 0.43.0 |
| `ae754e4` fix: discover TypeScript 7 runtime (#378) | 1.0.0-beta.2 |
| `873e6cc` fix: restore oxlint type relations for TypeScript 7 (#394) | 1.0.0-beta.5 |
| `72cd39f` refactor: drop stylistic lint rules (#415) | 1.3.0 |
| `566a9f8` fix: restore cross-file type metadata (#429) | 1.6.0 |
| `6644720` fix: keep compact TypeScript 7 handles out of source ranges (#430) | 1.7.0 |
| `ec2f8ec` release: v1.8.0 (#442), `aa17650` fix: signature parameter symbols (#443) | 1.9.0 |

(`13ac7a7` also touched the file but only reworded an existing 0.7.1 bullet.)

## What this does not do

It does not invent entries for the releases that shipped without any. A note at the top says the file only covers documented releases and points at GitHub Releases for the complete published list. Reconstructing ~50 sections from commit archaeology would be guesswork, not history.

## Two things this surfaced

- **1.8.0 was never published.** `ec2f8ec` bumped the version on `main` and the release notes for 1.9.0 name it, but no `v1.8.0` tag was ever pushed, so the publish workflows never ran. npm and the tag list both go 1.7.1 → 1.9.0. Its entries are filed under 1.9.0, and the 1.9.0 section says so.
- **1.0.0 final never existed** — the tags go `1.0.0-beta.5` → `1.1.0`. Nothing to fix in this file; noting it since it is the other gap in the version sequence.

## Verification

- 29 bullets before, 29 after. `diff` of the sorted bullet lines is empty apart from the native-preview `Removed` entry from #447, whose "supersedes the two entries under Fixed below" cross-reference now names the sections those entries moved to (1.0.0-beta.2 and 1.6.0).
- `vp fmt --check` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789624156&installation_model_id=422833&pr_number=452&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F452&signature=c449db7511d22dbbbed1929d916c2d7a9c6e01a4239b32f8465d6094220c309d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->