### PR TITLE
feat: support trusted content mappers and using syntax

### DIFF
--- a/docs/nodejs_binding.md
+++ b/docs/nodejs_binding.md
@@ -84,6 +84,7 @@ const client = CorsaApiClient.spawn({
 | `shutdownTimeoutMs`          | `number`                 | `2000`       | Graceful shutdown budget on `close()`.                         |
 | `outboundCapacity`           | `number`                 | `256`        | Outbound request queue capacity.                               |
 | `allowUnstableUpstreamCalls` | `boolean`                | `false`      | Opt in to unstable upstream endpoints such as `printNode`.     |
+| `runExternalCode`            | `boolean`                | `false`      | Opt in to trusted TypeScript content mapper processes.         |
 
 Always pair a `spawn()` with a `close()` (use `try`/`finally`):
 
@@ -126,6 +127,13 @@ try {
   client.close();
 }
 ```
+
+For TypeScript content mappers, keep `runExternalCode` unset unless the
+workspace is trusted. Setting it to `true` forwards TypeScript's
+`--runExternalCode` gate to the spawned checker so configured `contentMappers`
+may launch their mapper processes.
+The same checker path understands TypeScript explicit resource management
+syntax, including `using` declarations and `await using` inside async scopes.
 
 ### Snapshots and handles
 

--- a/docs/oxlint_guide.md
+++ b/docs/oxlint_guide.md
@@ -101,6 +101,8 @@ export default [
             executable: "./.cache/corsa", // the Corsa binary you provide
             mode: "msgpack",
             requestTimeoutMs: 30000,
+            // Required only for trusted workspaces that use TypeScript content mappers.
+            runExternalCode: false,
           },
         },
       },
@@ -111,9 +113,17 @@ export default [
 
 The `corsa` block maps onto the same runtime controls as the
 [Node binding](./nodejs_binding.md): `executable`, `mode`, `requestTimeoutMs`,
-`shutdownTimeoutMs`, `outboundCapacity`, and `allowUnstableUpstreamCalls`.
+`shutdownTimeoutMs`, `outboundCapacity`, `allowUnstableUpstreamCalls`, and
+`runExternalCode`.
 Leaving `allowUnstableUpstreamCalls` unset keeps unstable upstream endpoints
 such as `printNode` disabled.
+Leave `runExternalCode` unset unless the workspace is trusted and its
+`tsconfig.json` uses TypeScript `contentMappers`; when enabled, it forwards the
+checker-side `--runExternalCode` gate so those mapper processes can run.
+Explicit resource management syntax is supported in both lanes: custom
+type-aware rules can inspect `using` declarations through parser services, and
+the built-in `require-await` rule treats `await using` as an await-like
+operation.
 
 > [!IMPORTANT]
 > `corsa-oxlint` needs a Corsa binary at the `executable` path. It is not
@@ -175,6 +185,9 @@ tester.run("no-string-plus-number", noStringPlusNumber, {
 the runnable `examples/corsa_oxlint/rule_tester.ts` and
 `native_rule_tester.ts` samples for end-to-end usage against the real pinned
 Corsa binary.
+RuleTester-generated projects also cover TypeScript explicit resource
+management syntax, so a custom rule can match `using` declaration kinds and
+still use `getParserServices()` for the declared resource.
 
 ## How the Rust lane works
 

--- a/src/bindings/nodejs/corsa_node/src/util.rs
+++ b/src/bindings/nodejs/corsa_node/src/util.rs
@@ -14,6 +14,7 @@ pub struct SpawnOptions {
     pub shutdown_timeout_ms: Option<u64>,
     pub outbound_capacity: Option<usize>,
     pub allow_unstable_upstream_calls: Option<bool>,
+    pub run_external_code: Option<bool>,
 }
 
 pub fn build_spawn_config(options: SpawnOptions) -> Result<ApiSpawnConfig> {
@@ -35,6 +36,9 @@ pub fn build_spawn_config(options: SpawnOptions) -> Result<ApiSpawnConfig> {
     }
     if let Some(allow) = options.allow_unstable_upstream_calls {
         config = config.with_allow_unstable_upstream_calls(allow);
+    }
+    if let Some(allow) = options.run_external_code {
+        config = config.with_run_external_code(allow);
     }
     Ok(config)
 }
@@ -103,7 +107,7 @@ mod tests {
     #[test]
     fn spawn_config_accepts_transport_limits() {
         let options = serde_json::from_str::<SpawnOptions>(
-            r#"{"executable":"./corsa","requestTimeoutMs":5000,"shutdownTimeoutMs":250,"outboundCapacity":8,"allowUnstableUpstreamCalls":true}"#,
+            r#"{"executable":"./corsa","requestTimeoutMs":5000,"shutdownTimeoutMs":250,"outboundCapacity":8,"allowUnstableUpstreamCalls":true,"runExternalCode":true}"#,
         )
         .unwrap();
         let config = build_spawn_config(options).unwrap();
@@ -117,5 +121,6 @@ mod tests {
         );
         assert_eq!(config.outbound_capacity, 8);
         assert!(config.allow_unstable_upstream_calls);
+        assert!(config.run_external_code);
     }
 }

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -1,5 +1,6 @@
-import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -370,7 +371,154 @@ describe("CorsaApiClient", () => {
       }
     });
   }
+
+  const contentMapperCase = realCorsaReady ? it : it.skip;
+
+  contentMapperCase("runs trusted TypeScript content mappers through the spawned runtime", () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), "corsa-content-mapper-"));
+    const tsconfig = join(projectRoot, "tsconfig.json");
+    const mapperFile = join(projectRoot, "node_modules", "mapper", "mapper.mjs");
+    let client: ReturnType<typeof CorsaApiClient.spawn> | undefined;
+    let snapshotHandle: string | undefined;
+
+    try {
+      writeContentMapperProject(projectRoot);
+
+      client = CorsaApiClient.spawn({
+        executable: realBinary,
+        cwd: projectRoot,
+        mode: "msgpack",
+        runExternalCode: true,
+      });
+      client.initialize();
+
+      const config = client.parseConfigFile(tsconfig);
+      expect(config.fileNames.some((fileName) => fileName.endsWith("main.ts"))).toBe(true);
+
+      const snapshot = client.updateSnapshot({ openProject: tsconfig });
+      snapshotHandle = snapshot.snapshot;
+      const project = snapshot.projects[0];
+      expect(project).toBeDefined();
+
+      const source = readText(
+        client.getSourceFile(snapshot.snapshot, project.id, join(projectRoot, "app.box")),
+      );
+      expect(source).toContain('export const mapped: string = "from mapper";');
+      expect(existsSync(mapperFile)).toBe(true);
+    } finally {
+      try {
+        if (client && snapshotHandle) {
+          client.releaseHandle(snapshotHandle);
+        }
+      } finally {
+        client?.close();
+        rmSync(projectRoot, { force: true, recursive: true });
+      }
+    }
+  });
 });
+
+function writeContentMapperProject(projectRoot: string): void {
+  const mapperRoot = join(projectRoot, "node_modules", "mapper");
+  mkdirSync(mapperRoot, { recursive: true });
+  writeFileSync(
+    join(projectRoot, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          module: "esnext",
+          moduleResolution: "bundler",
+          strict: true,
+          target: "es2020",
+        },
+        contentMappers: [{ package: "mapper", extensions: [".box"] }],
+        include: ["**/*"],
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(join(projectRoot, "app.box"), "ignored by the mapper\n");
+  writeFileSync(
+    join(projectRoot, "main.ts"),
+    ['import { mapped } from "./app.box";', "export const value: string = mapped;", ""].join("\n"),
+  );
+  writeFileSync(
+    join(mapperRoot, "package.json"),
+    JSON.stringify(
+      {
+        name: "mapper",
+        version: "1.0.0",
+        typescript: {
+          contentMapper: {
+            exec: [process.execPath, join(mapperRoot, "mapper.mjs")],
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(
+    join(mapperRoot, "mapper.mjs"),
+    [
+      "let buffer = Buffer.alloc(0);",
+      'process.stdin.on("data", (chunk) => {',
+      "  buffer = Buffer.concat([buffer, chunk]);",
+      "  drain();",
+      "});",
+      "function drain() {",
+      "  for (;;) {",
+      '    const headerEnd = buffer.indexOf("\\r\\n\\r\\n");',
+      "    if (headerEnd < 0) return;",
+      '    const header = buffer.subarray(0, headerEnd).toString("utf8");',
+      "    const match = /^Content-Length: (\\d+)/im.exec(header);",
+      '    if (!match) throw new Error("missing Content-Length");',
+      "    const bodyStart = headerEnd + 4;",
+      "    const length = Number(match[1]);",
+      "    if (buffer.length < bodyStart + length) return;",
+      '    const message = JSON.parse(buffer.subarray(bodyStart, bodyStart + length).toString("utf8"));',
+      "    buffer = buffer.subarray(bodyStart + length);",
+      "    handle(message);",
+      "  }",
+      "}",
+      "function handle(message) {",
+      "  switch (message.method) {",
+      '    case "initialize":',
+      '      send(message.id, { protocolVersion: 1, positionEncoding: "utf-8", diagnosticSource: "box" });',
+      "      return;",
+      '    case "openProject":',
+      "      send(message.id, {});",
+      "      return;",
+      '    case "closeProject":',
+      "      send(message.id, null);",
+      "      return;",
+      '    case "transform":',
+      '      send(message.id, { text: "export const mapped: string = \\"from mapper\\";\\n", extension: ".ts", mappings: [] });',
+      "      return;",
+      "    default:",
+      "      sendError(message.id, `unexpected method ${message.method}`);",
+      "  }",
+      "}",
+      "function send(id, result) {",
+      '  const body = Buffer.from(JSON.stringify({ jsonrpc: "2.0", id, result }), "utf8");',
+      "  process.stdout.write(`Content-Length: ${body.length}\\r\\n\\r\\n`);",
+      "  process.stdout.write(body);",
+      "}",
+      "function sendError(id, message) {",
+      '  const body = Buffer.from(JSON.stringify({ jsonrpc: "2.0", id, error: { code: -32601, message } }), "utf8");',
+      "  process.stdout.write(`Content-Length: ${body.length}\\r\\n\\r\\n`);",
+      "  process.stdout.write(body);",
+      "}",
+      "",
+    ].join("\n"),
+  );
+}
+
+function readText(source: Uint8Array | null): string {
+  expect(source).not.toBeNull();
+  return Buffer.from(source!).toString("utf8");
+}
 
 describe("CorsaVirtualDocument", () => {
   it("tracks incremental virtual file changes", () => {

--- a/src/bindings/nodejs/corsa_node/ts/types.ts
+++ b/src/bindings/nodejs/corsa_node/ts/types.ts
@@ -8,6 +8,8 @@ export interface ApiClientOptions {
   shutdownTimeoutMs?: number;
   outboundCapacity?: number;
   allowUnstableUpstreamCalls?: boolean;
+  /** Allows trusted projects to execute configured TypeScript content mapper processes. */
+  runExternalCode?: boolean;
 }
 
 export interface InitializeResponse {

--- a/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.test.ts
@@ -47,6 +47,7 @@ describe("context", () => {
             project: ["tsconfig.json"],
             corsa: {
               executable: "/repo/.cache/corsa",
+              runExternalCode: true,
             },
           },
         },
@@ -60,6 +61,7 @@ describe("context", () => {
     expect(resolved.corsa).toEqual({
       executable: "/repo/.cache/corsa",
       mode: "jsonrpc",
+      runExternalCode: true,
     });
   });
 
@@ -92,6 +94,7 @@ describe("context", () => {
 
     expect(normalizePathSeparators(resolved.configPath)).toContain(".cache/corsa_oxlint/default/");
     expect(resolved.runtime.executable).toBe(resolve(workspace, ".cache/corsa"));
+    expect(resolved.runtime.runExternalCode).toBe(false);
   });
 
   it("resolves the platform-specific default corsa executable when it exists", () => {

--- a/src/bindings/nodejs/corsa_oxlint/ts/context.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/context.ts
@@ -102,6 +102,7 @@ function resolveRuntimeOptions(
     ),
     cwd: resolve(runtime?.cwd ?? rootDir),
     mode: runtime?.mode ?? "msgpack",
+    runExternalCode: runtime?.runExternalCode ?? false,
     cacheLifetimeMs: runtime?.cacheLifetimeMs ?? DEFAULT_CACHE_LIFETIME_MS,
   };
 }

--- a/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts
@@ -936,6 +936,99 @@ describe("corsa oxlint", () => {
     }
   });
 
+  integrationCase("exposes using declarations to custom type-aware RuleTester rules", () => {
+    const seen: Record<string, unknown>[] = [];
+    const rule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`)({
+      name: "using-type-service-probe",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise parser services on explicit resource management declarations",
+          recommended: "recommended",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          fired: "using type service probe fired",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          VariableDeclaration(node: any) {
+            if (node.kind !== "using") {
+              return;
+            }
+            const identifier = node.declarations[0]?.id;
+            if (identifier?.type !== "Identifier") {
+              return;
+            }
+            const tsNode = services.esTreeNodeToTSNodeMap.get(identifier);
+            const type = services.getTypeAtLocation(identifier);
+            const normalized = type ? (checker.getBaseTypeOfLiteralType(type) ?? type) : undefined;
+            seen.push({
+              declarationKind: node.kind,
+              hasFullTypeInformation: services.hasFullTypeInformation,
+              hasEstreeToTsNode: services.esTreeNodeToTSNodeMap.has(identifier),
+              hasTsNodeToEstree: services.tsNodeToESTreeNodeMap.has(tsNode),
+              roundTripsToEstree: services.tsNodeToESTreeNodeMap.get(tsNode) === identifier,
+              typeText: normalized ? checker.typeToString(normalized) : undefined,
+              symbolName: services.getSymbolAtLocation(identifier)?.name,
+            });
+            context.report({ node: identifier, messageId: "fired" });
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester({
+      settings: {
+        corsaOxlint: {
+          parserOptions: {
+            corsa: {
+              executable: realCorsaBinary,
+            },
+          },
+        },
+      },
+    });
+
+    tester.run("using-type-service-probe", rule as any, {
+      valid: [],
+      invalid: [
+        {
+          code: [
+            "interface SymbolConstructor { readonly dispose: unique symbol; }",
+            "type DisposableResource = {",
+            "  readonly label: string;",
+            "  [Symbol.dispose](): void;",
+            "};",
+            "declare const resource: DisposableResource;",
+            "function inspect() {",
+            "  using value = resource;",
+            "  value.label;",
+            "}",
+          ].join("\n"),
+          errors: [{ messageId: "fired" }],
+        },
+      ],
+    });
+
+    expect(seen).toEqual([
+      {
+        declarationKind: "using",
+        hasFullTypeInformation: true,
+        hasEstreeToTsNode: true,
+        hasTsNodeToEstree: true,
+        roundTripsToEstree: true,
+        typeText: "DisposableResource",
+        symbolName: "value",
+      },
+    ]);
+  });
+
   integrationCase("keeps type-aware RuleTester cases in the shared default project", () => {
     const rule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`)({
       name: "class-type-probe",

--- a/src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts
@@ -321,6 +321,14 @@ describe("corsa oxlint native rules", () => {
         valid: [
           { code: "async function ok() { await Promise.resolve(1); }" },
           { code: "async function ok() { return Promise.resolve(1); }" },
+          {
+            code: [
+              "interface SymbolConstructor { readonly asyncDispose: unique symbol; }",
+              "interface AsyncDisposable { [Symbol.asyncDispose](): PromiseLike<void>; }",
+              "declare const resource: AsyncDisposable;",
+              "async function ok() { await using value = resource; }",
+            ].join("\n"),
+          },
         ],
         invalid: [
           { code: "async function nope() { return 1; }", errors: 1 },

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const clients: FakeClient[] = [];
 const clientSetups: ((client: FakeClient) => void)[] = [];
+const spawnOptions: unknown[] = [];
 
 class FakeClient {
   readonly initialize = vi.fn();
@@ -41,7 +42,8 @@ class FakeClient {
 
 vi.mock("@corsa-bind/napi", () => ({
   CorsaApiClient: {
-    spawn: vi.fn(() => {
+    spawn: vi.fn((options: unknown) => {
+      spawnOptions.push(options);
       const client = new FakeClient();
       clients.push(client);
       return client;
@@ -54,6 +56,7 @@ const { CorsaProjectSession, uniqueClassDeclarationPosition } = await import("./
 describe("CorsaProjectSession", () => {
   beforeEach(() => {
     clientSetups.length = 0;
+    spawnOptions.length = 0;
   });
 
   it("reuses the current snapshot when visiting a new unchanged file", () => {
@@ -62,6 +65,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -80,6 +84,35 @@ describe("CorsaProjectSession", () => {
     expect(clients[0]?.updateSnapshot).toHaveBeenCalledTimes(1);
   });
 
+  it("passes trusted content mapper external-code opt-in to the spawned runtime", () => {
+    clients.length = 0;
+    const runtime = {
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      runExternalCode: true,
+      cacheLifetimeMs: 60_000,
+    } as const;
+    const session = new CorsaProjectSession(
+      {
+        filename: "/tmp/one.ts",
+        rootDir: "/tmp",
+        configPath: "/tmp/tsconfig.json",
+        runtime,
+      },
+      runtime,
+    );
+
+    session.getTypeAtPosition("/tmp/one.ts", 0);
+
+    expect(spawnOptions[0]).toMatchObject({
+      executable: "/tmp/corsa",
+      cwd: "/tmp",
+      mode: "msgpack",
+      runExternalCode: true,
+    });
+  });
+
   it("does not rotate an unchanged snapshot only because the cache lifetime expired", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
@@ -89,6 +122,7 @@ describe("CorsaProjectSession", () => {
         executable: "/tmp/corsa",
         cwd: "/tmp",
         mode: "msgpack",
+        runExternalCode: false,
         cacheLifetimeMs: 1,
       } as const;
       const session = new CorsaProjectSession(
@@ -119,6 +153,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -153,6 +188,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -187,6 +223,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -238,6 +275,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -274,6 +312,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -310,6 +349,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -346,6 +386,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -390,6 +431,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -427,6 +469,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -463,6 +506,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -502,6 +546,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -538,6 +583,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -580,6 +626,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -611,6 +658,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -652,6 +700,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -679,6 +728,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(
@@ -722,6 +772,7 @@ describe("CorsaProjectSession", () => {
       executable: "/tmp/corsa",
       cwd: "/tmp",
       mode: "msgpack",
+      runExternalCode: false,
       cacheLifetimeMs: 60_000,
     } as const;
     const session = new CorsaProjectSession(

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -1425,6 +1425,7 @@ export class CorsaProjectSession {
         executable: this.runtime.executable,
         cwd: this.runtime.cwd,
         mode: this.runtime.mode,
+        runExternalCode: this.runtime.runExternalCode,
       });
       this.#client.initialize();
     }

--- a/src/bindings/nodejs/corsa_oxlint/ts/types.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/types.ts
@@ -9,6 +9,8 @@ export interface CorsaRuntimeOptions {
   shutdownTimeoutMs?: number;
   outboundCapacity?: number;
   allowUnstableUpstreamCalls?: boolean;
+  /** Allows trusted projects to execute configured TypeScript content mapper processes. */
+  runExternalCode?: boolean;
   cacheLifetimeMs?: number;
 }
 
@@ -32,6 +34,7 @@ export interface ResolvedRuntimeOptions {
   executable: string;
   cwd: string;
   mode: ApiMode;
+  runExternalCode: boolean;
   cacheLifetimeMs: number;
 }
 

--- a/src/core/corsa_client/src/api/client.rs
+++ b/src/core/corsa_client/src/api/client.rs
@@ -230,6 +230,7 @@ impl ApiClient {
             ApiMode::AsyncJsonRpcStdio => {
                 let driver = spawn_jsonrpc_stdio(
                     &config.command,
+                    config.run_external_code,
                     config.filesystem.clone(),
                     config.request_timeout,
                     config.shutdown_timeout,
@@ -242,6 +243,7 @@ impl ApiClient {
             ApiMode::SyncMsgpackStdio => {
                 let driver = spawn_msgpack_stdio(
                     &config.command,
+                    config.run_external_code,
                     config.filesystem.clone(),
                     config.request_timeout,
                     config.outbound_capacity,

--- a/src/core/corsa_client/src/api/config.rs
+++ b/src/core/corsa_client/src/api/config.rs
@@ -54,6 +54,8 @@ pub struct ApiSpawnConfig {
     pub release_queue_capacity: usize,
     /// Allows calls to upstream endpoints that are known to be unstable.
     pub allow_unstable_upstream_calls: bool,
+    /// Allows trusted projects to execute configured TypeScript content mapper processes.
+    pub run_external_code: bool,
     /// Optional observer for structured transport events.
     pub observer: Option<SharedObserver>,
     /// Optional profiler for fine-grained request phase samples.
@@ -75,6 +77,7 @@ impl ApiSpawnConfig {
             outbound_capacity: 256,
             release_queue_capacity: 256,
             allow_unstable_upstream_calls: false,
+            run_external_code: false,
             observer: None,
             profiler: None,
         }
@@ -138,6 +141,12 @@ impl ApiSpawnConfig {
         self
     }
 
+    /// Enables TypeScript's `--runExternalCode` gate for trusted content mappers.
+    pub fn with_run_external_code(mut self, allow: bool) -> Self {
+        self.run_external_code = allow;
+        self
+    }
+
     /// Sets the observer used for structured transport events.
     pub fn with_observer(mut self, observer: SharedObserver) -> Self {
         self.observer = Some(observer);
@@ -191,5 +200,6 @@ mod tests {
     fn new_prefers_msgpack_fast_path() {
         let config = ApiSpawnConfig::new("/opt/bin/corsa");
         assert_eq!(config.mode, ApiMode::SyncMsgpackStdio);
+        assert!(!config.run_external_code);
     }
 }

--- a/src/core/corsa_client/src/api/spawn_stdio.rs
+++ b/src/core/corsa_client/src/api/spawn_stdio.rs
@@ -22,6 +22,7 @@ use std::{
 
 pub(super) async fn spawn_jsonrpc_stdio(
     command: &CorsaCommand,
+    run_external_code: bool,
     filesystem: Option<Arc<dyn super::ApiFileSystem>>,
     request_timeout: Option<std::time::Duration>,
     shutdown_timeout: std::time::Duration,
@@ -31,7 +32,7 @@ pub(super) async fn spawn_jsonrpc_stdio(
     // JSON-RPC mode is used for callback-capable, async request/response
     // flows. The worker process is wrapped in `AsyncChildGuard` so shutdown
     // always reaps the child.
-    let args = stdio_args(command, filesystem.as_deref(), true);
+    let args = stdio_args(command, run_external_code, filesystem.as_deref(), true);
     let mut child = command.spawn_async(args.iter().map(CompactString::as_str))?;
     let stdin = child.stdin.take().ok_or(CorsaError::Closed("api stdin"))?;
     let stdout = child
@@ -57,6 +58,7 @@ pub(super) async fn spawn_jsonrpc_stdio(
 
 pub(super) fn spawn_msgpack_stdio(
     command: &CorsaCommand,
+    run_external_code: bool,
     filesystem: Option<Arc<dyn super::ApiFileSystem>>,
     request_timeout: Option<std::time::Duration>,
     outbound_capacity: usize,
@@ -64,7 +66,7 @@ pub(super) fn spawn_msgpack_stdio(
 ) -> Result<ClientDriver> {
     // Msgpack mode keeps a dedicated worker thread around the blocking stdio
     // pipes. This avoids async framing overhead on the hot path.
-    let args = stdio_args(command, filesystem.as_deref(), false);
+    let args = stdio_args(command, run_external_code, filesystem.as_deref(), false);
     let child = command.spawn_blocking(args.iter().map(CompactString::as_str))?;
     let worker = super::msgpack_worker::MsgpackWorker::spawn(
         child,
@@ -80,13 +82,17 @@ pub(super) fn spawn_msgpack_stdio(
 
 fn stdio_args(
     command: &CorsaCommand,
+    run_external_code: bool,
     filesystem: Option<&dyn super::ApiFileSystem>,
     async_mode: bool,
-) -> SmallVec<[CompactString; 6]> {
-    let mut args = SmallVec::<[CompactString; 6]>::new();
+) -> SmallVec<[CompactString; 7]> {
+    let mut args = SmallVec::<[CompactString; 7]>::new();
     args.push(CompactString::from("--api"));
     if async_mode {
         args.push(CompactString::from("--async"));
+    }
+    if run_external_code {
+        args.push(CompactString::from("--runExternalCode"));
     }
     // Pass the resolved working directory explicitly so downstream tools and
     // diagnostics see the same root the Rust side expects.
@@ -96,4 +102,37 @@ fn stdio_args(
         args.push(filesystem);
     }
     args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stdio_args;
+    use crate::process::CorsaCommand;
+
+    #[test]
+    fn stdio_args_keep_external_code_disabled_by_default() {
+        let command = CorsaCommand::new("/opt/bin/corsa").with_cwd("/workspace");
+        let args = stdio_args(&command, false, None, false);
+        let args = args.iter().map(|arg| arg.as_str()).collect::<Vec<_>>();
+
+        assert_eq!(args, ["--api", "--cwd", "/workspace"]);
+    }
+
+    #[test]
+    fn stdio_args_can_enable_content_mapper_external_code() {
+        let command = CorsaCommand::new("/opt/bin/corsa").with_cwd("/workspace");
+        let args = stdio_args(&command, true, None, true);
+        let args = args.iter().map(|arg| arg.as_str()).collect::<Vec<_>>();
+
+        assert_eq!(
+            args,
+            [
+                "--api",
+                "--async",
+                "--runExternalCode",
+                "--cwd",
+                "/workspace"
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add `runExternalCode` to the Rust/Node spawn config and forward it as TypeScript's `--runExternalCode` gate
- pass the same trusted content mapper opt-in through `corsa-oxlint` runtime settings
- cover real content mapper execution, custom type-aware `using` declarations, and built-in `require-await` `await using` behavior
- document the opt-in, trusted-workspace requirement, `using` support, and `close()` lifecycle guidance

## Verification
- `cargo test -p corsa_client --lib api::`
- `cargo test -p corsa_node util::tests:: --lib`
- `pnpm exec vitest run src/bindings/nodejs/corsa_node/ts/index.test.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts --reporter=dot`
- `pnpm exec vitest run src/bindings/nodejs/corsa_oxlint/ts/context.test.ts src/bindings/nodejs/corsa_oxlint/ts/session.test.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts --reporter=dot`
- `pnpm exec tsc --noEmit`
- `pnpm exec vp run -w test_ts`
- `pnpm exec vp fmt --check docs/nodejs_binding.md docs/oxlint_guide.md src/bindings/nodejs/corsa_node/ts/index.test.ts src/bindings/nodejs/corsa_node/src/util.rs src/bindings/nodejs/corsa_node/ts/types.ts src/bindings/nodejs/corsa_oxlint/ts/context.test.ts src/bindings/nodejs/corsa_oxlint/ts/context.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts src/bindings/nodejs/corsa_oxlint/ts/session.test.ts src/bindings/nodejs/corsa_oxlint/ts/session.ts src/bindings/nodejs/corsa_oxlint/ts/types.ts src/core/corsa_client/src/api/client.rs src/core/corsa_client/src/api/config.rs src/core/corsa_client/src/api/spawn_stdio.rs`
- `pnpm exec vp lint docs/nodejs_binding.md docs/oxlint_guide.md src/bindings/nodejs/corsa_node/src/util.rs src/bindings/nodejs/corsa_node/ts/index.test.ts src/bindings/nodejs/corsa_node/ts/types.ts src/bindings/nodejs/corsa_oxlint/ts/context.test.ts src/bindings/nodejs/corsa_oxlint/ts/context.ts src/bindings/nodejs/corsa_oxlint/ts/framework.test.ts src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts src/bindings/nodejs/corsa_oxlint/ts/session.test.ts src/bindings/nodejs/corsa_oxlint/ts/session.ts src/bindings/nodejs/corsa_oxlint/ts/types.ts src/core/corsa_client/src/api/client.rs src/core/corsa_client/src/api/config.rs src/core/corsa_client/src/api/spawn_stdio.rs`
- `pnpm exec vp pack`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789891130&installation_model_id=422833&pr_number=459&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F459&signature=f50da03d5ed6b7caca6fb3ac608b468cc7d73adb12f4f5600d843663a5fe1a4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->