### PR TITLE
chore: track TypeScript upstream repository

### DIFF
--- a/.github/workflows/blacksmith-testbox.yml
+++ b/.github/workflows/blacksmith-testbox.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Go for pinned Corsa ref
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: ref/corsa-upstream/go.mod
+          go-version-file: ref/corsa-upstream/tsc/go.mod
           cache: false
 
       - name: Setup Vite+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,7 +429,7 @@ jobs:
       - name: Setup Go for pinned Corsa ref
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: ref/corsa-upstream/go.mod
+          go-version-file: ref/corsa-upstream/tsc/go.mod
           cache: false
 
       - name: Setup Vite+

--- a/.github/workflows/pr-performance.yml
+++ b/.github/workflows/pr-performance.yml
@@ -125,11 +125,24 @@ jobs:
             echo "missing upstream checkout" >&2
             exit 1
           fi
+          if [ -f ref/corsa-upstream/tsc/go.mod ]; then
+            echo "go_version_file=ref/corsa-upstream/tsc/go.mod" >> "$GITHUB_OUTPUT"
+          else
+            echo "go_version_file=ref/corsa-upstream/go.mod" >> "$GITHUB_OUTPUT"
+          fi
+          if [ -f ref/corsa-upstream/packages/typescript/tsconfig.json ]; then
+            echo "dataset_path=ref/corsa-upstream/packages/typescript/tsconfig.json" >> "$GITHUB_OUTPUT"
+          elif [ -f ref/corsa-upstream/_packages/native-preview/tsconfig.json ]; then
+            echo "dataset_path=ref/corsa-upstream/_packages/native-preview/tsconfig.json" >> "$GITHUB_OUTPUT"
+          else
+            echo "missing benchmark dataset" >&2
+            exit 1
+          fi
 
       - name: Setup Go for pinned Corsa ref
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: ref/corsa-upstream/go.mod
+          go-version-file: ${{ steps.compat.outputs.go_version_file }}
           cache: false
 
       - name: Setup Vite+
@@ -185,6 +198,7 @@ jobs:
           benchmark_args=(--allow-partial-failures)
           cargo run --manifest-path .cache/pr-benchmark/workflow-scripts/src/bindings/rust/corsa/Cargo.toml --release -p corsa --bin bench_tooling_compare -- \
             --corsa .cache/corsa \
+            --dataset "${{ steps.compat.outputs.dataset_path }}" \
             "${benchmark_args[@]}" \
             --iterations "$BENCH_ITERATIONS" \
             --warmup-iterations "$BENCH_WARMUP_ITERATIONS" \

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Go for pinned Corsa ref
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: ref/corsa-upstream/go.mod
+          go-version-file: ref/corsa-upstream/tsc/go.mod
           cache: false
 
       - name: Setup Vite+

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Setup Go for pinned Corsa ref
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: ref/corsa-upstream/go.mod
+          go-version-file: ref/corsa-upstream/tsc/go.mod
           cache: false
 
       - name: Setup Vite+

--- a/bench/src/report_guard.test.ts
+++ b/bench/src/report_guard.test.ts
@@ -36,7 +36,7 @@ const nativeScenarios = [
   "type_to_string",
 ] as const;
 
-const datasets = ["native-preview", "_extension"] as const;
+const datasets = ["typescript"] as const;
 
 describe("benchmark guards", () => {
   benchCase("ts benchmarks emit complete metrics", () => {

--- a/bench/src/support.ts
+++ b/bench/src/support.ts
@@ -9,10 +9,9 @@ export const corsaPath = resolve(
   workspaceRoot,
   process.platform === "win32" ? ".cache/corsa.exe" : ".cache/corsa",
 );
-const datasetCandidates = [
-  "ref/corsa-upstream/_packages/native-preview/tsconfig.json",
-  "ref/corsa-upstream/_packages/api/tsconfig.json",
-].map((path) => resolve(workspaceRoot, path));
+const datasetCandidates = ["ref/corsa-upstream/packages/typescript/tsconfig.json"].map((path) =>
+  resolve(workspaceRoot, path),
+);
 export const datasetPath =
   datasetCandidates.find((candidate) => existsSync(candidate)) ?? datasetCandidates[0];
 export const corsaOxlintFixtureDir = resolve(workspaceRoot, "bench/fixtures/corsa_oxlint");

--- a/corsa_ref.lock.toml
+++ b/corsa_ref.lock.toml
@@ -2,9 +2,9 @@ version = 1
 
 [corsa_upstream]
 path = "ref/corsa-upstream"
-repository = "https://github.com/microsoft/typescript-go.git"
-commit = "89d5d5b2849a0db0957065889ca58536fa6d2e4a"
-tree = "bc369d37139fbc9792a2a32b89e92ace2344e43a"
-committer_date = "2026-08-20T06:46:10Z"
-author = "Ryan Cavanaugh"
-subject = "Add closure notice and link to original repo (#4919)"
+repository = "https://github.com/microsoft/TypeScript.git"
+commit = "c087644e82dc3d48cf87e4c5519eeaaea9daf35c"
+tree = "0ff705d2c52d2c6f05b53be8ee72223bb96b2168"
+committer_date = "2026-08-20T20:21:21Z"
+author = "Jake Bailey"
+subject = "Downgrade too-new npm deps (#63925)"

--- a/docs/benchmarking_guide.md
+++ b/docs/benchmarking_guide.md
@@ -219,7 +219,7 @@ Flow:
 
 Important design choices:
 
-- the default tooling dataset is the pinned upstream `native-preview` package, which currently completes a clean Corsa CLI project check
+- the default tooling dataset is the pinned upstream `packages/typescript` project, which tracks the TypeScript 7 JavaScript package surface
 - `typescript-eslint`, `corsa-oxlint`, bare `oxlint`, and `tsgolint` are allowed to exit with code `1` because lint findings are expected and should not invalidate timing
 - `typescript-eslint`, `corsa-oxlint`, and `tsgolint` use the overlapping type-aware rule set currently exported from `corsa-oxlint/rules`
 - bare `oxlint` intentionally runs without the Corsa JS plugin or type-aware `tsgolint` bridge, so it is a raw Oxlint process baseline rather than the same rule workload

--- a/docs/ci_guide.md
+++ b/docs/ci_guide.md
@@ -280,7 +280,7 @@ The pinned upstream ref now declares:
 
 in:
 
-- [`../ref/corsa-upstream/go.mod`](../ref/corsa-upstream/go.mod)
+- [`../ref/corsa-upstream/tsc/go.mod`](../ref/corsa-upstream/tsc/go.mod)
 
 That means CI cannot rely on whatever `go` version happens to be preinstalled on a runner.
 Without an explicit setup step, `vp run -w build_corsa` can fail even if the repository itself is otherwise correct.
@@ -289,7 +289,7 @@ The workflow now sets Go explicitly through:
 
 - [`../.github/workflows/ci.yml`](../.github/workflows/ci.yml)
 
-using `actions/setup-go` and `go-version-file: ref/corsa-upstream/go.mod`.
+using `actions/setup-go` and `go-version-file: ref/corsa-upstream/tsc/go.mod`.
 
 This keeps the workflow aligned with the actual upstream requirement instead of duplicating a version string elsewhere.
 
@@ -388,7 +388,7 @@ Using `go-version-file` means:
 - there is less room for silent drift
 
 Because `ref/corsa-upstream` is a managed checkout, fresh CI jobs must run
-`corsa_ref sync` before `actions/setup-go` can read `ref/corsa-upstream/go.mod`.
+`corsa_ref sync` before `actions/setup-go` can read `ref/corsa-upstream/tsc/go.mod`.
 
 ## Reproducibility Beats Convenience
 
@@ -407,7 +407,7 @@ The most important files for this CI stabilization work are:
 - [`../src/bindings/nodejs/corsa_oxlint/tsconfig.json`](../src/bindings/nodejs/corsa_oxlint/tsconfig.json)
 - [`../src/bindings/nodejs/corsa_oxlint/ts/session.ts`](../src/bindings/nodejs/corsa_oxlint/ts/session.ts)
 - [`../src/bindings/nodejs/corsa_oxlint/ts/rules/type_utils.ts`](../src/bindings/nodejs/corsa_oxlint/ts/rules/type_utils.ts)
-- [`../ref/corsa-upstream/go.mod`](../ref/corsa-upstream/go.mod)
+- [`../ref/corsa-upstream/tsc/go.mod`](../ref/corsa-upstream/tsc/go.mod)
 
 ## Branch Protection Readiness
 
@@ -461,7 +461,7 @@ Check:
 
 - `go version`
 - whether the shell actually exposes Go 1.26
-- whether CI is using `actions/setup-go` with `ref/corsa-upstream/go.mod`
+- whether CI is using `actions/setup-go` with `ref/corsa-upstream/tsc/go.mod`
 
 If a login shell is overriding the toolchain, prefer the `nix develop -c sh -c '...'` pattern.
 

--- a/docs/corsa_upstream_dependency.md
+++ b/docs/corsa_upstream_dependency.md
@@ -12,6 +12,8 @@ Core policy:
 Rules:
 
 - The authoritative upstream is `ref/corsa-upstream`.
+- The repository is `https://github.com/microsoft/TypeScript.git`; the native
+  Go module lives under `ref/corsa-upstream/tsc`.
 - The lock file records repository, exact commit hash, tree hash, committer timestamp, author, and subject.
 - `ref/corsa-upstream` must remain on a detached `HEAD` at the exact locked commit.
 - A dirty worktree fails verification.
@@ -24,3 +26,8 @@ Workflow:
 3. When intentionally updating upstream, move `ref/corsa-upstream` to the new commit and run `cargo run -p corsa_ref -- pin-current`
 
 This keeps reproduction commit-exact and leaves an auditable metadata trail for every upstream bump.
+
+If an existing local checkout still points at the retired
+`microsoft/typescript-go` repository, remove `ref/corsa-upstream` or update its
+`origin` remote to `https://github.com/microsoft/TypeScript.git` before running
+`sync`. Fresh CI checkouts clone the locked repository directly.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -102,7 +102,7 @@ fn main() -> Result<(), corsa::CorsaError> {
     block_on(async {
         let client = ApiClient::spawn(
             ApiSpawnConfig::new(".cache/corsa")
-                .with_cwd("ref/corsa-upstream/_packages/native-preview"),
+                .with_cwd("ref/corsa-upstream/packages/typescript"),
         )
         .await?;
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -48,10 +48,9 @@ cargo run --release -p corsa --bin bench_tooling_compare -- \
   --json-output .cache/bench_tooling_compare.json
 ```
 
-By default the tooling runner uses the pinned upstream `native-preview`
-package, because it is the largest bundled dataset that currently completes a
-clean Corsa CLI project check. Use `--dataset PATH` to add more projects when
-you want exploratory numbers and are prepared to handle diagnostics.
+By default the tooling runner uses the pinned upstream `packages/typescript`
+project. Use `--dataset PATH` to add more projects when you want exploratory
+numbers and are prepared to handle diagnostics.
 
 `project_check` is the apples-to-apples CLI comparison.
 The lint lanes use the overlapping type-aware rules currently published by
@@ -133,11 +132,9 @@ Default native scenarios now cover both transport and type-query hot paths:
 
 ## Datasets
 
-| dataset          | files |   bytes |  lines | config                                                      |
-| ---------------- | ----: | ------: | -----: | ----------------------------------------------------------- |
-| `ast`            |    29 | 630,429 | 14,653 | `ref/corsa-upstream/_packages/ast/tsconfig.json`            |
-| `native-preview` |    71 | 939,501 | 21,144 | `ref/corsa-upstream/_packages/native-preview/tsconfig.json` |
-| `_extension`     |    13 |  78,255 |  2,022 | `ref/corsa-upstream/_extension/tsconfig.json`               |
+| dataset      | files |     bytes |  lines | config                                                 |
+| ------------ | ----: | --------: | -----: | ------------------------------------------------------ |
+| `typescript` |   106 | 1,299,988 | 30,007 | `ref/corsa-upstream/packages/typescript/tsconfig.json` |
 
 ## 2026-03-31 Tooling Compare
 

--- a/docs/project_guide.md
+++ b/docs/project_guide.md
@@ -29,9 +29,9 @@ That systems layer is where most of the repository's value lives.
 
 `corsa-bind` is the repository and distribution name for bindings around the
 Corsa effort: the native TypeScript 7 implementation line tracked here in the
-`typescript-go` codebase. The TypeScript roadmap describes this as the JS-based
-TypeScript 6 line versus the native TypeScript 7 line, and it uses `Strada` for
-the original TypeScript codename and `Corsa` for this effort
+`tsc` module inside `microsoft/TypeScript`. The TypeScript roadmap describes this
+as the JS-based TypeScript 6 line versus the native TypeScript 7 line, and it uses
+`Strada` for the original TypeScript codename and `Corsa` for this effort
 ([TypeScript Native Port: Versioning Roadmap](https://devblogs.microsoft.com/typescript/typescript-native-port/#versioning-roadmap)).
 
 We keep `corsa` for crate, binary, and upstream-facing labels where that matches

--- a/docs/support_policy.md
+++ b/docs/support_policy.md
@@ -36,7 +36,7 @@ receives fixes.
 - Rust: `1.85+`
 - JavaScript runtimes for published packages: Node.js `22+`, Deno `2.0+`, Bun `1.2+`
 - Node.js tooling for repository scripts and examples: `24+`
-- Go: the version declared by `ref/corsa-upstream/go.mod`
+- Go: the version declared by `ref/corsa-upstream/tsc/go.mod`
 - Operating systems: Linux, macOS, and Windows for the supported local surface
 - Published Node prebuilds: `darwin-arm64`, `darwin-x64`, `linux-arm64-gnu`, `linux-arm64-musl`, `linux-x64-gnu`, `linux-x64-musl`, `win32-arm64-msvc`, `win32-x64-msvc`
 

--- a/examples/rust/support/mod.rs
+++ b/examples/rust/support/mod.rs
@@ -69,15 +69,12 @@ pub fn resolved_real_binary() -> Option<PathBuf> {
 }
 
 pub fn real_dataset() -> PathBuf {
-    [
-        workspace_root().join("ref/corsa-upstream/_packages/native-preview/tsconfig.json"),
-        workspace_root().join("ref/corsa-upstream/_packages/api/tsconfig.json"),
-    ]
-    .into_iter()
-    .find(|path| path.exists())
-    .unwrap_or_else(|| {
-        workspace_root().join("ref/corsa-upstream/_packages/native-preview/tsconfig.json")
-    })
+    [workspace_root().join("ref/corsa-upstream/packages/typescript/tsconfig.json")]
+        .into_iter()
+        .find(|path| path.exists())
+        .unwrap_or_else(|| {
+            workspace_root().join("ref/corsa-upstream/packages/typescript/tsconfig.json")
+        })
 }
 
 pub fn require_path(path: &Path, label: &str, hint: &str) -> Result<(), CorsaError> {

--- a/examples/shared.ts
+++ b/examples/shared.ts
@@ -8,10 +8,9 @@ const executableSuffix = process.platform === "win32" ? ".exe" : "";
 export const workspaceRoot = resolve(examplesDir, "..");
 export const mockBinary = resolve(workspaceRoot, `target/debug/mock_corsa${executableSuffix}`);
 export const realBinary = resolve(workspaceRoot, `.cache/corsa${executableSuffix}`);
-const realDatasetCandidates = [
-  "ref/corsa-upstream/_packages/native-preview/tsconfig.json",
-  "ref/corsa-upstream/_packages/api/tsconfig.json",
-].map((path) => resolve(workspaceRoot, path));
+const realDatasetCandidates = ["ref/corsa-upstream/packages/typescript/tsconfig.json"].map((path) =>
+  resolve(workspaceRoot, path),
+);
 export const realDataset =
   realDatasetCandidates.find((candidate) => existsSync(candidate)) ?? realDatasetCandidates[0];
 

--- a/scripts/build_corsa.ts
+++ b/scripts/build_corsa.ts
@@ -4,14 +4,14 @@ import { resolve } from "node:path";
 import { fail, rootDir, runCommand } from "./shared.ts";
 
 function main(): void {
-  const refDir = resolve(rootDir, "ref/corsa-upstream");
+  const refDir = resolve(rootDir, "ref/corsa-upstream/tsc");
   const goCacheDir = resolve(rootDir, ".cache/go-build");
   const outputName = process.platform === "win32" ? "corsa.exe" : "corsa";
   const outputPath = resolve(rootDir, ".cache", outputName);
 
   mkdirSync(goCacheDir, { recursive: true });
 
-  runCommand("go", ["build", "-o", outputPath, "./cmd/tsgo"], {
+  runCommand("go", ["build", "-o", outputPath, "./cmd/tsc"], {
     cwd: refDir,
     env: {
       ...process.env,

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -25,10 +25,9 @@ const workspaceRoot = resolve(import.meta.dirname, "../../../../..");
 const executableSuffix = process.platform === "win32" ? ".exe" : "";
 const mockBinary = resolve(workspaceRoot, `target/debug/mock_corsa${executableSuffix}`);
 const realBinary = resolve(workspaceRoot, `.cache/corsa${executableSuffix}`);
-const realDatasetCandidates = [
-  "ref/corsa-upstream/_packages/native-preview/tsconfig.json",
-  "ref/corsa-upstream/_packages/api/tsconfig.json",
-].map((path) => resolve(workspaceRoot, path));
+const realDatasetCandidates = ["ref/corsa-upstream/packages/typescript/tsconfig.json"].map((path) =>
+  resolve(workspaceRoot, path),
+);
 const realDataset =
   realDatasetCandidates.find((candidate) => existsSync(candidate)) ?? realDatasetCandidates[0];
 const realCorsaReady = existsSync(realBinary) && existsSync(realDataset);

--- a/src/bindings/rust/corsa/src/bin/bench_real_corsa/args.rs
+++ b/src/bindings/rust/corsa/src/bin/bench_real_corsa/args.rs
@@ -169,12 +169,7 @@ fn default_datasets(root_dir: &std::path::Path) -> SmallVec<[PathBuf; 4]> {
         root_dir.join("ref/corsa-upstream"),
         root_dir.join("origin/corsa-upstream"),
     ] {
-        for path in [
-            base.join("_packages/ast/tsconfig.json"),
-            base.join("_packages/native-preview/tsconfig.json"),
-            base.join("_packages/api/tsconfig.json"),
-            base.join("_extension/tsconfig.json"),
-        ] {
+        for path in [base.join("packages/typescript/tsconfig.json")] {
             if path.exists() {
                 datasets.push(path);
             }

--- a/src/bindings/rust/corsa/src/bin/bench_tooling_compare/args.rs
+++ b/src/bindings/rust/corsa/src/bin/bench_tooling_compare/args.rs
@@ -160,7 +160,7 @@ fn default_corsa_path(root_dir: &std::path::Path) -> PathBuf {
 
 fn default_datasets(root_dir: &std::path::Path) -> SmallVec<[PathBuf; 4]> {
     let base = root_dir.join("ref/corsa-upstream");
-    let candidates = [base.join("_packages/native-preview/tsconfig.json")];
+    let candidates = [base.join("packages/typescript/tsconfig.json")];
     let mut datasets = SmallVec::<[PathBuf; 4]>::new();
     for path in candidates {
         if path.exists() {

--- a/src/bindings/rust/corsa/tests/data/real_corsa_api_baseline.json
+++ b/src/bindings/rust/corsa/tests/data/real_corsa_api_baseline.json
@@ -1,12 +1,12 @@
 {
   "currentDirectory": ".",
-  "fileCount": 104,
-  "firstFile": "ref/corsa-upstream/_packages/native-preview/src/api/fs.ts",
-  "lastFile": "ref/corsa-upstream/_packages/native-preview/src/internal/utils.ts",
+  "fileCount": 106,
+  "firstFile": "ref/corsa-upstream/packages/typescript/src/api/fs.ts",
+  "lastFile": "ref/corsa-upstream/packages/typescript/src/internal/utils.ts",
   "projectCount": 1,
-  "rootFiles": 104,
-  "configFileName": "ref/corsa-upstream/_packages/native-preview/tsconfig.json",
-  "primaryFile": "ref/corsa-upstream/_packages/native-preview/src/api/fs.ts",
+  "rootFiles": 106,
+  "configFileName": "ref/corsa-upstream/packages/typescript/tsconfig.json",
+  "primaryFile": "ref/corsa-upstream/packages/typescript/src/api/fs.ts",
   "stringTypeFlags": 32,
   "rendered": "string"
 }

--- a/src/bindings/rust/corsa/tests/support/mod.rs
+++ b/src/bindings/rust/corsa/tests/support/mod.rs
@@ -79,15 +79,12 @@ pub fn real_corsa_binary() -> PathBuf {
 }
 
 pub fn real_dataset() -> PathBuf {
-    [
-        workspace_root().join("ref/corsa-upstream/_packages/native-preview/tsconfig.json"),
-        workspace_root().join("ref/corsa-upstream/_packages/api/tsconfig.json"),
-    ]
-    .into_iter()
-    .find(|path| path.exists())
-    .unwrap_or_else(|| {
-        workspace_root().join("ref/corsa-upstream/_packages/native-preview/tsconfig.json")
-    })
+    [workspace_root().join("ref/corsa-upstream/packages/typescript/tsconfig.json")]
+        .into_iter()
+        .find(|path| path.exists())
+        .unwrap_or_else(|| {
+            workspace_root().join("ref/corsa-upstream/packages/typescript/tsconfig.json")
+        })
 }
 
 pub fn real_api_config(mode: ApiMode) -> Option<ApiSpawnConfig> {

--- a/src/core/corsa_ref/src/git.rs
+++ b/src/core/corsa_ref/src/git.rs
@@ -225,24 +225,24 @@ mod tests {
     #[test]
     fn canonicalizes_https_and_ssh_urls() {
         assert_eq!(
-            canonical_repository_id("https://github.com/microsoft/typescript-go.git"),
-            "github.com/microsoft/typescript-go"
+            canonical_repository_id("https://github.com/microsoft/TypeScript.git"),
+            "github.com/microsoft/TypeScript"
         );
         assert_eq!(
-            canonical_repository_id("git@github.com:microsoft/typescript-go.git"),
-            "github.com/microsoft/typescript-go"
+            canonical_repository_id("git@github.com:microsoft/TypeScript.git"),
+            "github.com/microsoft/TypeScript"
         );
         assert_eq!(
-            canonical_repository_url("git@github.com:microsoft/typescript-go.git"),
-            "https://github.com/microsoft/typescript-go.git"
+            canonical_repository_url("git@github.com:microsoft/TypeScript.git"),
+            "https://github.com/microsoft/TypeScript.git"
         );
         assert_eq!(
-            canonical_repository_id("ssh://git@github.com/microsoft/typescript-go.git"),
-            "github.com/microsoft/typescript-go"
+            canonical_repository_id("ssh://git@github.com/microsoft/TypeScript.git"),
+            "github.com/microsoft/TypeScript"
         );
         assert_eq!(
-            canonical_repository_url("ssh://git@github.com/microsoft/typescript-go.git"),
-            "https://github.com/microsoft/typescript-go.git"
+            canonical_repository_url("ssh://git@github.com/microsoft/TypeScript.git"),
+            "https://github.com/microsoft/TypeScript.git"
         );
     }
 }

--- a/src/core/corsa_ref/src/lockfile.rs
+++ b/src/core/corsa_ref/src/lockfile.rs
@@ -69,7 +69,7 @@ mod tests {
             version: 1,
             corsa_upstream: LockedRepository {
                 path: "ref/corsa-upstream".into(),
-                repository: "https://github.com/microsoft/typescript-go.git".into(),
+                repository: "https://github.com/microsoft/TypeScript.git".into(),
                 commit: "abc".into(),
                 tree: "def".into(),
                 committer_date: "2026-03-30T00:00:00Z".into(),

--- a/src/core/corsa_ref/src/manager.rs
+++ b/src/core/corsa_ref/src/manager.rs
@@ -184,7 +184,7 @@ mod tests {
                 "remote",
                 "add",
                 "origin",
-                "https://github.com/microsoft/typescript-go.git",
+                "https://github.com/microsoft/TypeScript.git",
             ])
             .current_dir(&repo)
             .output()
@@ -195,7 +195,7 @@ mod tests {
         assert_eq!(lock.corsa_upstream.path, "ref/corsa-upstream");
         assert_eq!(
             lock.corsa_upstream.repository,
-            "https://github.com/microsoft/typescript-go.git"
+            "https://github.com/microsoft/TypeScript.git"
         );
         assert_eq!(lock.version, 1);
     }
@@ -208,7 +208,7 @@ mod tests {
             version: 1,
             corsa_upstream: LockedRepository {
                 path: "ref/corsa-upstream".into(),
-                repository: "https://github.com/microsoft/typescript-go.git".into(),
+                repository: "https://github.com/microsoft/TypeScript.git".into(),
                 commit: "abc".into(),
                 tree: "tree".into(),
                 committer_date: "2026-03-30T00:00:00Z".into(),
@@ -245,7 +245,7 @@ mod tests {
                 "remote",
                 "add",
                 "origin",
-                "https://github.com/microsoft/typescript-go.git",
+                "https://github.com/microsoft/TypeScript.git",
             ])
             .current_dir(&repo)
             .output()

--- a/src/core/corsa_ref/src/status.rs
+++ b/src/core/corsa_ref/src/status.rs
@@ -112,7 +112,7 @@ mod tests {
     fn lock() -> LockedRepository {
         LockedRepository {
             path: "ref/corsa-upstream".into(),
-            repository: "https://github.com/microsoft/typescript-go.git".into(),
+            repository: "https://github.com/microsoft/TypeScript.git".into(),
             commit: "abc".into(),
             tree: "tree".into(),
             committer_date: "2026-03-30T00:00:00Z".into(),
@@ -123,7 +123,7 @@ mod tests {
 
     fn snapshot() -> RepositorySnapshot {
         RepositorySnapshot {
-            remote_url: "git@github.com:microsoft/typescript-go.git".into(),
+            remote_url: "git@github.com:microsoft/TypeScript.git".into(),
             commit: "abc".into(),
             tree: "tree".into(),
             committer_date: "2026-03-30T00:00:00Z".into(),


### PR DESCRIPTION
## Summary
- switch the locked Corsa upstream from microsoft/typescript-go to microsoft/TypeScript
- build the native worker from ref/corsa-upstream/tsc via ./cmd/tsc
- update CI Go version paths, real dataset defaults, baseline fixtures, and docs for packages/typescript

## Verification
- cargo run -p corsa_ref --target-dir .cache/corsa-ref-target -- verify
- vp run -w build_corsa
- cargo test -p corsa_ref
- cargo test -p corsa --bin bench_real_corsa --bin bench_tooling_compare
- cargo test -p corsa --no-default-features --test real_corsa_regression --test real_corsa_typecheck --test real_corsa_baseline
- vp run -w test_ts
- vp run -w examples_real
- vp run -w test
- cargo run --release -p corsa --bin bench_real_corsa -- --transport msgpack --cold-iterations 1 --warm-iterations 1 --json-output .cache/bench_native_smoke.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789881048&installation_model_id=422833&pr_number=456&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F456&signature=1657cae8282850d7f845506eab7617d223c0ffeb83097d1239dfdb3084d6269e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tooling benchmarks now use the upstream TypeScript package dataset by default.
  * Benchmark workflows automatically locate compatible Go modules and dataset files, with clearer errors when data is unavailable.
  * Updated Corsa integration to build and run from the current TypeScript repository layout.

* **Documentation**
  * Updated setup, CI, performance, benchmarking, and support guides for the current upstream repository and dataset paths.
  * Added migration guidance for existing upstream checkouts.

* **Tests**
  * Updated real-dataset validation, baselines, and repository checks to match the current TypeScript source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->