### PR TITLE
ci: own the CodeQL workflow so the required Analyze checks always run

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,15 +50,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
-        with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
-
-      # The Go binding is cgo and links against the Rust C ABI, so `libcorsa_ffi`
-      # has to exist before the extractor can build the package. This mirrors the
-      # Non-Node Bindings job in ci.yml.
+      # Both toolchains have to be installed before `init`: CodeQL traces the Go
+      # build through a `go` shim it places on PATH there, and actions/setup-go
+      # would shadow that shim if it ran afterwards, leaving the extractor with
+      # nothing to process.
       - name: Install Rust
         if: matrix.language == 'go'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -70,6 +65,15 @@ jobs:
           go-version-file: src/bindings/go/corsa_utils/go.mod
           cache: false
 
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # The binding is cgo and links `libcorsa_ffi` out of target/debug, so the
+      # Rust crate has to be built before `go build` can succeed. This mirrors the
+      # Non-Node Bindings job in ci.yml.
       - name: Build the Go binding
         if: matrix.language == 'go'
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,85 @@
+name: CodeQL
+
+# The `Analyze (...)` checks are required on `main`, but GitHub's managed Code
+# Quality analysis only starts when a pull request touches analyzable source.
+# Dependency bumps, workflow edits, and pull requests that do not target the
+# default branch therefore never reported those contexts, and auto-merge sat
+# waiting on checks that were never going to arrive. Owning the workflow makes
+# the three contexts run on every pull request.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: csharp
+            build-mode: none
+          - language: go
+            build-mode: manual
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # The Go binding is cgo and links against the Rust C ABI, so `libcorsa_ffi`
+      # has to exist before the extractor can build the package. This mirrors the
+      # Non-Node Bindings job in ci.yml.
+      - name: Install Rust
+        if: matrix.language == 'go'
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Setup Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: src/bindings/go/corsa_utils/go.mod
+          cache: false
+
+      - name: Build the Go binding
+        if: matrix.language == 'go'
+        env:
+          LD_LIBRARY_PATH: ${{ github.workspace }}/target/debug
+        run: |
+          cargo build -p corsa_ffi
+          cd src/bindings/go/corsa_utils
+          go build ./...
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Fixes the auto-merge hang.

## Diagnosis

The `default` ruleset on `main` requires 19 status checks. Three of them —

```
Analyze (csharp)
Analyze (go)
Analyze (javascript-typescript)
```

— were produced by nothing in this repository. They came from GitHub's **managed** Code Quality analysis (`dynamic/github-code-scanning/codeql`, driven by the ruleset's `code_quality` rule). That analysis only starts when a pull request touches analyzable source. Querying the API for the head SHA of #446 and #449 returns **no code-scanning workflow run at all** — the jobs are not skipped, they are never scheduled, so the three contexts never report and the pull request waits on them forever.

Measured across every open pull request at the time of writing:

| PR | changes | `Analyze` checks | result |
|---|---|---|---|
| #446 | `Cargo.toml`, `Cargo.lock` | **0** | auto-merge enabled 5h+, still `BLOCKED` |
| #448 | `package.json`, `pnpm-lock.yaml` | **0** | `BLOCKED` |
| #449 | `.github/workflows/*.yml` | **0** | `BLOCKED` |
| #450 | `bench/cli_compare/package*.json` | **0** | `BLOCKED` |
| #451 | `nix/vite-plus/package.json` | **0** | `BLOCKED` |
| #447 | `.ts` sources | 3 | reported |

#446 is the clearest case: `mergeable: MERGEABLE`, `statusCheckRollup: SUCCESS`, zero unresolved review threads, auto-merge enabled at 05:50Z — and `mergeStateStatus: BLOCKED`. The only thing missing is the three checks that were never going to arrive.

This makes **every dependency bump hang by construction**, since dependency bumps almost never touch analyzable source.

## Fix

Own the workflow instead of relying on the managed run, so the contexts are produced on every pull request — including dependency bumps and pull requests that do not target the default branch.

- Job name is `Analyze (${{ matrix.language }})`, which matches the three required contexts exactly.
- The matrix covers exactly the three required languages, not the nine the repository language scan detects.
- `pull_request` is unfiltered, so stacked pull requests get the checks too.
- **Go uses `build-mode: manual`.** The binding is cgo — `#cgo LDFLAGS: -L${SRCDIR}/../../../../target/debug -lcorsa_ffi` — so the extractor cannot build the package until the Rust crate exists. The steps mirror the Non-Node Bindings job in `ci.yml`. `autobuild` would have failed here.
- C# and JS/TS use `build-mode: none` (buildless extraction), so no dotnet SDK or native library is needed.
- All actions pinned by commit SHA, matching the repository convention and keeping the OpenSSF Scorecard pinned-dependencies check green.

## Note on overlap

The ruleset's `code_quality` rule stays as it is. On pull requests that do touch analyzable source, the managed analysis and this workflow will both report `Analyze (...)`; required-check evaluation resolves by name and both pass. If the duplication is unwanted, the follow-up is to drop the `code_quality` rule from the ruleset, since this workflow now provides the same analysis on a schedule that actually covers every pull request. I have not changed the ruleset here.

## Verification

This pull request only touches `.github/workflows/`, so it reproduces the failing case exactly: the managed analysis will not run on it. If the three `Analyze` checks appear here, the hang is fixed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789624777&installation_model_id=422833&pr_number=453&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F453&signature=42892bd45ec911ca73ed7e8109f0a83d7559df67d35d2201b9dd24292f80262d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->