### PR TITLE
feat: support latest tsgo upstream

### DIFF
--- a/corsa_ref.lock.toml
+++ b/corsa_ref.lock.toml
@@ -3,8 +3,8 @@ version = 1
 [corsa_upstream]
 path = "ref/corsa-upstream"
 repository = "https://github.com/microsoft/typescript-go.git"
-commit = "2bd066d87f5bafd315be9f40889d0a60b9e58e0b"
-tree = "ed2c2c12c401b84bd5888d0b889737495aa93a20"
-committer_date = "2026-07-07T21:22:40-07:00"
-author = "Jake Bailey"
-subject = "Merge branch 'main' into ts7-release"
+commit = "89d5d5b2849a0db0957065889ca58536fa6d2e4a"
+tree = "bc369d37139fbc9792a2a32b89e92ace2344e43a"
+committer_date = "2026-08-20T06:46:10Z"
+author = "Ryan Cavanaugh"
+subject = "Add closure notice and link to original repo (#4919)"

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -150,7 +150,8 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
       return sessionForContext(context).session.getTypePredicateOfSignature(signature);
     },
     getBaseTypes(type) {
-      return sessionForContext(context).session.getBaseTypes(type);
+      const bases = sessionForContext(context).session.getBaseTypes(type);
+      return bases.length > 0 ? bases : constructorBaseTypesFromType(context, type, this);
     },
     getImplementedTypes(node) {
       if ("pos" in node) {
@@ -211,7 +212,10 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
       return sessionForContext(context).session.getBaseTypeOfType(type);
     },
     getConstraintOfType(type) {
-      return sessionForContext(context).session.getConstraintOfType(type);
+      return (
+        sessionForContext(context).session.getConstraintOfType(type) ??
+        constraintFromTypeParameterSource(context, type, this)
+      );
     },
     isUnionType(type) {
       return (type.flags & typeFlags.union) !== 0;
@@ -288,10 +292,191 @@ function typeOfNewExpression(
   }
   const constructSignature = checker.getSignaturesOfType(calleeType, SignatureKind.Construct)[0];
   const type = constructSignature
-    ? (checker.getReturnTypeOfSignature(constructSignature) ?? calleeType)
-    : calleeType;
+    ? (checker.getReturnTypeOfSignature(constructSignature) ??
+      constructorInstanceTypeFromType(context, calleeType, checker) ??
+      calleeType)
+    : (constructorInstanceTypeFromType(context, calleeType, checker) ?? calleeType);
   sessionForContext(context).session.rememberTypeLookupFromType(type, calleeType);
   return type;
+}
+
+function constructorBaseTypesFromType(
+  context: ContextWithParserOptions,
+  type: CorsaType,
+  checker: CorsaTypeCheckerShape,
+): readonly CorsaType[] {
+  const instanceType = constructorInstanceTypeFromType(context, type, checker);
+  if (!instanceType) {
+    return constructorBaseTypesFromConstituents(context, type, checker);
+  }
+  if (isSuperclassConstructorLookup(context, type)) {
+    return [instanceType];
+  }
+  const instanceBases = sessionForContext(context).session.getBaseTypes(instanceType);
+  return instanceBases.length > 0 ? instanceBases : [instanceType];
+}
+
+function constructorBaseTypesFromConstituents(
+  context: ContextWithParserOptions,
+  type: CorsaType,
+  checker: CorsaTypeCheckerShape,
+): readonly CorsaType[] {
+  if (!checker.isIntersectionType(type) && !checker.isUnionType(type)) {
+    return [];
+  }
+  const bases: CorsaType[] = [];
+  const seen = new Set<string>();
+  for (const constituent of checker.getTypesOfType(type)) {
+    for (const base of constructorBaseTypesFromType(context, constituent, checker)) {
+      if (seen.has(base.id)) {
+        continue;
+      }
+      seen.add(base.id);
+      bases.push(base);
+    }
+  }
+  return bases;
+}
+
+function constructorInstanceTypeFromType(
+  context: ContextWithParserOptions,
+  type: CorsaType,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
+  const text = safeTypeToString(checker, type);
+  if (!text || !/\btypeof\s+/.test(text)) {
+    return undefined;
+  }
+  const symbol = checker.getSymbolOfType(type);
+  const declared = symbol ? checker.getDeclaredTypeOfSymbol(symbol) : undefined;
+  if (
+    declared &&
+    declared.id !== type.id &&
+    !safeTypeToString(checker, declared)?.includes("typeof ")
+  ) {
+    return declared;
+  }
+  const name = firstConstructorTypeName(text);
+  return name ? typeFromClassName(context, name, checker, type) : undefined;
+}
+
+function firstConstructorTypeName(text: string): string | undefined {
+  const match = /\btypeof\s+([A-Za-z_$][\w$]*)/.exec(text);
+  return match?.[1];
+}
+
+function typeFromClassName(
+  context: ContextWithParserOptions,
+  name: string,
+  checker: CorsaTypeCheckerShape,
+  relatedType: CorsaType,
+): CorsaType | undefined {
+  const session = sessionForContext(context).session;
+  const lookup = session.getTypeLookupSource(relatedType);
+  const sourceText = lookup
+    ? (lookup.sourceText ?? session.getSourceTextForPath(lookup.fileName))
+    : context.sourceCode.text;
+  const fileName = lookup?.fileName ?? context.filename;
+  if (!sourceText) {
+    return undefined;
+  }
+  const position = classIdentifierPosition(sourceText, name);
+  if (position === undefined) {
+    return undefined;
+  }
+  return checker.getTypeAtLocation({
+    fileName,
+    pos: position,
+    end: position + name.length,
+    range: [position, position + name.length] as const,
+  });
+}
+
+function classIdentifierPosition(sourceText: string, name: string): number | undefined {
+  const pattern = new RegExp(`\\b(?:declare\\s+)?class\\s+${escapeRegExp(name)}\\b`, "g");
+  const match = pattern.exec(sourceText);
+  return match ? match.index + match[0].lastIndexOf(name) : undefined;
+}
+
+function isSuperclassConstructorLookup(
+  context: ContextWithParserOptions,
+  type: CorsaType,
+): boolean {
+  const session = sessionForContext(context).session;
+  const lookup = session.getTypeLookupSource(type);
+  if (!lookup) {
+    return false;
+  }
+  const sourceText = lookup.sourceText ?? session.getSourceTextForPath(lookup.fileName);
+  if (!sourceText) {
+    return false;
+  }
+  return /\bextends\s*$/.test(sourceText.slice(Math.max(0, lookup.position - 32), lookup.position));
+}
+
+function constraintFromTypeParameterSource(
+  context: ContextWithParserOptions,
+  type: CorsaType,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
+  const name = safeTypeToString(checker, type)?.trim();
+  if (!name || !/^[A-Za-z_$][\w$]*$/.test(name)) {
+    return undefined;
+  }
+  const session = sessionForContext(context).session;
+  const lookup = session.getTypeLookupSource(type);
+  const sourceText = lookup
+    ? (lookup.sourceText ?? session.getSourceTextForPath(lookup.fileName))
+    : context.sourceCode.text;
+  const fileName = lookup?.fileName ?? context.filename;
+  if (!sourceText) {
+    return undefined;
+  }
+  const range = typeParameterConstraintRange(sourceText, name);
+  if (!range) {
+    return undefined;
+  }
+  const constraintNode = {
+    fileName,
+    pos: range[0],
+    end: range[1],
+    range,
+  };
+  const symbol = checker.getSymbolAtLocation(constraintNode);
+  return (
+    (symbol
+      ? (checker.getDeclaredTypeOfSymbol(symbol) ?? checker.getTypeOfSymbol(symbol))
+      : undefined) ?? checker.getTypeAtLocation(constraintNode)
+  );
+}
+
+function typeParameterConstraintRange(
+  sourceText: string,
+  name: string,
+): readonly [number, number] | undefined {
+  const pattern = new RegExp(`\\b${escapeRegExp(name)}\\s+extends\\s+`, "g");
+  const match = pattern.exec(sourceText);
+  if (!match) {
+    return undefined;
+  }
+  const start = match.index + match[0].length;
+  let end = start;
+  while (end < sourceText.length && /[A-Za-z0-9_$.[\]]/.test(sourceText[end]!)) {
+    end += 1;
+  }
+  return end > start ? ([start, end] as const) : undefined;
+}
+
+function safeTypeToString(checker: CorsaTypeCheckerShape, type: CorsaType): string | undefined {
+  try {
+    return checker.typeToString(type);
+  } catch {
+    return undefined;
+  }
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function nodeForTypeLookup(node: Node | CorsaNode): Node | CorsaNode {

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -124,6 +124,12 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
     },
     typeToString(type, enclosingDeclaration, flags) {
       void enclosingDeclaration;
+      if (flags === undefined) {
+        const syntheticText = syntheticTypeText(type);
+        if (syntheticText !== undefined) {
+          return syntheticText;
+        }
+      }
       return sessionForContext(context).session.typeToString(type, flags);
     },
     getBaseTypeOfLiteralType(type) {
@@ -179,10 +185,16 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
       return implementedTypesFromTypeAndBases(context, type, this);
     },
     getTypeArguments(type) {
+      const syntheticArguments = (type as SyntheticSourceType).syntheticTypeArguments;
+      if (syntheticArguments) {
+        return syntheticArguments;
+      }
       return sessionForContext(context).session.getTypeArguments(type);
     },
     getTypesOfType(type) {
-      return sessionForContext(context).session.getTypesOfType(type);
+      return (
+        syntheticTypeConstituents(type) ?? sessionForContext(context).session.getTypesOfType(type)
+      );
     },
     getTargetOfType(type) {
       return sessionForContext(context).session.getTargetOfType(type);
@@ -251,6 +263,15 @@ const typeFlags = {
   intersection: 1 << 28,
 } as const;
 
+type SyntheticCompoundType = CorsaType & {
+  readonly syntheticTypes: readonly CorsaType[];
+};
+
+type SyntheticSourceType = CorsaType & {
+  readonly syntheticText?: string;
+  readonly syntheticTypeArguments?: readonly CorsaType[];
+};
+
 function sourceTextFor(
   context: ContextWithParserOptions,
   node: Node | CorsaNode | CorsaType | CorsaSymbol | CorsaSignature,
@@ -275,6 +296,79 @@ function pathsReferToSameFile(left: string, right: string): boolean {
     normalizedLeft.endsWith(`/${normalizedRight}`) ||
     normalizedRight.endsWith(`/${normalizedLeft}`)
   );
+}
+
+function syntheticTypeText(type: CorsaType): string | undefined {
+  return (
+    (type as SyntheticSourceType).syntheticText ??
+    (isSyntheticCompoundType(type) ? type.texts[0] : undefined)
+  );
+}
+
+function syntheticTypeConstituents(type: CorsaType): readonly CorsaType[] | undefined {
+  return isSyntheticCompoundType(type) ? type.syntheticTypes : undefined;
+}
+
+function isSyntheticCompoundType(type: CorsaType): type is SyntheticCompoundType {
+  return (
+    type.id.startsWith("synthetic-compound:") &&
+    Array.isArray((type as SyntheticCompoundType).syntheticTypes)
+  );
+}
+
+function syntheticCompoundType(
+  kind: "union" | "intersection",
+  types: readonly CorsaType[],
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
+  const uniqueTypes = uniqueTypesById(types);
+  if (uniqueTypes.length === 0) {
+    return undefined;
+  }
+  if (uniqueTypes.length === 1) {
+    return uniqueTypes[0];
+  }
+  const separator = kind === "union" ? " | " : " & ";
+  const text = uniqueTypes
+    .map((type) => safeTypeToString(checker, type))
+    .filter((part): part is string => part !== undefined && part.length > 0)
+    .join(separator);
+  if (!text) {
+    return undefined;
+  }
+  return {
+    __corsaOxlintKind: "type",
+    id: `synthetic-compound:${kind}:${uniqueTypes.map((type) => type.id).join(separator)}`,
+    flags: kind === "union" ? typeFlags.union : typeFlags.intersection,
+    texts: [text],
+    syntheticTypes: uniqueTypes,
+  } as SyntheticCompoundType;
+}
+
+function syntheticSourceType(
+  type: CorsaType,
+  text: string,
+  typeArguments: readonly CorsaType[],
+): CorsaType {
+  return {
+    ...type,
+    texts: [text],
+    syntheticText: text,
+    syntheticTypeArguments: typeArguments,
+  } as SyntheticSourceType;
+}
+
+function uniqueTypesById(types: readonly CorsaType[]): readonly CorsaType[] {
+  const seen = new Set<string>();
+  const unique: CorsaType[] = [];
+  for (const type of types) {
+    if (seen.has(type.id)) {
+      continue;
+    }
+    seen.add(type.id);
+    unique.push(type);
+  }
+  return unique;
 }
 
 function typeOfNewExpression(
@@ -305,9 +399,13 @@ function constructorBaseTypesFromType(
   type: CorsaType,
   checker: CorsaTypeCheckerShape,
 ): readonly CorsaType[] {
+  const constituentBases = constructorBaseTypesFromConstituents(context, type, checker);
+  if (constituentBases.length > 0) {
+    return constituentBases;
+  }
   const instanceType = constructorInstanceTypeFromType(context, type, checker);
   if (!instanceType) {
-    return constructorBaseTypesFromConstituents(context, type, checker);
+    return [];
   }
   if (isSuperclassConstructorLookup(context, type)) {
     return [instanceType];
@@ -327,7 +425,12 @@ function constructorBaseTypesFromConstituents(
   const bases: CorsaType[] = [];
   const seen = new Set<string>();
   for (const constituent of checker.getTypesOfType(type)) {
-    for (const base of constructorBaseTypesFromType(context, constituent, checker)) {
+    const directBases = sessionForContext(context).session.getBaseTypes(constituent);
+    const constituentBases =
+      directBases.length > 0
+        ? directBases
+        : constructorBaseTypesFromType(context, constituent, checker);
+    for (const base of constituentBases) {
       if (seen.has(base.id)) {
         continue;
       }
@@ -339,6 +442,42 @@ function constructorBaseTypesFromConstituents(
 }
 
 function constructorInstanceTypeFromType(
+  context: ContextWithParserOptions,
+  type: CorsaType,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
+  const constituentInstance = constructorInstanceTypeFromConstituents(context, type, checker);
+  if (constituentInstance) {
+    return constituentInstance;
+  }
+  return constructorInstanceTypeFromScalar(context, type, checker);
+}
+
+function constructorInstanceTypeFromConstituents(
+  context: ContextWithParserOptions,
+  type: CorsaType,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
+  const kind = compoundTypeKind(type, checker);
+  if (!kind) {
+    return undefined;
+  }
+  const constituents = checker.getTypesOfType(type);
+  if (constituents.length === 0) {
+    return undefined;
+  }
+  const instances: CorsaType[] = [];
+  for (const constituent of constituents) {
+    const instance = constructorInstanceTypeFromType(context, constituent, checker);
+    if (!instance) {
+      return undefined;
+    }
+    instances.push(instance);
+  }
+  return syntheticCompoundType(kind, instances, checker);
+}
+
+function constructorInstanceTypeFromScalar(
   context: ContextWithParserOptions,
   type: CorsaType,
   checker: CorsaTypeCheckerShape,
@@ -356,13 +495,29 @@ function constructorInstanceTypeFromType(
   ) {
     return declared;
   }
-  const name = firstConstructorTypeName(text);
-  return name ? typeFromClassName(context, name, checker, type) : undefined;
+  const names = constructorTypeNames(text);
+  return names.length === 1 ? typeFromClassName(context, names[0]!, checker, type) : undefined;
 }
 
-function firstConstructorTypeName(text: string): string | undefined {
-  const match = /\btypeof\s+([A-Za-z_$][\w$]*)/.exec(text);
-  return match?.[1];
+function compoundTypeKind(
+  type: CorsaType,
+  checker: CorsaTypeCheckerShape,
+): "union" | "intersection" | undefined {
+  if (checker.isUnionType(type)) {
+    return "union";
+  }
+  return checker.isIntersectionType(type) ? "intersection" : undefined;
+}
+
+function constructorTypeNames(text: string): readonly string[] {
+  const names: string[] = [];
+  const pattern = /\btypeof\s+([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)/g;
+  for (const match of text.matchAll(pattern)) {
+    if (match[1]) {
+      names.push(match[1]);
+    }
+  }
+  return names;
 }
 
 function typeFromClassName(
@@ -380,22 +535,123 @@ function typeFromClassName(
   if (!sourceText) {
     return undefined;
   }
-  const position = classIdentifierPosition(sourceText, name);
+  const simpleName = lastQualifiedNamePart(name);
+  const position = classIdentifierPosition(sourceText, name, lookup?.position);
   if (position === undefined) {
     return undefined;
   }
   return checker.getTypeAtLocation({
     fileName,
     pos: position,
-    end: position + name.length,
-    range: [position, position + name.length] as const,
+    end: position + simpleName.length,
+    range: [position, position + simpleName.length] as const,
   });
 }
 
-function classIdentifierPosition(sourceText: string, name: string): number | undefined {
-  const pattern = new RegExp(`\\b(?:declare\\s+)?class\\s+${escapeRegExp(name)}\\b`, "g");
-  const match = pattern.exec(sourceText);
-  return match ? match.index + match[0].lastIndexOf(name) : undefined;
+function classIdentifierPosition(
+  sourceText: string,
+  qualifiedName: string,
+  anchorPosition: number | undefined,
+): number | undefined {
+  const parts = qualifiedName.split(".");
+  const simpleName = parts.at(-1)!;
+  const namespaceRange =
+    parts.length > 1
+      ? namespaceBodyRange(sourceText, parts.slice(0, -1), anchorPosition)
+      : undefined;
+  return classIdentifierPositionInRange(
+    sourceText,
+    simpleName,
+    namespaceRange ?? [0, sourceText.length],
+  );
+}
+
+function classIdentifierPositionInRange(
+  sourceText: string,
+  name: string,
+  range: readonly [number, number],
+): number | undefined {
+  const pattern = new RegExp(
+    `\\b(?:export\\s+)?(?:declare\\s+)?class\\s+${escapeRegExp(name)}\\b`,
+    "g",
+  );
+  pattern.lastIndex = range[0];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(sourceText))) {
+    if (match.index >= range[1]) {
+      return undefined;
+    }
+    return match.index + match[0].lastIndexOf(name);
+  }
+  return undefined;
+}
+
+function namespaceBodyRange(
+  sourceText: string,
+  names: readonly string[],
+  anchorPosition: number | undefined,
+): readonly [number, number] | undefined {
+  let range: readonly [number, number] = [0, sourceText.length];
+  for (const name of names) {
+    const nextRange = namespaceBodyRangeForName(sourceText, name, range, anchorPosition);
+    if (!nextRange) {
+      return undefined;
+    }
+    range = nextRange;
+  }
+  return range;
+}
+
+function namespaceBodyRangeForName(
+  sourceText: string,
+  name: string,
+  range: readonly [number, number],
+  anchorPosition: number | undefined,
+): readonly [number, number] | undefined {
+  const pattern = new RegExp(`\\b(?:export\\s+)?namespace\\s+${escapeRegExp(name)}\\s*\\{`, "g");
+  pattern.lastIndex = range[0];
+  let fallback: readonly [number, number] | undefined;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(sourceText))) {
+    if (match.index >= range[1]) {
+      break;
+    }
+    const bodyStart = sourceText.indexOf("{", match.index) + 1;
+    const bodyEnd = matchingBraceEnd(sourceText, bodyStart - 1);
+    if (bodyStart <= 0 || bodyEnd === undefined || bodyEnd > range[1]) {
+      continue;
+    }
+    const bodyRange = [bodyStart, bodyEnd] as const;
+    if (
+      anchorPosition !== undefined &&
+      anchorPosition >= bodyRange[0] &&
+      anchorPosition <= bodyRange[1]
+    ) {
+      return bodyRange;
+    }
+    fallback ??= bodyRange;
+  }
+  return fallback;
+}
+
+function lastQualifiedNamePart(name: string): string {
+  return name.slice(name.lastIndexOf(".") + 1);
+}
+
+function matchingBraceEnd(sourceText: string, openBracePosition: number): number | undefined {
+  let depth = 0;
+  for (let index = openBracePosition; index < sourceText.length; index += 1) {
+    const char = sourceText[index];
+    if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return undefined;
 }
 
 function isSuperclassConstructorLookup(
@@ -432,7 +688,7 @@ function constraintFromTypeParameterSource(
   if (!sourceText) {
     return undefined;
   }
-  const range = typeParameterConstraintRange(sourceText, name);
+  const range = typeParameterConstraintRange(sourceText, name, lookup?.position);
   if (!range) {
     return undefined;
   }
@@ -443,28 +699,284 @@ function constraintFromTypeParameterSource(
     range,
   };
   const symbol = checker.getSymbolAtLocation(constraintNode);
+  const constraintType =
+    (symbol
+      ? (checker.getDeclaredTypeOfSymbol(symbol) ?? checker.getTypeOfSymbol(symbol))
+      : undefined) ?? checker.getTypeAtLocation(constraintNode);
+  if (!constraintType) {
+    return undefined;
+  }
+  const constraintText = sourceText.slice(range[0], range[1]).trim();
+  const argumentTypes = typeArgumentRanges(sourceText, range[0], range[1])
+    .map((argumentRange) => typeFromSourceRange(fileName, argumentRange, checker))
+    .filter((argument): argument is CorsaType => argument !== undefined);
+  return argumentTypes.length > 0
+    ? syntheticSourceType(constraintType, constraintText, argumentTypes)
+    : constraintType;
+}
+
+function typeFromSourceRange(
+  fileName: string,
+  range: readonly [number, number],
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
+  const node = {
+    fileName,
+    pos: range[0],
+    end: range[1],
+    range,
+  };
+  const symbol = checker.getSymbolAtLocation(node);
   return (
     (symbol
       ? (checker.getDeclaredTypeOfSymbol(symbol) ?? checker.getTypeOfSymbol(symbol))
-      : undefined) ?? checker.getTypeAtLocation(constraintNode)
+      : undefined) ?? checker.getTypeAtLocation(node)
   );
 }
 
 function typeParameterConstraintRange(
   sourceText: string,
   name: string,
+  lookupPosition: number | undefined,
 ): readonly [number, number] | undefined {
+  const candidate = typeParameterConstraintCandidate(sourceText, name, lookupPosition);
+  return candidate ? [candidate.constraintStart, candidate.constraintEnd] : undefined;
+}
+
+type TypeParameterConstraintCandidate = {
+  readonly nameStart: number;
+  readonly nameEnd: number;
+  readonly constraintStart: number;
+  readonly constraintEnd: number;
+  readonly declarationRange?: readonly [number, number];
+};
+
+function typeParameterConstraintCandidate(
+  sourceText: string,
+  name: string,
+  lookupPosition: number | undefined,
+): TypeParameterConstraintCandidate | undefined {
   const pattern = new RegExp(`\\b${escapeRegExp(name)}\\s+extends\\s+`, "g");
-  const match = pattern.exec(sourceText);
-  if (!match) {
+  let selected: TypeParameterConstraintCandidate | undefined;
+  let selectedScore = Number.NEGATIVE_INFINITY;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(sourceText))) {
+    const nameStart = match.index;
+    const nameEnd = nameStart + name.length;
+    const constraintStart = match.index + match[0].length;
+    const constraintEnd = scanTypeParameterConstraintEnd(sourceText, constraintStart);
+    if (constraintEnd <= constraintStart) {
+      continue;
+    }
+    const declarationRange = declarationRangeForTypeParameter(sourceText, nameStart, constraintEnd);
+    const candidate = {
+      nameStart,
+      nameEnd,
+      constraintStart,
+      constraintEnd,
+      declarationRange,
+    };
+    if (lookupPosition !== undefined && lookupPosition >= nameStart && lookupPosition <= nameEnd) {
+      return candidate;
+    }
+    const score = typeParameterConstraintCandidateScore(candidate, lookupPosition);
+    if (score > selectedScore) {
+      selected = candidate;
+      selectedScore = score;
+    }
+  }
+  return selected;
+}
+
+function typeParameterConstraintCandidateScore(
+  candidate: TypeParameterConstraintCandidate,
+  lookupPosition: number | undefined,
+): number {
+  if (lookupPosition === undefined) {
+    return -candidate.nameStart;
+  }
+  const declarationRange = candidate.declarationRange;
+  if (
+    declarationRange &&
+    lookupPosition >= declarationRange[0] &&
+    lookupPosition <= declarationRange[1]
+  ) {
+    return declarationRange[0];
+  }
+  return candidate.nameStart <= lookupPosition ? candidate.nameStart - 1_000_000 : -2_000_000;
+}
+
+function declarationRangeForTypeParameter(
+  sourceText: string,
+  nameStart: number,
+  constraintEnd: number,
+): readonly [number, number] | undefined {
+  const listStart = sourceText.lastIndexOf("<", nameStart);
+  if (listStart === -1) {
     return undefined;
   }
-  const start = match.index + match[0].length;
+  const listEnd = scanTypeParameterListEnd(sourceText, listStart);
+  if (listEnd === undefined || listEnd < constraintEnd) {
+    return undefined;
+  }
+  const bodyStart = sourceText.indexOf("{", listEnd);
+  if (bodyStart === -1) {
+    return [listStart, listEnd + 1];
+  }
+  const bodyEnd = matchingBraceEnd(sourceText, bodyStart);
+  return bodyEnd === undefined ? [listStart, sourceText.length] : [listStart, bodyEnd + 1];
+}
+
+function scanTypeParameterListEnd(sourceText: string, listStart: number): number | undefined {
+  let depth = 0;
+  for (let index = listStart; index < sourceText.length; index += 1) {
+    const char = sourceText[index];
+    if (char === "<") {
+      depth += 1;
+    } else if (char === ">") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return undefined;
+}
+
+function scanTypeParameterConstraintEnd(sourceText: string, start: number): number {
   let end = start;
-  while (end < sourceText.length && /[A-Za-z0-9_$.[\]]/.test(sourceText[end]!)) {
+  let angleDepth = 0;
+  let bracketDepth = 0;
+  let parenDepth = 0;
+  let braceDepth = 0;
+  while (end < sourceText.length) {
+    const char = sourceText[end]!;
+    if (char === "<") {
+      angleDepth += 1;
+    } else if (char === ">") {
+      if (angleDepth === 0) {
+        break;
+      }
+      angleDepth -= 1;
+    } else if (char === "[") {
+      bracketDepth += 1;
+    } else if (char === "]") {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+    } else if (char === "(") {
+      parenDepth += 1;
+    } else if (char === ")") {
+      parenDepth = Math.max(0, parenDepth - 1);
+    } else if (char === "{") {
+      braceDepth += 1;
+    } else if (char === "}") {
+      if (braceDepth === 0) {
+        break;
+      }
+      braceDepth -= 1;
+    } else if (
+      angleDepth === 0 &&
+      bracketDepth === 0 &&
+      parenDepth === 0 &&
+      braceDepth === 0 &&
+      (char === "," || char === "=")
+    ) {
+      break;
+    }
     end += 1;
   }
-  return end > start ? ([start, end] as const) : undefined;
+  while (end > start && /\s/.test(sourceText[end - 1]!)) {
+    end -= 1;
+  }
+  return end;
+}
+
+function typeArgumentRanges(
+  sourceText: string,
+  start: number,
+  end: number,
+): readonly (readonly [number, number])[] {
+  const open = sourceText.indexOf("<", start);
+  if (open === -1 || open >= end) {
+    return [];
+  }
+  const close = matchingAngleEnd(sourceText, open, end);
+  if (close === undefined) {
+    return [];
+  }
+  const ranges: (readonly [number, number])[] = [];
+  let argumentStart = open + 1;
+  let angleDepth = 0;
+  let bracketDepth = 0;
+  let parenDepth = 0;
+  let braceDepth = 0;
+  for (let index = open + 1; index < close; index += 1) {
+    const char = sourceText[index]!;
+    if (char === "<") {
+      angleDepth += 1;
+    } else if (char === ">") {
+      angleDepth = Math.max(0, angleDepth - 1);
+    } else if (char === "[") {
+      bracketDepth += 1;
+    } else if (char === "]") {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+    } else if (char === "(") {
+      parenDepth += 1;
+    } else if (char === ")") {
+      parenDepth = Math.max(0, parenDepth - 1);
+    } else if (char === "{") {
+      braceDepth += 1;
+    } else if (char === "}") {
+      braceDepth = Math.max(0, braceDepth - 1);
+    } else if (
+      char === "," &&
+      angleDepth === 0 &&
+      bracketDepth === 0 &&
+      parenDepth === 0 &&
+      braceDepth === 0
+    ) {
+      appendTrimmedRange(ranges, sourceText, argumentStart, index);
+      argumentStart = index + 1;
+    }
+  }
+  appendTrimmedRange(ranges, sourceText, argumentStart, close);
+  return ranges;
+}
+
+function matchingAngleEnd(
+  sourceText: string,
+  openAnglePosition: number,
+  limit: number,
+): number | undefined {
+  let depth = 0;
+  for (let index = openAnglePosition; index < limit; index += 1) {
+    const char = sourceText[index];
+    if (char === "<") {
+      depth += 1;
+    } else if (char === ">") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return undefined;
+}
+
+function appendTrimmedRange(
+  ranges: (readonly [number, number])[],
+  sourceText: string,
+  start: number,
+  end: number,
+): void {
+  while (start < end && /\s/.test(sourceText[start]!)) {
+    start += 1;
+  }
+  while (end > start && /\s/.test(sourceText[end - 1]!)) {
+    end -= 1;
+  }
+  if (end > start) {
+    ranges.push([start, end] as const);
+  }
 }
 
 function safeTypeToString(checker: CorsaTypeCheckerShape, type: CorsaType): string | undefined {

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
@@ -304,6 +304,123 @@ describe("CorsaProjectSession", () => {
     ).toEqual([]);
   });
 
+  it("returns an empty list when getBaseTypes hits an empty signature handle", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    session.getTypeAtPosition("/tmp/one.ts", 0);
+    const client = clients[0];
+    if (!client) {
+      throw new Error("expected a fake client");
+    }
+    client.callJson.mockImplementationOnce(() => {
+      throw new Error("protocol error: api: client error: empty signature handle");
+    });
+
+    expect(
+      session.getBaseTypes({
+        id: "type-1",
+        flags: 0,
+        texts: ["Base"],
+      } as never),
+    ).toEqual([]);
+  });
+
+  it("does not send empty signatures back to the runtime", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    session.getTypeAtPosition("/tmp/one.ts", 0);
+    const client = clients[0];
+    if (!client) {
+      throw new Error("expected a fake client");
+    }
+    client.callJson.mockClear();
+
+    expect(
+      session.getReturnTypeOfSignature({
+        id: "",
+        flags: 0,
+        typeParameters: [],
+        parameters: [],
+      } as never),
+    ).toBeUndefined();
+    expect(
+      session.getTypePredicateOfSignature({
+        id: "",
+        flags: 0,
+        typeParameters: [],
+        parameters: [],
+      } as never),
+    ).toBeUndefined();
+    expect(client.callJson).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when signature relations hit an empty signature handle", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    session.getTypeAtPosition("/tmp/one.ts", 0);
+    const client = clients[0];
+    if (!client) {
+      throw new Error("expected a fake client");
+    }
+    client.callJson.mockImplementation(() => {
+      throw new Error("protocol error: api: client error: empty signature handle");
+    });
+
+    const signature = {
+      id: "signature-1",
+      flags: 0,
+      typeParameters: [],
+      parameters: [],
+    };
+    expect(session.getReturnTypeOfSignature(signature as never)).toBeUndefined();
+    expect(session.getTypePredicateOfSignature(signature as never)).toBeUndefined();
+  });
+
   it("returns a server-rendered cached type text when typeToString later hits a stale handle", () => {
     clients.length = 0;
     const runtime = {

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -629,6 +629,15 @@ export class CorsaProjectSession {
     return this.#classDeclarationByTypeId.get(type.id);
   }
 
+  getTypeLookupSource(
+    type: CorsaType,
+  ): { fileName: string; position: number; sourceText?: string } | undefined {
+    const lookup = this.#typeLookupById.get(type.id);
+    return lookup
+      ? { fileName: lookup.fileName, position: lookup.position, sourceText: lookup.sourceText }
+      : undefined;
+  }
+
   rememberTypeLookupFromType(
     type: CorsaType | undefined,
     relatedType: CorsaType | undefined,
@@ -774,24 +783,45 @@ export class CorsaProjectSession {
   }
 
   getReturnTypeOfSignature(signature: CorsaSignature): CorsaType | undefined {
-    return this.rememberType(
-      this.client().callJson("getReturnTypeOfSignature", {
-        snapshot: this.#snapshot,
-        project: this.projectId(),
-        signature: signature.id,
-      }),
-    );
+    if (signature.id.trim().length === 0) {
+      return undefined;
+    }
+    try {
+      return this.rememberType(
+        this.client().callJson("getReturnTypeOfSignature", {
+          snapshot: this.#snapshot,
+          project: this.projectId(),
+          signature: signature.id,
+        }),
+      );
+    } catch (error) {
+      if (isMissingTypeHandleError(error)) {
+        return undefined;
+      }
+      throw error;
+    }
   }
 
   getTypePredicateOfSignature(signature: CorsaSignature): CorsaTypePredicate | undefined {
-    const predicate = this.client().callJson<CorsaTypePredicate | undefined>(
-      "getTypePredicateOfSignature",
-      {
-        snapshot: this.#snapshot,
-        project: this.projectId(),
-        signature: signature.id,
-      },
-    );
+    if (signature.id.trim().length === 0) {
+      return undefined;
+    }
+    let predicate: CorsaTypePredicate | undefined;
+    try {
+      predicate = this.client().callJson<CorsaTypePredicate | undefined>(
+        "getTypePredicateOfSignature",
+        {
+          snapshot: this.#snapshot,
+          project: this.projectId(),
+          signature: signature.id,
+        },
+      );
+    } catch (error) {
+      if (isMissingTypeHandleError(error)) {
+        return undefined;
+      }
+      throw error;
+    }
     if (predicate?.type) {
       this.rememberType(predicate.type);
     }
@@ -2045,7 +2075,9 @@ function isRecoverableTransportError(error: unknown): boolean {
 function isMissingTypeHandleError(error: unknown): boolean {
   const message = errorMessage(error);
   return (
-    message.includes("not found in snapshot registry") || message.includes("empty type handle")
+    message.includes("not found in snapshot registry") ||
+    message.includes("empty type handle") ||
+    message.includes("empty signature handle")
   );
 }
 

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -343,6 +343,88 @@ describe("corsa oxlint type locations", () => {
     expect(seen.usage).toBe("Foo");
   });
 
+  integrationCase("uses lookup position for repeated type parameter constraints", () => {
+    const seen: Record<
+      string,
+      { readonly text: string; readonly args: readonly string[] } | undefined
+    > = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "repeated-type-parameter-constraints",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise repeated type parameter constraint lookup",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          Identifier(node: any) {
+            if (node.name !== "outerUse" && node.name !== "innerUse") {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node);
+            const constraint = type ? checker.getConstraintOfType(type) : undefined;
+            seen[node.name] = constraint
+              ? {
+                  text: checker.typeToString(constraint),
+                  args: checker
+                    .getTypeArguments(constraint)
+                    .map((argument) => checker.typeToString(argument)),
+                }
+              : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("repeated-type-parameter-constraints", rule as any, {
+      valid: [
+        {
+          code: [
+            "class OuterConstraint {}",
+            "class InnerConstraint {}",
+            "class Box<T> {}",
+            "function outer<T extends OuterConstraint>(outerParam: T): T {",
+            "  const outerUse = outerParam;",
+            "  function inner<T extends Box<InnerConstraint>>(innerParam: T): T {",
+            "    const innerUse = innerParam;",
+            "    return innerUse;",
+            "  }",
+            "  inner(outerParam as any);",
+            "  return outerUse;",
+            "}",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.outerUse?.text).toBe("OuterConstraint");
+    expect(seen.outerUse?.args).toEqual([]);
+    expect(seen.innerUse?.text).toBe("Box<InnerConstraint>");
+    expect(seen.innerUse?.args).toEqual(["InnerConstraint"]);
+  });
+
   integrationCase("resolves types from wrapper-like AST nodes", () => {
     const seen: Record<string, string | undefined> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
@@ -665,6 +747,145 @@ describe("corsa oxlint type locations", () => {
     expect(seen.constructorBases).toContain("Animal");
     expect(seen.mixedBases?.[0]).toContain("Animal");
     expect(seen.intersectionBases).toContain("Animal");
+  });
+
+  integrationCase("preserves constructor union and intersection instance types", () => {
+    const seen: Record<string, unknown> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "compound-constructor-instance-types",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise compound constructor fallback lookups",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          NewExpression(node: any) {
+            const sourceText = context.sourceCode.text.slice(node.range[0], node.range[1]);
+            const key = sourceText.includes("UnionCtor") ? "union" : "intersection";
+            const type = checker.getTypeAtLocation(node);
+            seen[key] = type
+              ? {
+                  text: checker.typeToString(type),
+                  parts: checker.getTypesOfType(type).map((part) => checker.typeToString(part)),
+                  isIntersection: checker.isIntersectionType(type),
+                  isUnion: checker.isUnionType(type),
+                }
+              : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("compound-constructor-instance-types", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Dog { readonly dog = true; }",
+            "class Cat { readonly cat = true; }",
+            "declare const UnionCtor: typeof Dog | typeof Cat;",
+            "declare const IntersectionCtor: typeof Dog & typeof Cat;",
+            "new UnionCtor();",
+            "new IntersectionCtor();",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.union).toMatchObject({
+      isUnion: true,
+      parts: expect.arrayContaining(["Dog", "Cat"]),
+    });
+    expect(seen.intersection).toMatchObject({
+      isIntersection: true,
+      parts: expect.arrayContaining(["Dog", "Cat"]),
+    });
+  });
+
+  integrationCase("resolves qualified constructor class names in their namespace scope", () => {
+    const seen: Record<string, readonly string[] | undefined> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "qualified-constructor-base-types",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise qualified constructor fallback lookup",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          VariableDeclarator(node: any) {
+            if (node.id?.name !== "qualifiedCtor") {
+              return;
+            }
+            const type = checker.getTypeAtLocation(node.id);
+            seen.bases = type
+              ? checker.getBaseTypes(type).map((base) => checker.typeToString(base))
+              : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("qualified-constructor-base-types", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Widget {}",
+            "namespace Models {",
+            "  export class Base {}",
+            "  export class Widget extends Base {}",
+            "}",
+            "const qualifiedCtor = Models.Widget;",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.bases).toEqual(["Base"]);
   });
 
   integrationCase("returns immediate instance type for superclass constructor types", () => {

--- a/src/bindings/rust/corsa/tests/data/real_corsa_api_baseline.json
+++ b/src/bindings/rust/corsa/tests/data/real_corsa_api_baseline.json
@@ -1,12 +1,12 @@
 {
   "currentDirectory": ".",
-  "fileCount": 91,
-  "firstFile": "ref/corsa-upstream/_packages/native-preview/src/api/compilerOptions.ts",
+  "fileCount": 104,
+  "firstFile": "ref/corsa-upstream/_packages/native-preview/src/api/fs.ts",
   "lastFile": "ref/corsa-upstream/_packages/native-preview/src/internal/utils.ts",
   "projectCount": 1,
-  "rootFiles": 91,
+  "rootFiles": 104,
   "configFileName": "ref/corsa-upstream/_packages/native-preview/tsconfig.json",
-  "primaryFile": "ref/corsa-upstream/_packages/native-preview/src/api/compilerOptions.ts",
+  "primaryFile": "ref/corsa-upstream/_packages/native-preview/src/api/fs.ts",
   "stringTypeFlags": 32,
   "rendered": "string"
 }


### PR DESCRIPTION
## Summary
- update the pinned microsoft/typescript-go upstream commit to 89d5d5b2849a0db0957065889ca58536fa6d2e4a
- adapt corsa-oxlint for latest tsgo constructor/signature handle behavior
- preserve fallback type relations for compound constructors, qualified constructors, and repeated generic constraints
- update the real Corsa API baseline for the new upstream native-preview file set

## Validation
- cargo run -p corsa_ref --target-dir .cache/corsa-ref-target -- verify
- vp run -w build_corsa
- CORSA_REQUIRE_INTEGRATION=1 vp run -w test_ts
- pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
- CORSA_REQUIRE_INTEGRATION=1 pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts src/bindings/nodejs/corsa_oxlint/ts/implemented_types.test.ts src/bindings/nodejs/corsa_oxlint/ts/native_rule_edges.test.ts src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts
- cargo test -p corsa --no-default-features --test real_corsa_baseline
- vp fmt --check
- vp check --no-fmt
- git diff --check

## Notes
- typescript npm latest is 7.0.2; oxlint-tsgolint npm latest is 7.0.2001, so the package versions were already current and this PR updates the tsgo upstream pin.
- PR CI passed on head 6ef01a5114a70e7a48d93c464b214ebce682a6d5: 26 successful, 1 skipped, 0 pending, 0 failing.