### PR TITLE
fix: resolve RuleTester runtime from test file cwd

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -657,6 +657,71 @@ describe("corsa oxlint", () => {
     }
   });
 
+  it("defaults RuleTester corsa executable from the calling test file directory", async () => {
+    const previousExecutable = process.env.CORSA_EXECUTABLE;
+    const previousCwd = process.cwd();
+    const previousDescribe = RuleTester.describe;
+    const previousIt = RuleTester.it;
+    delete process.env.CORSA_EXECUTABLE;
+    try {
+      const { packageRoot, executable: expectedExecutable } = createTypeScriptPackage();
+      const launchRoot = mkdtempSync(join(tmpdir(), "corsa-oxlint-launch-"));
+      cleanupDirs.add(launchRoot);
+      const probeDir = resolve(packageRoot, "__tests__");
+      const probePath = resolve(probeDir, `rule_tester_probe_${Date.now()}.ts`);
+      mkdirSync(probeDir, { recursive: true });
+      writeFileSync(
+        probePath,
+        [
+          `import { RuleTester } from ${JSON.stringify(pathToFileURL(resolve(import.meta.dirname, "rule_tester.ts")).href)};`,
+          "",
+          "export let seen;",
+          "RuleTester.describe = (_name, fn) => fn?.();",
+          "RuleTester.it = (_name, fn) => fn?.();",
+          "",
+          'new RuleTester({ languageOptions: { sourceType: "module" } }).run("default-executable-callsite", {',
+          "  meta: {",
+          '    messages: { demo: "demo" },',
+          "    schema: [],",
+          "  },",
+          "  create(context) {",
+          "    seen = {",
+          "      languageExecutable: context.languageOptions?.parserOptions?.corsa?.executable,",
+          "      parserExecutable: context.parserOptions?.corsa?.executable,",
+          "      settingsExecutable: context.settings?.corsaOxlint?.parserOptions?.corsa?.executable,",
+          "    };",
+          "    return {};",
+          "  },",
+          "}, {",
+          '  valid: [{ code: "const value = 1;" }],',
+          "  invalid: [],",
+          "});",
+          "",
+        ].join("\n"),
+      );
+
+      process.chdir(launchRoot);
+      const probe = (await import(`${pathToFileURL(probePath).href}?case=${Date.now()}`)) as {
+        seen: Record<string, unknown> | undefined;
+      };
+
+      expect(probe.seen).toEqual({
+        languageExecutable: expectedExecutable,
+        parserExecutable: expectedExecutable,
+        settingsExecutable: expectedExecutable,
+      });
+    } finally {
+      process.chdir(previousCwd);
+      RuleTester.describe = previousDescribe;
+      RuleTester.it = previousIt;
+      if (previousExecutable === undefined) {
+        delete process.env.CORSA_EXECUTABLE;
+      } else {
+        process.env.CORSA_EXECUTABLE = previousExecutable;
+      }
+    }
+  });
+
   it("defaults decorated type-aware rules to the corsa executable", () => {
     const previousExecutable = process.env.CORSA_EXECUTABLE;
     delete process.env.CORSA_EXECUTABLE;

--- a/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { RuleTester as OxlintRuleTester } from "oxlint/plugins-dev";
 
@@ -25,6 +26,7 @@ type TestLifecycleGlobal = typeof globalThis & {
 
 const cleanupDirs = new Set<string>();
 let cleanupInstalled = false;
+const ruleTesterModulePath = fileURLToPath(import.meta.url);
 
 export class RuleTester {
   /**
@@ -65,8 +67,8 @@ export class RuleTester {
   readonly #config?: RuleTesterConfig;
 
   constructor(config?: RuleTesterConfig) {
-    this.#config = config;
-    this.#inner = new OxlintRuleTester(config);
+    this.#config = normalizeRuleTesterConfig(config);
+    this.#inner = new OxlintRuleTester(this.#config);
   }
 
   run(ruleName: string, rule: Record<string, unknown>, tests: TestCases): void {
@@ -173,7 +175,10 @@ function applyRuleTesterRuntimeDefaults(
   if (parserOptions.corsa?.executable !== undefined) {
     return parserOptions;
   }
-  const rootDir = resolve(test.cwd ?? config?.cwd ?? process.cwd());
+  const rootDir = resolveRuleTesterRuntimeRoot(test, config);
+  if (!rootDir) {
+    return parserOptions;
+  }
   const executable = process.env.CORSA_EXECUTABLE ?? optionalDefaultCorsaExecutable(rootDir);
   if (!executable) {
     return parserOptions;
@@ -183,6 +188,61 @@ function applyRuleTesterRuntimeDefaults(
       executable,
     },
   });
+}
+
+function normalizeRuleTesterConfig(
+  config: RuleTesterConfig | undefined,
+): RuleTesterConfig | undefined {
+  const cwd = config?.cwd === undefined ? resolveCallingTestDirectory() : resolve(config.cwd);
+  if (!cwd) {
+    return config;
+  }
+  return config ? { ...config, cwd } : ({ cwd } as RuleTesterConfig);
+}
+
+function resolveRuleTesterRuntimeRoot(
+  test: TestCase,
+  config: RuleTesterConfig | undefined,
+): string | undefined {
+  if (test.cwd !== undefined) {
+    return resolve(test.cwd);
+  }
+  if (config?.cwd !== undefined) {
+    return resolve(config.cwd);
+  }
+  if (test.filename && isAbsolute(test.filename)) {
+    return dirname(test.filename);
+  }
+  return undefined;
+}
+
+function resolveCallingTestDirectory(): string | undefined {
+  const stack = new Error().stack;
+  if (!stack) {
+    return undefined;
+  }
+  for (const line of stack.split("\n")) {
+    const filename = stackLineFilePath(line);
+    if (!filename || resolve(filename) === ruleTesterModulePath) {
+      continue;
+    }
+    return dirname(filename);
+  }
+  return undefined;
+}
+
+function stackLineFilePath(line: string): string | undefined {
+  const trimmed = line.trim();
+  const parenthesized = /\((?<location>.+)\)$/.exec(trimmed)?.groups?.location;
+  const location = parenthesized ?? trimmed.replace(/^at\s+/, "");
+  const positioned = /^(?<specifier>.+):\d+:\d+$/.exec(location)?.groups?.specifier;
+  if (!positioned || positioned.startsWith("node:")) {
+    return undefined;
+  }
+  if (positioned.startsWith("file://")) {
+    return fileURLToPath(positioned);
+  }
+  return isAbsolute(positioned) ? positioned : undefined;
 }
 
 function optionalDefaultCorsaExecutable(rootDir: string): string | undefined {


### PR DESCRIPTION
## Summary
- normalize corsa-oxlint RuleTester cwd from explicit config.cwd or the calling test file directory
- stop RuleTester runtime discovery from falling back to process.cwd() when cwd is omitted
- add a regression that launches from a different cwd while the runtime dependency is resolvable from the test file package

Closes #454

## Verification
- pnpm exec vp run -w build_node_debug
- pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
- pnpm exec tsc --noEmit
- pnpm exec vp fmt --check src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
- git diff --check
- pnpm exec vp lint src/bindings/nodejs/corsa_oxlint/ts/rule_tester.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
- pnpm exec vp pack
- pnpm exec vp run -w test_ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789883970&installation_model_id=422833&pr_number=457&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F457&signature=cd9e13d9ced34ccb62e6a6b9f7368dee23678d7496f33dbbd87669429a158d81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->